### PR TITLE
Flex column sizing, size containment, transform-origin, and inset-derived heights

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/CssTransformOriginTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/CssTransformOriginTests.cs
@@ -1,0 +1,151 @@
+using System.Drawing;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Transforms 1 §8: the <c>transform-origin</c> grammar, shared by the three places that need
+/// to agree about where an element's transform is applied — the paint walker, the script bridge's
+/// transform chain (what <c>getBoundingClientRect</c> reports) and the SVG renderer's
+/// <c>transform-box</c> handling.
+/// </summary>
+/// <remarks>
+/// <para>
+/// They did not agree. The paint walker did not read the property at all and used the box centre
+/// for every element, so a page's painted output and the geometry its own script measured put a
+/// transformed element in different places. The bridge read it, but by splitting on whitespace and
+/// taking the components in order — which gets a lone <c>top</c>, the <c>top left</c> spelling and
+/// an invalid pair all wrong.
+/// </para>
+/// <para>
+/// The reference box below is deliberately offset from the origin (10, 20) as well as sized, so a
+/// case that forgets to add the box's own corner is not hidden by a box at (0, 0).
+/// </para>
+/// </remarks>
+public sealed class CssTransformOriginTests
+{
+    private static readonly RectangleF Box = new(10, 20, 100, 200);
+
+    private static PointF ForCssBox(string value) =>
+        CssTransformOrigin.Resolve(value, Box, initialIsBoxCorner: false);
+
+    private static PointF ForSvgElement(string value) =>
+        CssTransformOrigin.Resolve(value, Box, initialIsBoxCorner: true);
+
+    private static void AssertPoint(float x, float y, PointF actual)
+    {
+        Assert.Equal(x, actual.X, 3);
+        Assert.Equal(y, actual.Y, 3);
+    }
+
+    // ---- the initial value, which is what separates a CSS box from an SVG element ----
+
+    /// <summary>A CSS box's initial <c>transform-origin</c> is <c>50% 50%</c> — its centre.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ACssBoxDefaultsToItsCentre(string? value) => AssertPoint(60, 120, ForCssBox(value));
+
+    /// <summary>
+    /// An SVG element has no CSS layout box, and §8 gives one of those a used value of <c>0 0</c>:
+    /// the reference box's own corner. Same declaration, different point — which is why the caller
+    /// states which it is rather than this guessing.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AnSvgElementDefaultsToTheBoxCorner(string? value) => AssertPoint(10, 20, ForSvgElement(value));
+
+    // ---- lengths, percentages and keywords ----
+
+    [Fact(Timeout = 600000)]
+    public void ZeroZeroIsTheBoxCorner() => AssertPoint(10, 20, ForCssBox("0 0"));
+
+    [Fact(Timeout = 600000)]
+    public void PercentagesResolveAgainstTheBox() => AssertPoint(110, 220, ForCssBox("100% 100%"));
+
+    [Fact(Timeout = 600000)]
+    public void LengthsAreMeasuredFromTheBoxCorner() => AssertPoint(35, 60, ForCssBox("25px 40px"));
+
+    [Theory]
+    [InlineData("left top", 10, 20)]
+    [InlineData("right bottom", 110, 220)]
+    [InlineData("center center", 60, 120)]
+    [InlineData("left bottom", 10, 220)]
+    [InlineData("right top", 110, 20)]
+    public void TheKeywordPairsNameTheCorners(string value, float x, float y) =>
+        AssertPoint(x, y, ForCssBox(value));
+
+    /// <summary>
+    /// The keyword pair may be written the other way round: <c>top left</c> is the same point as
+    /// <c>left top</c>. Taking the components in order put the vertical keyword on the horizontal
+    /// axis, where <c>top</c> reads as <c>left</c> — the same answer by luck for that pair, and the
+    /// wrong one for <c>bottom left</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("top left", 10, 20)]
+    [InlineData("bottom left", 10, 220)]
+    [InlineData("top right", 110, 20)]
+    [InlineData("bottom right", 110, 220)]
+    public void AVerticalKeywordMayLead(string value, float x, float y) =>
+        AssertPoint(x, y, ForCssBox(value));
+
+    // ---- one component ----
+
+    /// <summary>One value sets that axis and centres the other.</summary>
+    [Fact(Timeout = 600000)]
+    public void ALoneHorizontalValueCentresTheOther() => AssertPoint(110, 120, ForCssBox("right"));
+
+    /// <summary>
+    /// And a lone <c>top</c> or <c>bottom</c> names the <b>vertical</b> axis, so it moves y — not
+    /// x, which is where reading the first component as the horizontal one put it.
+    /// </summary>
+    [Theory]
+    [InlineData("top", 60, 20)]
+    [InlineData("bottom", 60, 220)]
+    public void ALoneVerticalKeywordMovesTheVerticalAxis(string value, float x, float y) =>
+        AssertPoint(x, y, ForCssBox(value));
+
+    [Fact(Timeout = 600000)]
+    public void ALoneLengthSetsXAndCentresY() => AssertPoint(40, 120, ForCssBox("30px"));
+
+    // ---- invalid declarations are dropped whole ----
+
+    /// <summary>
+    /// A <c>&lt;length-percentage&gt;</c> may not follow a vertical keyword, so <c>top 100%</c> is
+    /// not a re-ordered <c>100% top</c> — it is invalid, and an invalid declaration is dropped
+    /// whole and takes the initial value. The twelve WPT
+    /// <c>css-transforms/transform-origin/svg-origin-relative-length-invalid-*</c> cases are built
+    /// to catch exactly that.
+    /// </summary>
+    [Theory]
+    [InlineData("top 100%")]
+    [InlineData("bottom 25px")]
+    [InlineData("left right")]
+    [InlineData("top bottom")]
+    [InlineData("nonsense")]
+    public void AnInvalidDeclarationTakesTheInitialValue(string value)
+    {
+        AssertPoint(60, 120, ForCssBox(value));
+        AssertPoint(10, 20, ForSvgElement(value));
+    }
+
+    /// <summary>
+    /// The asymmetry that makes <c>top 100%</c> invalid is not "a keyword and a length cannot mix":
+    /// the two-value form is <c>[left|center|right|&lt;lp&gt;] [top|center|bottom|&lt;lp&gt;]</c>, so a
+    /// length in the horizontal slot followed by a vertical keyword is perfectly valid. Only a
+    /// <em>leading</em> vertical keyword needs its partner to be a keyword too.
+    /// </summary>
+    [Theory]
+    [InlineData("10px top", 20, 20)]
+    [InlineData("25% bottom", 35, 220)]
+    [InlineData("left 30px", 10, 50)]
+    public void ALengthMayShareTheDeclarationWithAKeyword(string value, float x, float y) =>
+        AssertPoint(x, y, ForCssBox(value));
+
+    /// <summary>The z component a third value carries is dropped — none of this is 3D.</summary>
+    [Fact(Timeout = 600000)]
+    public void AThirdComponentIsIgnored() => AssertPoint(10, 20, ForCssBox("left top 40px"));
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -508,7 +508,128 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         if (ContainingBlock.HasDefiniteAspectRatioBlockHeight())
             return false;
 
+        // CSS2.1 §10.6.4: a containing block that is out of flow with an `auto` height but both
+        // `top` and `bottom` specified takes its used block size from the constraint equation, so
+        // that size is definite even though nothing declared it. The `Height == auto` test below
+        // cannot see that and would send every percentage inside such a box to `auto`.
+        if (ContainingBlock.TryGetInsetDerivedContentHeight(out _))
+            return false;
+
         return ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height);
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.6.4: the used <em>content</em>-box height of an out-of-flow box whose
+    /// <c>height</c> is <c>auto</c> but whose <c>top</c> and <c>bottom</c> are both specified —
+    /// the constraint equation
+    /// <c>top + margin-top + border + padding + height + padding + border + margin-bottom + bottom</c>
+    /// <c> = containing-block height</c> leaves exactly one unknown, so the block size is
+    /// <b>definite</b> even though no <c>height</c> declaration names it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The definiteness is what callers are after, not just the number. Percentage heights inside
+    /// such a box resolve against it rather than falling back to <c>auto</c> (§10.5), and a flex or
+    /// grid container sized this way has a definite main/block size to hand out to its items
+    /// (CSS Flexbox §9.2). Both were reading the <c>height</c> declaration alone and so treated
+    /// <c>position: absolute; inset: 0</c> — the shape a full-viewport app shell is written in — as
+    /// content-sized: WPT <c>css-flexbox/percentage-heights-002</c> is a
+    /// <c>position: absolute; top/right/bottom/left: 0</c> column flex container over a red
+    /// backdrop, and every percentage in it collapsed to the text's own height, leaving the page
+    /// red where the test says "you should see no red".
+    /// </para>
+    /// <para>
+    /// Read at measurement time, before block sizes resolve bottom-up, so the containing block's
+    /// extent comes from <see cref="GetAbsoluteContainingBlockPaddingBox"/> — which already walks
+    /// up a chain of inset-sized ancestors — rather than from a <see cref="CssBoxProperties.Size"/>
+    /// that has not settled. A box whose own used height is over-constrained to nothing returns
+    /// <see langword="false"/>: a zero block size is indistinguishable here from one that has not
+    /// been computed, and every caller treats it as indefinite anyway.
+    /// </para>
+    /// <para>
+    /// Auto margins are not the §10.6.4 centring case: that applies only when none of the three of
+    /// <c>top</c>, <c>height</c> and <c>bottom</c> is <c>auto</c>. With <c>height: auto</c> the
+    /// spec sets an auto margin to zero and solves for the height, which is what
+    /// <see cref="CssBoxProperties.ActualMarginTop"/> already holds.
+    /// </para>
+    /// </remarks>
+    internal bool TryGetInsetDerivedContentHeight(out double contentHeight)
+    {
+        contentHeight = 0;
+
+        if (Position is not (CssConstants.Absolute or CssConstants.Fixed))
+            return false;
+
+        if (!string.IsNullOrEmpty(Height) && Height != CssConstants.Auto)
+            return false;
+
+        if (Top is null or CssConstants.Auto || Bottom is null or CssConstants.Auto)
+            return false;
+
+        double cbHeight;
+
+        if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+        {
+            cbHeight = FixedPositioningViewport().Height;
+        }
+        else
+        {
+            var cb = FindPositionedContainingBlock();
+
+            // A box that is its own positioned containing block has no outer extent to solve
+            // against; the recursion in GetAbsoluteContainingBlockPaddingBox makes the same guard.
+            if (ReferenceEquals(cb, this))
+                return false;
+
+            GetAbsoluteContainingBlockPaddingBox(cb, out _, out _, out _, out cbHeight);
+        }
+
+        if (cbHeight <= 0)
+            return false;
+
+        double resolved = cbHeight
+            - ParseUsedLength(Top, cbHeight) - ParseUsedLength(Bottom, cbHeight)
+            - ActualMarginTop - ActualMarginBottom
+            - ActualPaddingTop - ActualPaddingBottom
+            - ActualBorderTopWidth - ActualBorderBottomWidth;
+
+        if (double.IsNaN(resolved) || double.IsInfinity(resolved))
+            return false;
+
+        // §10.7: the used height is then clamped, and the clamped value is the definite one.
+        resolved = ClampInsetDerivedContentHeight(resolved, cbHeight);
+
+        contentHeight = resolved;
+        return contentHeight > 0;
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.7 over the §10.6.4 result: <c>min-height</c> and <c>max-height</c> clamp the
+    /// height the inset pair solved for, in the content-box frame that solution is stated in.
+    /// </summary>
+    private double ClampInsetDerivedContentHeight(double contentHeight, double cbHeight)
+    {
+        double em = GetEmHeight();
+
+        double? ToContentHeight(string declaration)
+        {
+            if (string.IsNullOrEmpty(declaration) || declaration == CssConstants.Auto
+                || declaration.Equals("none", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            double length = CssLengthParser.ParseLength(declaration, cbHeight, em);
+            return double.IsNaN(length) || double.IsInfinity(length)
+                ? null
+                : ResolveSpecifiedHeightToContentBox(length);
+        }
+
+        if (ToContentHeight(MaxHeight) is { } max && max < contentHeight)
+            contentHeight = max;
+
+        if (ToContentHeight(MinHeight) is { } min && min > contentHeight)
+            contentHeight = min;
+
+        return Math.Max(0, contentHeight);
     }
 
     /// <summary>CSS Sizing 4 §4: <c>true</c> when this box's block (height) axis is
@@ -588,6 +709,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 return flowCb.ResolveSpecifiedHeightToContentBox(cssHeight);
         }
 
+        // §10.6.4 again: the containing block is out of flow with an auto height that its own
+        // top/bottom pair makes definite. Its Size.Height is still 0 at this point for the same
+        // bottom-up reason the definite-declaration branch above exists.
+        if (flowCb != null && flowCb.TryGetInsetDerivedContentHeight(out double insetHeight))
+            return insetHeight;
+
         // Size.Height is a border box, so the padding and border come off it to leave the
         // content height, exactly as TryGetPercentageBlockSizeBasis does for the same box.
         if (flowCb == null)
@@ -664,6 +791,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 cb.TryGetAspectRatioBlockHeight(out basis);
                 return basis > 0;
             }
+
+            // CSS2.1 §10.6.4: so is an auto block axis an out-of-flow box's own top/bottom pair
+            // solves for — the same exception, and made in the same two places.
+            if (heightIsAuto && cb.TryGetInsetDerivedContentHeight(out basis))
+                return true;
 
             // A real element with an auto (or already-resolved percentage) height: its used block
             // size, when layout has settled it, and otherwise indefinite. Size.Height is a border

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -536,8 +536,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     }
 
     /// <summary>
-    /// CSS Flexbox §9.7: distributes a <c>column</c> flex container's positive free space along
-    /// its main (block) axis, per <c>flex-grow</c>.
+    /// CSS Flexbox §9.7: distributes a <c>column</c> flex container's free space along its main
+    /// (block) axis, growing its items into what is left over and shrinking them into what is not.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -548,18 +548,19 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// </para>
     /// <para>
     /// It runs only when the container's main size is <b>definite</b>, which per §9.2 means a
-    /// specified <c>height</c> (then clamped by <c>min-height</c>/<c>max-height</c>) — not a
-    /// <c>min-height</c> alone. The distinction is exactly what
-    /// css-flexbox/percentage-heights-003 pins: its <c>height: 0; min-height: 100%</c> containers
-    /// flex their items to the clamped 100px, and its <c>min-height: 100%</c>-only containers,
-    /// whose main size stays content-based, leave them at zero.
+    /// specified <c>height</c> (then clamped by <c>min-height</c>/<c>max-height</c>) or a block
+    /// size the box's own inset pair solves for — not a <c>min-height</c> alone. The distinction
+    /// is exactly what css-flexbox/percentage-heights-003 pins: its <c>height: 0;
+    /// min-height: 100%</c> containers flex their items to the clamped 100px, and its
+    /// <c>min-height: 100%</c>-only containers, whose main size stays content-based, leave them at
+    /// zero.
     /// </para>
     /// <para>
-    /// Each grown item is laid out again at its target height rather than resized in place,
+    /// Each flexed item is laid out again at its target height rather than resized in place,
     /// because a percentage-height descendant resolves against the item's used height — the
     /// <c>span { height: 100% }</c> the same test measures — and poking <c>Size</c> alone would
-    /// leave it reading the pre-flex one. Single-line only: <c>column wrap</c> with items that
-    /// overflow the main axis needs real line breaking, which this does not attempt.
+    /// leave it reading the pre-flex one. Single-line only: <c>column wrap</c> is
+    /// <see cref="PerformFlexColumnLineLayout"/>'s.
     /// </para>
     /// </remarks>
     private void ApplyFlexColumnMainAxisSizing(ILayoutEnvironment g)
@@ -567,11 +568,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         if (!IsFlexContainer() || IsRowFlexContainer())
             return;
 
+        // `column` names the *block* axis, so under a vertical writing mode the main axis is
+        // horizontal — the opposite of every axis this pass reads, starting with the height it
+        // takes for the container's main size. PerformFlexColumnLineLayout declines for the same
+        // reason; growing on the wrong axis was merely inert here (a vertical container's items
+        // rarely leave vertical free space to hand out), but shrinking on it is not, and
+        // css-flexbox/flexbox-column-row-gap-002's `vertical-lr` container squashed all six of its
+        // 28px items to fit a main size that is not its main size.
+        if (IsVerticalWritingMode(WritingMode))
+            return;
+
         if (TryGetDefiniteMainAxisContentHeight() is not { } mainSize)
             return;
 
         var items = new List<CssBox>();
-        double usedOuterHeight = 0;
 
         foreach (var child in Boxes)
         {
@@ -579,44 +589,26 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 continue;
 
             items.Add(child);
-            usedOuterHeight += GetFlexItemOuterHeight(child);
         }
 
         if (items.Count == 0)
             return;
 
         double rowGap = ResolveFlexGap(RowGap, mainSize);
-        double freeSpace = mainSize - usedOuterHeight - Math.Max(0, items.Count - 1) * rowGap;
 
-        // Growth only. Shrinking is the other half of §9.7 and is deliberately left out:
-        // `flex-shrink` defaults to 1, so implementing it here would make every column
-        // container whose content overflows squash its items — and squash them further than
-        // §4.5 allows, because that clamp (an item's min-content size as the floor for an
-        // `auto` `min-height`) does not exist yet. Not shrinking is the better of the two
-        // wrong answers until it does.
-        if (freeSpace <= 0.5)
-            return;
-
-        double growTotal = 0;
-
-        foreach (var child in items)
-            growTotal += ParseFlexFactor(child.FlexGrow, 0);
-
-        if (growTotal <= 0)
+        if (!ResolveFlexColumnMainSizes(g, items, mainSize, rowGap, out var targets))
             return;
 
         double cursorY = ClientTop;
         bool moved = false;
 
-        foreach (var child in items)
+        for (int i = 0; i < items.Count; i++)
         {
-            double outerHeight = GetFlexItemOuterHeight(child);
-            double factor = ParseFlexFactor(child.FlexGrow, 0);
-            double target = outerHeight + freeSpace * (factor / growTotal);
+            var child = items[i];
 
-            if (factor > 0 && Math.Abs(target - outerHeight) > 0.5)
+            if (Math.Abs(targets[i] - GetFlexItemOuterHeight(child)) > 0.5)
             {
-                LayoutFlexItemAtTargetHeight(g, child, Math.Max(0, target));
+                LayoutFlexItemAtTargetHeight(g, child, Math.Max(0, targets[i]));
                 moved = true;
             }
 
@@ -639,6 +631,331 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         cursorY -= rowGap;   // the trailing gap the loop added after the last item
         ActualBottom = Math.Max(ActualBottom, cursorY + ActualPaddingBottom + ActualBorderBottomWidth);
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.2, §9.4 and §9.7 over one column flex line: each item's flex base size in
+    /// the block axis, clamped to its hypothetical main size, and the target outer height that
+    /// growing or shrinking into <paramref name="mainSize"/> then gives it.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when no item's target differs from the height block flow already
+    /// gave it, so the caller can leave the stack exactly as it stands.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The base size is read from <c>flex-basis</c> (or, when that is <c>auto</c>, from the item's
+    /// own <c>height</c>) rather than from the height block flow gave it. Those coincide for an
+    /// item sized by its content, which is why the growth-only pass this replaces got away with
+    /// measuring: they part company the moment <c>flex-basis</c> names a block size of its own,
+    /// which block flow does not implement and so had simply ignored — WPT
+    /// css-flexbox/percentage-heights-002's <c>flex-basis: 100%</c> pane sat at the height of the
+    /// one line of text in it.
+    /// </para>
+    /// <para>
+    /// Shrinking is the half of §9.7 that was left out here until now, on the grounds that §4.5's
+    /// automatic minimum size did not exist in this axis to floor it with. It does now
+    /// (<see cref="ClampFlexColumnItemBorderBoxHeight"/>), so an item that overflows its container
+    /// shrinks the way <c>flex-shrink: 1</c> — the initial value, and therefore what nearly every
+    /// column flex item on the web has — asks it to, and no further than its own content.
+    /// </para>
+    /// <para>
+    /// That clamp is applied twice, and both are load-bearing: to the base size, giving §9.4
+    /// step 3's hypothetical main size that free space is measured from, and again to each
+    /// distributed target (§9.7 step 4). Clamping only the shrink branch is not enough — an item
+    /// that takes no share at all still has a minimum and a maximum. <c>flex-basis: 0</c> with a
+    /// 100px child in a 10px container (<c>flex-minimum-height-flex-items-011</c>) is floored at
+    /// its content either way, and <c>max-height: min-content</c> over a <c>flex-basis: 200px</c>
+    /// (<c>flex-item-max-height-min-content</c>) is capped at it.
+    /// </para>
+    /// </remarks>
+    private bool ResolveFlexColumnMainSizes(
+        ILayoutEnvironment g, List<CssBox> items, double mainSize, double rowGap, out double[] targets)
+    {
+        int count = items.Count;
+        targets = new double[count];
+
+        // The §4.5 content size suggestion, memoized: reading it re-lays an item out, and each is
+        // read by both clamps below.
+        var contentHeights = new double?[count];
+        double usedOuterHeight = 0;
+
+        for (int i = 0; i < count; i++)
+        {
+            targets[i] = ClampFlexColumnItemOuterHeight(
+                g, items[i], ResolveFlexItemBaseOuterHeight(items[i], mainSize), mainSize, ref contentHeights[i]);
+
+            usedOuterHeight += targets[i];
+        }
+
+        double freeSpace = mainSize - usedOuterHeight - Math.Max(0, count - 1) * rowGap;
+
+        if (freeSpace > 0.5)
+        {
+            double growTotal = 0;
+
+            foreach (var child in items)
+                growTotal += ParseFlexFactor(child.FlexGrow, 0);
+
+            if (growTotal > 0)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    targets[i] = ClampFlexColumnItemOuterHeight(
+                        g, items[i],
+                        targets[i] + freeSpace * (ParseFlexFactor(items[i].FlexGrow, 0) / growTotal),
+                        mainSize, ref contentHeights[i]);
+                }
+            }
+        }
+        else if (freeSpace < -0.5)
+        {
+            // §9.7 step 2: the shrink factor is scaled by the base size, so a large item gives up
+            // more of the overflow than a small one with the same `flex-shrink`.
+            double shrinkTotal = 0;
+
+            for (int i = 0; i < count; i++)
+                shrinkTotal += ParseFlexFactor(items[i].FlexShrink, 1) * Math.Max(0, targets[i]);
+
+            if (shrinkTotal > 0)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    double share = (ParseFlexFactor(items[i].FlexShrink, 1) * Math.Max(0, targets[i])) / shrinkTotal;
+
+                    targets[i] = ClampFlexColumnItemOuterHeight(
+                        g, items[i], targets[i] + freeSpace * share, mainSize, ref contentHeights[i]);
+                }
+            }
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            if (Math.Abs(targets[i] - GetFlexItemOuterHeight(items[i])) > 0.5)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <see cref="ClampFlexColumnItemBorderBoxHeight"/> over an <em>outer</em> height, since that
+    /// is the currency §9.7 distributes free space in.
+    /// </summary>
+    private static double ClampFlexColumnItemOuterHeight(
+        ILayoutEnvironment g, CssBox child, double outerHeight, double containerContentHeight,
+        ref double? contentHeight)
+    {
+        double marginHeight = child.ActualMarginTop + child.ActualMarginBottom;
+        double borderBoxHeight = ClampFlexColumnItemBorderBoxHeight(
+            g, child, Math.Max(0, outerHeight - marginHeight), containerContentHeight, ref contentHeight);
+
+        return borderBoxHeight + marginHeight;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.2 step 3 in the block axis: an item's flex base size, as an outer height.
+    /// <c>flex-basis</c> when it names a length, the item's own definite <c>height</c> when it does
+    /// not, and the block size its content produced when neither does.
+    /// </summary>
+    private static double ResolveFlexItemBaseOuterHeight(CssBox child, double containerContentHeight)
+    {
+        double marginHeight = child.ActualMarginTop + child.ActualMarginBottom;
+        double borderBoxHeight;
+        string basis = child.FlexBasis?.Trim();
+
+        if (!string.IsNullOrEmpty(basis)
+            && !basis.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            && !basis.Equals("content", StringComparison.OrdinalIgnoreCase)
+            && !IsIntrinsicSizingHeightKeyword(basis))
+        {
+            borderBoxHeight = child.ResolveSpecifiedHeightToBorderBox(
+                ParseFlexLengthOrZero(child, basis, containerContentHeight));
+        }
+        else if (!string.IsNullOrEmpty(child.Height)
+            && child.Height != CssConstants.Auto
+            && !IsIntrinsicSizingHeightKeyword(child.Height)
+            && !child.HeightPercentageResolvesToAuto())
+        {
+            borderBoxHeight = child.ResolveSpecifiedHeightToBorderBox(
+                ParseFlexLengthOrZero(child, child.Height, containerContentHeight));
+        }
+        else
+        {
+            // The height block flow settled on, which for an auto-height item *is* its content
+            // size — the third branch of §9.2 step 3, already measured.
+            return GetFlexItemOuterHeight(child);
+        }
+
+        return Math.Max(0, borderBoxHeight) + marginHeight;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §4.5 and §9.7 step 4 in the block axis: clamps an item's target border-box
+    /// height by its <c>min-height</c>/<c>max-height</c>, treating an undeclared
+    /// <c>min-height</c> as the <c>auto</c> it computes to on a flex item — the automatic minimum
+    /// size, which is the item's own content block size, and no larger than a definite
+    /// <c>height</c> it declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the floor that makes column shrinking safe to turn on: without it a container
+    /// smaller than its content squashes every item towards nothing, because <c>flex-shrink</c>
+    /// defaults to <c>1</c>. The row axis has had the same clamp for as long as it has shrunk
+    /// (<see cref="ClampFlexItemBorderBoxWidth"/>); this is its block-axis twin, and reads the
+    /// content size the same way — by measuring the item with its own size declaration suppressed,
+    /// so a <c>height: 300px</c> item does not declare a 300px floor and become unshrinkable.
+    /// </para>
+    /// <para>
+    /// One thing it adds that the row clamp does not: §4.5 gives an automatic minimum size only to
+    /// an item whose main-axis <c>overflow</c> is <c>visible</c>. A scroll container states that
+    /// its content may be scrolled rather than that its box must fit it, and
+    /// <c>flex: 1; overflow: auto</c> is how the scrolling pane of nearly every column layout on
+    /// the web is written — flooring it at its content is what makes such a pane push its own
+    /// container open instead of scrolling.
+    /// </para>
+    /// <para>
+    /// <paramref name="contentHeight"/> memoizes the content measurement across the two clamps one
+    /// item takes (base size, then distributed target), because taking it re-lays the item out.
+    /// </para>
+    /// </remarks>
+    private static double ClampFlexColumnItemBorderBoxHeight(
+        ILayoutEnvironment g, CssBox child, double borderBoxHeight, double containerContentHeight,
+        ref double? contentHeight)
+    {
+        double? measured = contentHeight;
+
+        double ContentHeight() => measured ??= MeasureFlexColumnItemContentBorderBoxHeight(g, child);
+
+        if (!string.IsNullOrEmpty(child.MaxHeight) && !child.MaxHeight.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            // An intrinsic `max-height` is a content measurement, not a length: parsing it as one
+            // yields 0 and caps the item at nothing.
+            double maxHeight = IsIntrinsicSizingHeightKeyword(child.MaxHeight)
+                ? ContentHeight()
+                : child.ResolveSpecifiedHeightToBorderBox(
+                    ParseFlexLengthOrZero(child, child.MaxHeight, containerContentHeight));
+
+            if (borderBoxHeight > maxHeight)
+                borderBoxHeight = maxHeight;
+        }
+
+        bool useAutomaticMinHeight =
+            !child.IsMinHeightSpecified || child.MinHeight.Equals("auto", StringComparison.OrdinalIgnoreCase);
+
+        if (useAutomaticMinHeight)
+        {
+            if (!IsVisibleOverflow(child.Overflow))
+            {
+                contentHeight = measured;
+                return Math.Max(0, borderBoxHeight);
+            }
+
+            double minBorderBoxHeight = ContentHeight();
+
+            if (TryGetSpecifiedBlockSizeSuggestion(child, containerContentHeight, out double specified)
+                && specified < minBorderBoxHeight)
+            {
+                minBorderBoxHeight = specified;
+            }
+
+            if (borderBoxHeight < minBorderBoxHeight)
+                borderBoxHeight = minBorderBoxHeight;
+        }
+        else if (!string.IsNullOrEmpty(child.MinHeight)
+            && !child.MinHeight.Equals("0", StringComparison.OrdinalIgnoreCase))
+        {
+            double minHeight = IsIntrinsicSizingHeightKeyword(child.MinHeight)
+                ? ContentHeight()
+                : child.ResolveSpecifiedHeightToBorderBox(
+                    ParseFlexLengthOrZero(child, child.MinHeight, containerContentHeight));
+
+            if (borderBoxHeight < minHeight)
+                borderBoxHeight = minHeight;
+        }
+
+        contentHeight = measured;
+        return Math.Max(0, borderBoxHeight);
+    }
+
+    private static bool IsVisibleOverflow(string overflow) =>
+        string.IsNullOrEmpty(overflow)
+        || overflow.Equals("visible", StringComparison.OrdinalIgnoreCase)
+        || overflow.Equals("clip", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// CSS Flexbox §4.5 <em>specified size suggestion</em> in the block axis — the block-axis twin
+    /// of <see cref="TryGetSpecifiedSizeSuggestion"/>.
+    /// </summary>
+    private static bool TryGetSpecifiedBlockSizeSuggestion(
+        CssBox child, double containerContentHeight, out double borderBoxHeight)
+    {
+        borderBoxHeight = 0;
+
+        if (string.IsNullOrEmpty(child.Height)
+            || child.Height == CssConstants.Auto
+            || IsIntrinsicSizingHeightKeyword(child.Height)
+            || child.HeightPercentageResolvesToAuto())
+        {
+            return false;
+        }
+
+        borderBoxHeight = child.ResolveSpecifiedHeightToBorderBox(
+            ParseFlexLengthOrZero(child, child.Height, containerContentHeight));
+        return true;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §4.5 <em>content size suggestion</em> in the block axis: the border-box height
+    /// the item's content alone produces, measured by laying it out with its own <c>height</c>
+    /// declaration suppressed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An item that declares no height needs no measurement at all — block flow has already
+    /// produced exactly this number, and the box is left untouched.
+    /// </para>
+    /// <para>
+    /// One that does is laid out again, and the inline axis is <b>pinned</b> across that pass. The
+    /// item's used width at this point is the one the column path shrink-wrapped it to, and a
+    /// re-layout would re-derive it from the <c>auto</c> declaration against the ordinary
+    /// containing block instead — so measuring the block axis silently widened the item, and the
+    /// cross sizes and offsets computed from that width before the measurement no longer described
+    /// it (WPT css-flexbox/flex-lines/multi-line-wrap-with-column-reverse lost the 10px gutters
+    /// between its three columns, which is what the widened items had swallowed). A size
+    /// measurement must not move the axis it is not measuring.
+    /// </para>
+    /// <para>
+    /// It does leave the item laid out at the measured content height, which is why
+    /// <see cref="ResolveFlexColumnMainSizes"/>'s callers re-lay every item out whose target
+    /// differs from its current height — and after a measurement, one whose target is its base
+    /// size differs, so the pass restores it rather than leaving the measurement showing.
+    /// </para>
+    /// </remarks>
+    private static double MeasureFlexColumnItemContentBorderBoxHeight(ILayoutEnvironment g, CssBox child)
+    {
+        double Measured() => Math.Max(0, child.ActualBottom - child.Location.Y);
+
+        string savedHeight = child.Height;
+
+        if (string.IsNullOrEmpty(savedHeight) || savedHeight == CssConstants.Auto)
+            return Measured();
+
+        string savedWidth = child.Width;
+        double borderBoxWidth = child.Size.Width;
+        double cssWidth = child.UsesBorderBoxSizing
+            ? borderBoxWidth
+            : borderBoxWidth
+              - child.ActualPaddingLeft - child.ActualPaddingRight
+              - child.ActualBorderLeftWidth - child.ActualBorderRightWidth;
+
+        child.Width = FormatCssPx(Math.Max(0, cssWidth));
+        child.Height = CssConstants.Auto;
+        child.PerformLayout(g);
+        child.Width = savedWidth;
+        child.Height = savedHeight;
+
+        return Measured();
     }
 
     private sealed class FlexColumnLine
@@ -842,45 +1159,29 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     }
 
     /// <summary>
-    /// CSS Flexbox §9.7 and §9.4 step 11 for one column flex line: grows the items into the line's
-    /// free main space per <c>flex-grow</c>, and stretches an <c>auto</c>-width item across the
-    /// line's cross size.
+    /// CSS Flexbox §9.7 and §9.4 step 11 for one column flex line: flexes the items into the
+    /// line's main size, and stretches an <c>auto</c>-width item across the line's cross size.
     /// </summary>
     /// <remarks>
     /// Both are settled in a single re-layout per item, because they resize different axes of the
-    /// same box: laying an item out at its stretched width and then again at its grown height
+    /// same box: laying an item out at its stretched width and then again at its flexed height
     /// would let the second layout re-derive the width from the <c>auto</c> declaration and undo
-    /// the stretch. Growth only, no shrinking — the same restriction as the single-line pass, and
-    /// for the reason given there.
+    /// the stretch. The main-axis half is <see cref="ResolveFlexColumnMainSizes"/>, shared with the
+    /// single-line pass so a wrapped container flexes by the same rules an unwrapped one does.
     /// </remarks>
     private void ResolveFlexColumnLineItemSizes(ILayoutEnvironment g, FlexColumnLine line, double lineMain, double rowGap)
     {
-        double freeMain = lineMain - line.MainSize;
-        double growTotal = 0;
-
-        if (freeMain > 0.5)
-        {
-            foreach (var child in line.Items)
-                growTotal += ParseFlexFactor(child.FlexGrow, 0);
-        }
-
+        bool flexes = ResolveFlexColumnMainSizes(g, line.Items, lineMain, rowGap, out double[] targets);
         double mainSize = 0;
 
         for (int i = 0; i < line.Items.Count; i++)
         {
             var child = line.Items[i];
-            double outerHeight = GetFlexItemOuterHeight(child);
             double? targetHeight = null;
             double? targetWidth = null;
 
-            if (growTotal > 0)
-            {
-                double factor = ParseFlexFactor(child.FlexGrow, 0);
-                double grown = outerHeight + freeMain * (factor / growTotal);
-
-                if (factor > 0 && Math.Abs(grown - outerHeight) > 0.5)
-                    targetHeight = Math.Max(0, grown);
-            }
+            if (flexes && Math.Abs(targets[i] - GetFlexItemOuterHeight(child)) > 0.5)
+                targetHeight = Math.Max(0, targets[i]);
 
             if (ShouldStretchFlexColumnItemAcrossLine(child, line.CrossSize))
                 targetWidth = line.CrossSize;
@@ -1025,7 +1326,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     private double? TryGetDefiniteMainAxisContentHeight()
     {
         if (string.IsNullOrEmpty(Height) || Height == CssConstants.Auto || HeightPercentageResolvesToAuto())
-            return null;
+        {
+            // §9.2 reads "definite", not "declared": an out-of-flow container with an auto height
+            // and both insets set has its main size solved by CSS2.1 §10.6.4, already clamped.
+            return TryGetInsetDerivedContentHeight(out double insetHeight) ? insetHeight : null;
+        }
 
         double basis = PercentageHeightContainingBlockHeight();
         double em = GetEmHeight();
@@ -1184,7 +1489,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     private double? TryGetDefiniteContentHeight()
     {
         if (string.IsNullOrEmpty(Height) || Height == CssConstants.Auto || HeightPercentageResolvesToAuto())
-            return null;
+        {
+            // Same §10.6.4 exception the main-axis helper above makes: an inset-sized out-of-flow
+            // container has cross-axis space to hand out, so its items stretch rather than
+            // collapsing to their own content.
+            return TryGetInsetDerivedContentHeight(out double insetHeight) ? insetHeight : null;
+        }
 
         double containingBlockHeight =
             Position == CssConstants.Fixed && LayoutEnvironment != null ? LayoutEnvironment.ViewportSize.Height

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1605,6 +1605,22 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// </summary>
     private void ResolveUsedBlockHeight()
     {
+        // CSS Containment 2 §3.2: a size-contained box is sized as though it had no contents, so
+        // the content height the child loop just accumulated into ActualBottom is not this box's
+        // to report — `contain-intrinsic-height` stands in for it, or zero when nothing does.
+        // Stated up front rather than in an auto-height branch of its own: everything below
+        // (an explicit height, the inset-pair constraint, an aspect-ratio transfer, the
+        // quirks-mode floor) is the box's own size talking and still wins over its contents,
+        // exactly as it does without containment.
+        if (AppliesSizeContainment)
+        {
+            double containedContentHeight = ContainedIntrinsicContentHeight;
+
+            ActualBottom = Location.Y + containedContentHeight
+                + ActualPaddingTop + ActualPaddingBottom
+                + ActualBorderTopWidth + ActualBorderBottomWidth;
+        }
+
         // CSS content-box model: 'height' specifies the content height only;
         // padding and border are additive (CSS2.1 §10.6.3). An intrinsic-sizing
         // height keyword (min-/max-/fit-content) is not a length — the content

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.SizeContainment.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.SizeContainment.cs
@@ -1,0 +1,274 @@
+using Broiler.CSS;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// CSS Containment 2 §3.2 (size containment) and CSS Sizing 4 §5
+/// (<c>contain-intrinsic-size</c>): a box whose size is contained is laid out as though it had no
+/// contents, so nothing inside it can be observed from outside — its intrinsic sizes are the ones
+/// an empty box would have, and <c>contain-intrinsic-size</c> is how an author states a stand-in
+/// for the size the contents would have given it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The contents are still laid out and still painted; what containment removes is their
+/// <em>contribution to the box's own size</em>. A contained box with no
+/// <c>contain-intrinsic-size</c> is zero in both axes and everything in it overflows, which is the
+/// whole point: it is what lets a page state a placeholder size for a subtree it has not measured
+/// (and, paired with <c>content-visibility</c>, not rendered).
+/// </para>
+/// <para>
+/// This is the sizing half of a property Broiler already parsed. <c>contain</c> reached the box —
+/// background propagation reads it (CSS Backgrounds §2.11.1) and fragmentation reads it
+/// (<see cref="IsMonolithicForFragmentation"/>) — but nothing acted on what it says about
+/// <em>size</em>, so every one of the 96 assertions in WPT
+/// <c>css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003</c> (entry 21 of issue
+/// #1774's top 30) measured the contents the containment was there to hide.
+/// </para>
+/// </remarks>
+internal partial class CssBox
+{
+    /// <summary>
+    /// CSS Containment 2 §3.2: whether size containment applies to this box — the <c>contain</c>
+    /// value asks for it <em>and</em> the box is of a kind it can apply to.
+    /// </summary>
+    /// <remarks>
+    /// The applicability list is not a detail: containment is defined to have no effect on a box
+    /// whose size is not its own to decide. A non-atomic inline is sized by the line it sits on,
+    /// and an internal table box by the table's row and column algorithm, so honouring
+    /// <c>contain: size</c> on either would zero out a size the box never owned.
+    /// </remarks>
+    internal bool AppliesSizeContainment => AppliesSizeContainmentKeyword(Contain) && CanContainSize;
+
+    /// <summary>
+    /// CSS Containment 2 §2: whether a <c>contain</c> value asks for <b>size</b> containment.
+    /// </summary>
+    /// <remarks>
+    /// <c>strict</c> is <c>size layout paint style</c> and does; <c>content</c> is
+    /// <c>layout paint style</c> and deliberately does <b>not</b> — leaving a box's size to its
+    /// contents is the difference between the two keywords, and the reason a page can use
+    /// <c>content</c> without having to state a placeholder size. (The fragmentation predicate in
+    /// <see cref="IsMonolithicForFragmentation"/> treats <c>content</c> as monolithic too, and is
+    /// right to for its own question: paint containment clips the box, so a page break inside it
+    /// would cut content that cannot show. Two questions, two predicates.)
+    /// </remarks>
+    private static bool AppliesSizeContainmentKeyword(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        foreach (var token in value.Split((char[])null, System.StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Equals("size", System.StringComparison.OrdinalIgnoreCase)
+                || token.Equals("strict", System.StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// CSS Containment 2 §3.2: the box types size containment applies to — everything except a
+    /// <b>non-atomic</b> inline-level box, an internal table box, and an internal ruby box.
+    /// </summary>
+    /// <remarks>
+    /// "Non-atomic" is the load-bearing word in the inline case. A replaced element generates an
+    /// atomic inline-level box, and its computed <c>display</c> is still <c>inline</c> — that is the
+    /// UA value for <c>&lt;img&gt;</c>, <c>&lt;svg&gt;</c>, <c>&lt;video&gt;</c> and the rest — so
+    /// testing the keyword alone declines containment on exactly the elements
+    /// <c>css-contain/contain-size-replaced-*</c> is written about. WPT
+    /// <c>contain-size-replaced-002</c> is a bare <c>&lt;svg contain: size&gt;</c> with no
+    /// <c>display</c> of its own.
+    /// </remarks>
+    private bool CanContainSize
+    {
+        get
+        {
+            string display = Display?.Trim().ToLowerInvariant() ?? string.Empty;
+
+            return display switch
+            {
+                CssConstants.Inline => IsReplacedForContainment,
+                CssConstants.TableRow or CssConstants.TableRowGroup or CssConstants.TableCell
+                    or CssConstants.TableColumn or CssConstants.TableColumnGroup
+                    or CssConstants.TableHeaderGroup or CssConstants.TableFooterGroup
+                    or CssConstants.TableCaption => false,
+                "ruby" or "ruby-base" or "ruby-text" or "ruby-base-container" or "ruby-text-container" => false,
+                CssConstants.None => false,
+                _ => true,
+            };
+        }
+    }
+
+    /// <summary>
+    /// CSS Sizing 4 §5: the intrinsic <b>inline</b> extent a size-contained box reports — the
+    /// content-box width <c>contain-intrinsic-width</c> names, or zero when it names <c>none</c>.
+    /// </summary>
+    internal double ContainedIntrinsicContentWidth =>
+        ResolveContainIntrinsicLength(ContainIntrinsicWidth);
+
+    /// <summary>
+    /// CSS Sizing 4 §5: the intrinsic <b>block</b> extent a size-contained box reports; see
+    /// <see cref="ContainedIntrinsicContentWidth"/>.
+    /// </summary>
+    internal double ContainedIntrinsicContentHeight =>
+        ResolveContainIntrinsicLength(ContainIntrinsicHeight);
+
+    /// <summary>
+    /// One <c>contain-intrinsic-*</c> component — <c>auto? [ none | &lt;length&gt; ]</c> — as a
+    /// content-box length. <c>none</c>, an absent value and anything that will not parse are all
+    /// zero, which is the size an empty box has and therefore the right fallback for each.
+    /// </summary>
+    /// <remarks>
+    /// Percentages are not part of the grammar, so the length is resolved against no basis; a
+    /// value carrying one falls back to zero rather than resolving against something arbitrary.
+    /// </remarks>
+    private double ResolveContainIntrinsicLength(string declaration)
+    {
+        var value = declaration?.Trim();
+
+        if (string.IsNullOrEmpty(value) || value.Equals("none", System.StringComparison.OrdinalIgnoreCase))
+            return 0;
+
+        // `auto <length>` asks for the last remembered size and falls back to the length; the
+        // length is what a render that has never skipped this element sees either way.
+        if (value.StartsWith("auto ", System.StringComparison.OrdinalIgnoreCase))
+            value = value[5..].Trim();
+
+        if (value.Equals(CssConstants.Auto, System.StringComparison.OrdinalIgnoreCase)
+            || value.Equals("none", System.StringComparison.OrdinalIgnoreCase)
+            || value.Contains('%'))
+            return 0;
+
+        double length = CssLengthParser.ParseLength(value, 0, GetEmHeight());
+
+        return double.IsNaN(length) || double.IsInfinity(length) || length < 0 ? 0 : length;
+    }
+
+    /// <summary>
+    /// Whether this box is replaced, and so generates an <em>atomic</em> inline-level box when its
+    /// <c>display</c> is <c>inline</c> — the distinction <see cref="CanContainSize"/> turns on.
+    /// </summary>
+    /// <remarks>
+    /// Read from the element rather than from a single engine flag because no one flag covers it:
+    /// <c>IsImage</c> is only <c>&lt;img&gt;</c>, and <c>IntrinsicReplacedSize</c> is only what the
+    /// renderer's <c>&lt;canvas&gt;</c> fix-up records. An <c>&lt;svg&gt;</c>, an
+    /// <c>&lt;iframe&gt;</c> and a <c>&lt;video&gt;</c> are replaced too and carry neither.
+    /// </remarks>
+    private bool IsReplacedForContainment
+    {
+        get
+        {
+            if (IsImage || IntrinsicReplacedSize is not null)
+                return true;
+
+            var name = HtmlTag?.Name;
+
+            return name is not null
+                && (name.Equals("svg", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("canvas", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("video", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("audio", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("iframe", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("embed", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("object", System.StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("input", System.StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
+    /// HTML §14.4 ("Attributes for embedded content and images"): the UA stylesheet maps a replaced
+    /// element's presentational <c>width</c> and <c>height</c> attributes to
+    /// <c>aspect-ratio: attr(width) / attr(height)</c>. Read here only for a size-contained box.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The distinction this exists for is the one WPT <c>css-flexbox/canvas-contain-size</c> is
+    /// written to make, and it states it in its own <c>meta name="assert"</c>: the attributes "don't
+    /// map to css width/height, but do map to css aspect ratio, which is honored by flexbox, even
+    /// when the item has <c>contain: size</c>". Size containment removes an element's <em>natural</em>
+    /// dimensions and natural ratio; it does not remove a <em>declaration</em>, and the UA stylesheet
+    /// rule is one. So a <c>&lt;canvas width=20 height=20 style="contain: size; width: 100px"&gt;</c>
+    /// is still 100px tall.
+    /// </para>
+    /// <para>
+    /// Broiler carries the attributes as a natural size
+    /// (<see cref="CssBoxProperties.IntrinsicReplacedSize"/>, set by the renderer's canvas fix-up)
+    /// rather than as a declared ratio, so with the natural size suppressed the ratio went with it.
+    /// Reading the attributes back is the same rule expressed on the side of the seam that can see
+    /// them. Gated on containment so an uncontained box keeps taking its ratio from its natural
+    /// size, which is the path every other replaced element in the engine goes through.
+    /// </para>
+    /// </remarks>
+    internal bool TryGetContainedPresentationalRatio(out double ratio)
+    {
+        ratio = 0;
+
+        if (!AppliesSizeContainment || HtmlTag is null)
+            return false;
+
+        if (!IsPresentationalRatioElement(HtmlTag.Name))
+            return false;
+
+        if (!TryParsePresentationalDimension(GetAttribute("width"), out double width)
+            || !TryParsePresentationalDimension(GetAttribute("height"), out double height))
+        {
+            return false;
+        }
+
+        if (!(width > 0) || !(height > 0))
+            return false;
+
+        ratio = width / height;
+        return true;
+    }
+
+    /// <summary>The elements the UA stylesheet gives the <c>attr()</c> ratio rule to.</summary>
+    private static bool IsPresentationalRatioElement(string tagName) =>
+        tagName is not null
+        && (tagName.Equals("canvas", System.StringComparison.OrdinalIgnoreCase)
+            || tagName.Equals("img", System.StringComparison.OrdinalIgnoreCase)
+            || tagName.Equals("video", System.StringComparison.OrdinalIgnoreCase)
+            || tagName.Equals("input", System.StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// HTML §2.4.4.1: a presentational dimension attribute is a valid non-negative integer, and
+    /// anything else leaves the rule unmatched rather than contributing a garbage ratio.
+    /// </summary>
+    private static bool TryParsePresentationalDimension(string value, out double parsed)
+    {
+        parsed = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        return double.TryParse(
+            value.Trim(),
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out parsed);
+    }
+
+    /// <summary>
+    /// CSS Containment 2 §3.2 in the inline axis: replaces a contained box's content-derived
+    /// min-/max-content widths with the ones an empty box has, plus its own padding and border.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when size containment does not apply, leaving the caller to measure
+    /// the contents as before.
+    /// </returns>
+    internal bool TryGetContainedIntrinsicWidth(out double minWidth, out double maxWidth)
+    {
+        minWidth = maxWidth = 0;
+
+        if (!AppliesSizeContainment)
+            return false;
+
+        double borderBox = ContainedIntrinsicContentWidth
+            + ActualPaddingLeft + ActualPaddingRight
+            + ActualBorderLeftWidth + ActualBorderRightWidth;
+
+        minWidth = maxWidth = borderBox;
+        return true;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -323,6 +323,15 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// </summary>
     private bool TryGetNaturalReplacedSize(out SizeF natural)
     {
+        // CSS Containment 2 §3.2: a size-contained replaced element "must be treated as having no
+        // natural dimensions and no natural aspect ratio" — the bitmap or the canvas attributes are
+        // contents like any other, and just as unobservable from outside.
+        if (AppliesSizeContainment)
+        {
+            natural = default;
+            return false;
+        }
+
         if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } declared)
         {
             natural = declared;
@@ -398,6 +407,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
         using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
 
+        // CSS Containment 2 §3.2: a size-contained box measures as though it were empty, so there
+        // are no contents here to measure.
+        if (TryGetContainedIntrinsicWidth(out minWidth, out maxWidth))
+            return;
+
         double min = 0f;
         double maxSum = 0f;
         double paddingSum = 0f;
@@ -416,6 +430,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
         using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
+
+        // CSS Containment 2 §3.2: a size-contained box measures as though it were empty. Ahead of
+        // the grid branch below for the same reason it is ahead of the word walk: a contained
+        // grid's tracks are contents too, and are exactly as unobservable as its text.
+        if (TryGetContainedIntrinsicWidth(out minWidth, out maxWidth))
+            return;
 
         // A grid with a fixed track template contributes its physical-width track
         // sum (+ gaps + own border/padding) as both min- and max-content, rather
@@ -632,17 +652,59 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         }
     }
 
+    /// <summary>
+    /// The preferred aspect ratio the block-axis transfer uses: the box's own <c>aspect-ratio</c>,
+    /// an outer <c>&lt;svg&gt;</c>'s <c>viewBox</c> ratio (SVG 2 §8.2), or — for a size-contained
+    /// replaced element — the ratio its presentational <c>width</c>/<c>height</c> attributes declare.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The three are not interchangeable under CSS Containment 2 §3.2, which is the only reason this
+    /// is a method rather than one expression. Size containment removes an element's <b>natural</b>
+    /// ratio and leaves its <b>declared</b> one alone. A <c>viewBox</c> states a natural ratio, so it
+    /// goes; the UA stylesheet's <c>aspect-ratio: attr(width) / attr(height)</c> (HTML §14.4) is a
+    /// declaration, so it stays — WPT <c>css-contain/contain-size-replaced-002</c> and
+    /// <c>css-flexbox/canvas-contain-size</c> are the two halves of that, and they pull in opposite
+    /// directions.
+    /// </para>
+    /// <para>
+    /// The awkward case is the middle one: Broiler's style pass records an outer <c>&lt;svg&gt;</c>'s
+    /// <c>viewBox</c> ratio *into* <see cref="CssBoxProperties.AspectRatio"/> when the height is
+    /// <c>auto</c>, so by the time it is read here a natural ratio is indistinguishable from a
+    /// declared one. Comparing it back against the <c>viewBox</c> is what separates them, and it
+    /// misreads only an author who declares the ratio their own <c>viewBox</c> already implies —
+    /// where the two answers coincide anyway.
+    /// </para>
+    /// </remarks>
+    private bool TryGetPreferredRatioForBlockTransfer(out double ratio)
+    {
+        bool contained = AppliesSizeContainment;
+        bool hasViewBoxRatio = TryGetSvgViewBoxRatio(out double viewBoxRatio);
+
+        if (TryParseAspectRatio(AspectRatio, out ratio) && ratio > 0)
+        {
+            bool isRecordedViewBoxRatio =
+                hasViewBoxRatio && viewBoxRatio > 0 && Math.Abs(viewBoxRatio - ratio) < 1e-6;
+
+            if (!contained || !isRecordedViewBoxRatio)
+                return true;
+        }
+
+        if (!contained && hasViewBoxRatio && viewBoxRatio > 0)
+        {
+            ratio = viewBoxRatio;
+            return true;
+        }
+
+        return TryGetContainedPresentationalRatio(out ratio) && ratio > 0;
+    }
+
     private bool TryResolveAspectRatioBlockHeight(out double borderBoxHeight)
     {
         borderBoxHeight = 0;
-        if (!TryParseAspectRatio(AspectRatio, out double ratio) || !(ratio > 0))
-        {
-            // SVG 2 §8.2: an outer <svg>'s viewBox is its natural ratio. The style pass records it
-            // as an `aspect-ratio` only when the height is written `auto`, so a percentage height
-            // that computes to auto has to read it from the element itself.
-            if (!TryGetSvgViewBoxRatio(out ratio))
-                return false;
-        }
+
+        if (!TryGetPreferredRatioForBlockTransfer(out double ratio))
+            return false;
 
         double borderBoxWidth = Size.Width;
         if (!(borderBoxWidth > 0))

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
@@ -8,7 +8,6 @@ internal sealed class CssBoxImage : CssBox
 {
     private readonly CssRectImage _imageWord;
     private ILayoutImageLoader _imageLoadHandler;
-    private bool _imageLoadingComplete;
 
     /// <summary>
     /// This box's replaced-content completion, captured by the image prefetch (multithreading item #8)
@@ -129,21 +128,33 @@ internal sealed class CssBoxImage : CssBox
         base.Dispose();
     }
 
-    private void SetErrorBorder()
-    {
-        SetAllBorders(CssConstants.Solid, "2px", "#A0A0A0");
-        BorderRightColor = BorderBottomColor = "#E3E3E3";
-    }
-
+    /// <remarks>
+    /// A load that ended without an image used to give the box a 2px inset border in
+    /// <c>#A0A0A0</c>/<c>#E3E3E3</c> — the "broken image" frame a Netscape-era UA drew, inherited
+    /// here from HtmlRenderer. No UA draws one now: HTML's rendering rules give <c>&lt;img&gt;</c>
+    /// no default border at all, and a browser that cannot decode the image shows its <c>alt</c>
+    /// text, or nothing.
+    ///
+    /// <para>
+    /// Removing it is a <b>sizing</b> fix as much as a painting one, which is why it is worth doing
+    /// rather than leaving as cosmetic legacy. The frame is 2px on all four sides, so it inflated
+    /// the border box by 4px in <em>both axes</em> — and the inflated box is what
+    /// <c>getBoundingClientRect</c>, <c>clientWidth</c>/<c>clientHeight</c> and
+    /// <c>offsetWidth</c>/<c>offsetHeight</c> all reported: an <c>&lt;img style="width: 50px;
+    /// height: 30px"&gt;</c> came back 54×34 with no border and no padding declared anywhere. It
+    /// reached far more than genuinely broken images, because the geometry a script reads is
+    /// captured before the images finish loading, so an image that loads perfectly well still
+    /// reported the broken-image box to script. WPT
+    /// <c>css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003</c> measures exactly
+    /// that, and its sixteen <c>&lt;img&gt;</c> assertions all read 4 where they want 0 and 104
+    /// where they want 100.
+    /// </para>
+    /// </remarks>
     private void OnLoadImageComplete(object? image, RectangleF rectangle, bool async)
     {
         _imageWord.Image = image;
         _imageWord.ImageRectangle = rectangle;
-        _imageLoadingComplete = true;
         _wordsSizeMeasured = false;
-
-        if (_imageLoadingComplete && image == null)
-            SetErrorBorder();
 
         if (!LayoutEnvironment.AvoidImagesLateLoading || async)
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -1322,6 +1322,92 @@ internal abstract partial class CssBoxProperties
     public string Contain { get; set; } = "none";
 
     /// <summary>
+    /// CSS Sizing 4 §5: <c>contain-intrinsic-width</c> — the size a size-contained box reports as
+    /// its intrinsic inline extent in a horizontal writing mode, standing in for the contents that
+    /// containment made unobservable. <c>none</c> (the initial value) leaves that extent at zero.
+    /// </summary>
+    /// <remarks>
+    /// Only read when size containment actually applies; without it a box is sized by its contents
+    /// and this says nothing. The <c>auto</c> prefix of the grammar (<c>auto &lt;length&gt;</c>) is
+    /// parsed and dropped: it asks for the element's *last remembered size* when it has been
+    /// rendered before, which needs the skipped-contents bookkeeping <c>content-visibility: auto</c>
+    /// would bring, and the stated length is what the spec falls back to until then — the only
+    /// state a still render ever observes.
+    /// </remarks>
+    public string ContainIntrinsicWidth
+    {
+        get => ResolveContainIntrinsicAxis(_containIntrinsicWidth, isWidth: true);
+        set => _containIntrinsicWidth = value;
+    }
+
+    /// <summary>CSS Sizing 4 §5: <c>contain-intrinsic-height</c>; see <see cref="ContainIntrinsicWidth"/>.</summary>
+    public string ContainIntrinsicHeight
+    {
+        get => ResolveContainIntrinsicAxis(_containIntrinsicHeight, isWidth: false);
+        set => _containIntrinsicHeight = value;
+    }
+
+    /// <summary>
+    /// Picks the <c>contain-intrinsic-*</c> value for one axis of the frame the box is laid out
+    /// in, following <see cref="ResolvePhysicalSize"/> rather than
+    /// <see cref="ResolvePhysicalBound"/>.
+    /// </summary>
+    /// <remarks>
+    /// The distinction is the vertical-flow prototype's logical frame: a transposed box is laid out
+    /// horizontally with its <em>inline</em> extent as the frame width and its <em>block</em> extent
+    /// as the frame height, and the rotation swaps them into physical space afterwards. These values
+    /// are consumed by the sizing code inside that frame — the shrink-to-fit width in
+    /// <c>GetMinMaxWidth</c>, the atomic-inline height in <c>FlowInlineBlock</c> — so they have to
+    /// arrive in frame terms, exactly as <c>Width</c> and <c>Height</c> do. Mapping them the way
+    /// <c>min-width</c> is mapped instead put <c>contain-intrinsic-inline-size</c> on the physical
+    /// width and the rotation then turned it into the height (WPT
+    /// <c>contain-intrinsic-size-logical-003</c>'s eight <c>vertical-lr</c> cases come out
+    /// transposed).
+    /// </remarks>
+    private string ResolveContainIntrinsicAxis(string physical, bool isWidth)
+    {
+        static bool Declared(string value) => !string.IsNullOrEmpty(value);
+
+        if (IsVerticalWritingMode(WritingMode)
+            && VerticalFlowPrototype.Enabled
+            && WillBeVerticalTransposed())
+        {
+            string frameLogical = isWidth ? ContainIntrinsicInlineSize : ContainIntrinsicBlockSize;
+            if (Declared(frameLogical))
+                return frameLogical;
+
+            string swappedPhysical = isWidth ? _containIntrinsicHeight : _containIntrinsicWidth;
+            return Declared(swappedPhysical) ? swappedPhysical : physical;
+        }
+
+        if (Declared(physical))
+            return physical;
+
+        bool vertical = IsVerticalWritingMode(WritingMode);
+        string logical = isWidth
+            ? (vertical ? ContainIntrinsicBlockSize : ContainIntrinsicInlineSize)
+            : (vertical ? ContainIntrinsicInlineSize : ContainIntrinsicBlockSize);
+
+        return Declared(logical) ? logical : physical;
+    }
+
+    /// <summary>
+    /// CSS Sizing 4 §5: the flow-relative spellings, stored on their own for the same reason
+    /// <see cref="MinBlockSize"/> is — which physical axis each names depends on the writing mode,
+    /// and the mode is not settled while the cascade is applying declarations. Empty means
+    /// undeclared, which is what lets the physical longhand above win when both are absent.
+    /// </summary>
+    public string ContainIntrinsicInlineSize { get; set; } = "";
+
+    /// <summary>CSS Sizing 4 §5: <c>contain-intrinsic-block-size</c>; see <see cref="ContainIntrinsicInlineSize"/>.</summary>
+    public string ContainIntrinsicBlockSize { get; set; } = "";
+
+    // Empty rather than "none" so an undeclared physical longhand can be told from a declared
+    // `none`, which is what lets a flow-relative one win the lookup above. Both read as zero.
+    private string _containIntrinsicWidth = "";
+    private string _containIntrinsicHeight = "";
+
+    /// <summary>
     /// CSS Color Adjust Module Level 1: the <c>color-scheme</c> property.
     /// A space-separated list of the color schemes the element can render in
     /// (<c>normal</c>, <c>light</c>, <c>dark</c>, optionally prefixed by

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -679,6 +679,30 @@ internal abstract partial class CssBoxProperties
     private string _minHeight = "0";
 
     /// <summary>
+    /// Whether the author declared <c>min-height</c> (or a logical <c>min-block-size</c>/
+    /// <c>min-inline-size</c> that resolves to it) at all. The block-axis twin of
+    /// <see cref="IsMinWidthSpecified"/>, and needed for the same reason: <see cref="MinHeight"/>
+    /// defaults to <c>"0"</c>, so its value alone cannot tell an undeclared minimum from an
+    /// explicit <c>min-height: 0</c>. CSS Flexbox §4.5 turns on exactly that distinction — an
+    /// undeclared minimum on a flex item is <c>auto</c> and floors the item at its content, while
+    /// <c>min-height: 0</c> is the idiom that deliberately lets a column flex item shrink past it.
+    /// </summary>
+    /// <remarks>
+    /// The logical halves need no flag of their own: <see cref="MinBlockSize"/> and
+    /// <see cref="MinInlineSize"/> default to the empty string rather than to <c>"0"</c>, so a
+    /// value there already <em>is</em> the declaration. Which of the two lands on the physical
+    /// block axis follows the writing mode, exactly as <see cref="MinHeight"/> resolves it.
+    /// </remarks>
+    internal bool IsMinHeightSpecified
+    {
+        get => _isMinHeightSpecified
+            || !string.IsNullOrEmpty(IsVerticalWritingMode(WritingMode) ? MinInlineSize : MinBlockSize);
+        set => _isMinHeightSpecified = value;
+    }
+
+    private bool _isMinHeightSpecified;
+
+    /// <summary>
     /// CSS Logical 1 §4: the flow-relative minimum and maximum sizes. Stored on their own rather
     /// than folded into the physical longhands, for the same reason
     /// <see cref="BlockSize"/> is: which physical axis each names depends on the box's writing
@@ -2939,6 +2963,7 @@ internal abstract partial class CssBoxProperties
         MinWidth = p.MinWidth;
         IsMinWidthSpecified = p.IsMinWidthSpecified;
         MinHeight = p.MinHeight;
+        IsMinHeightSpecified = p.IsMinHeightSpecified;
         MaxHeight = p.MaxHeight;
         IntrinsicReplacedSize = p.IntrinsicReplacedSize;
         ObjectFit = p.ObjectFit;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -1428,6 +1428,17 @@ internal abstract partial class CssBoxProperties
     public string Transform { get; set; } = "none";
 
     /// <summary>
+    /// CSS Transforms 1 §8: <c>transform-origin</c> — the point <see cref="Transform"/> is applied
+    /// about, relative to the box's border box. The initial value is the box's centre.
+    /// </summary>
+    /// <remarks>
+    /// Kept as the declaration rather than a resolved point, because the point depends on the used
+    /// border box and that is not settled while the cascade is applying declarations.
+    /// <see cref="IR.CssTransformOrigin"/> resolves it once the box has one.
+    /// </remarks>
+    public string TransformOrigin { get; set; } = "50% 50%";
+
+    /// <summary>
     /// CSS Will Change Module Level 1: the <c>will-change</c> property. A
     /// comma-separated hint list (<c>auto</c> by default). Consumed only by the
     /// native anchor-placement containing-block resolution: <c>will-change: transform</c>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -97,6 +97,17 @@ internal static class CssLayoutEngine
         // selected against a zero-width slot) gives the zero-sized image the spec asks for.
         image = ApplyPixelDensity(image, imageWord.PixelDensity);
 
+        // CSS Containment 2 §3.2: a size-contained replaced element "must be treated as having no
+        // natural dimensions and no natural aspect ratio". Dropping the decoded bitmap here is the
+        // whole of that: the auto branches below fall to the contained stand-ins, and `usedRatio`
+        // has nothing left to derive one axis from the other with. An author's own `width`,
+        // `height` or `aspect-ratio` still applies — containment hides the contents, not the box's
+        // own declarations.
+        bool sizeContained = imageWord.OwnerBox.AppliesSizeContainment;
+
+        if (sizeContained)
+            image = null;
+
         double em = imageWord.OwnerBox.GetEmHeight();
 
         // A specified, non-percentage size counts as a "tag" size — but resolve it
@@ -148,6 +159,10 @@ internal static class CssLayoutEngine
                 // inline replaced elements are allowed to overflow their
                 // container.  Authors use max-width:100% to opt into clamping.
             }
+            else if (sizeContained)
+            {
+                imageWord.Width = imageWord.OwnerBox.ContainedIntrinsicContentWidth;
+            }
             else
             {
                 imageWord.Width = hasImageTagHeight ? tagHeightPx / 1.14f : 20;
@@ -163,6 +178,10 @@ internal static class CssLayoutEngine
             imageWord.Height = imageWord.ImageRectangle == RectangleF.Empty
                 ? image.Value.Height
                 : imageWord.ImageRectangle.Height / imageWord.PixelDensity;
+        }
+        else if (sizeContained)
+        {
+            imageWord.Height = imageWord.OwnerBox.ContainedIntrinsicContentHeight;
         }
         else
         {
@@ -181,9 +200,16 @@ internal static class CssLayoutEngine
 
         // The ratio the box is sized by: the author's preferred one when declared, otherwise the
         // image's natural one. Zero when the box has neither, which leaves the two axes independent.
+        // HTML §14.4: a size-contained replaced element has no natural ratio left, but the UA
+        // stylesheet's `aspect-ratio: attr(width) / attr(height)` is a declaration and survives —
+        // so `<img width=60 height=60 style="width: 100px; height: auto; contain: size">` is still
+        // square (WPT css-contain/contain-size-replaced-007, whose assert says exactly that).
         double usedRatio = hasCssAspectRatio
             ? cssAspectRatio
-            : image is { HasIntrinsicRatio: true, Height: > 0 } natural ? natural.Width / natural.Height : 0;
+            : image is { HasIntrinsicRatio: true, Height: > 0 } natural ? natural.Width / natural.Height
+            : sizeContained && imageWord.OwnerBox.TryGetContainedPresentationalRatio(out double attributeRatio)
+                ? attributeRatio
+                : 0;
 
         bool widthDriven = hasStatedWidth && !hasImageTagHeight;
 
@@ -1230,7 +1256,10 @@ internal static class CssLayoutEngine
         // than shrinking to fit its (absent) content, and keeps the two axes tied by the natural
         // ratio while min-*/max-* clamp them. Sized in one step below; the per-axis clamps that
         // follow are skipped for it.
-        var intrinsic = b.IntrinsicReplacedSize;
+        // CSS Containment 2 §3.2: size containment leaves a replaced element with no natural
+        // dimensions and no natural ratio, so a contained <canvas>/<svg> is sized like any other
+        // contained box rather than from its bitmap.
+        var intrinsic = b.AppliesSizeContainment ? null : b.IntrinsicReplacedSize;
         bool isReplaced = intrinsic is { Width: > 0, Height: > 0 };
 
         // --- Compute inline-block content width ---
@@ -1469,6 +1498,18 @@ internal static class CssLayoutEngine
         else if (b.TryGetAspectRatioBlockHeight(out double ratioHeight))
         {
             ibHeight = ratioHeight;
+        }
+        // CSS Containment 2 §3.2: an atomic inline computes its height here rather than in
+        // CssBox.ResolveUsedBlockHeight, so size containment has to be honoured on this path too —
+        // otherwise the contents this box just laid out are measured straight back into it. Below
+        // the ratio arm, because a preferred aspect ratio and a definite inline size settle the
+        // block axis outright and `contain-intrinsic-size` only stands in for *contents*; above the
+        // content-derived arm, which is precisely what containment removes.
+        else if (b.AppliesSizeContainment)
+        {
+            ibHeight = b.ContainedIntrinsicContentHeight
+                + b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                + b.ActualPaddingTop + b.ActualPaddingBottom;
         }
         else
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -172,6 +172,11 @@ internal static partial class CssUtils
             "grid-auto-rows" => cssBox.GridAutoRows,
             "grid-auto-columns" => cssBox.GridAutoColumns,
             "contain" => cssBox.Contain,
+            "contain-intrinsic-size" => JoinContainIntrinsicSize(cssBox),
+            "contain-intrinsic-width" => cssBox.ContainIntrinsicWidth,
+            "contain-intrinsic-height" => cssBox.ContainIntrinsicHeight,
+            "contain-intrinsic-inline-size" => cssBox.ContainIntrinsicInlineSize,
+            "contain-intrinsic-block-size" => cssBox.ContainIntrinsicBlockSize,
             "overflow-clip-margin" => cssBox.OverflowClipMargin,
             "content-visibility" => cssBox.ContentVisibility,
             "color-scheme" => cssBox.ColorScheme,
@@ -512,6 +517,21 @@ internal static partial class CssUtils
                 break;
             case "contain":
                 cssBox.Contain = value;
+                break;
+            case "contain-intrinsic-size":
+                ApplyContainIntrinsicSizeShorthand(cssBox, value);
+                break;
+            case "contain-intrinsic-width":
+                cssBox.ContainIntrinsicWidth = value;
+                break;
+            case "contain-intrinsic-height":
+                cssBox.ContainIntrinsicHeight = value;
+                break;
+            case "contain-intrinsic-inline-size":
+                cssBox.ContainIntrinsicInlineSize = value;
+                break;
+            case "contain-intrinsic-block-size":
+                cssBox.ContainIntrinsicBlockSize = value;
                 break;
             case "overflow-clip-margin":
                 cssBox.OverflowClipMargin = value;
@@ -936,6 +956,56 @@ internal static partial class CssUtils
     /// implicit-track longhands to their initial values when it applies, per the
     /// spec's reset semantics.
     /// </summary>
+    /// <summary>
+    /// CSS Sizing 4 §5: expands <c>contain-intrinsic-size</c> into
+    /// <c>contain-intrinsic-width</c> and <c>contain-intrinsic-height</c>. One component sets
+    /// both; two set width then height.
+    /// </summary>
+    /// <remarks>
+    /// A component is <c>auto? [ none | &lt;length&gt; ]</c>, so the value cannot simply be split on
+    /// whitespace: <c>auto 100px</c> is one component naming both axes, and
+    /// <c>auto 100px auto 200px</c> is two. The <c>auto</c> keyword binds forward to the value
+    /// after it, which is what tells the two apart.
+    /// </remarks>
+    private static void ApplyContainIntrinsicSizeShorthand(CssBox cssBox, string value)
+    {
+        var tokens = (value ?? string.Empty)
+            .Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+
+        var components = new List<string>();
+
+        for (int i = 0; i < tokens.Length; i++)
+        {
+            if (tokens[i].Equals(CssConstants.Auto, StringComparison.OrdinalIgnoreCase)
+                && i + 1 < tokens.Length)
+            {
+                components.Add(tokens[i] + " " + tokens[i + 1]);
+                i++;
+                continue;
+            }
+
+            components.Add(tokens[i]);
+        }
+
+        if (components.Count == 0)
+            return;
+
+        cssBox.ContainIntrinsicWidth = components[0];
+        cssBox.ContainIntrinsicHeight = components.Count > 1 ? components[1] : components[0];
+
+        // The shorthand names the physical longhands, so a flow-relative value cascaded earlier
+        // would otherwise keep winning the ResolvePhysicalBound lookup and the shorthand would
+        // appear to do nothing.
+        cssBox.ContainIntrinsicInlineSize = string.Empty;
+        cssBox.ContainIntrinsicBlockSize = string.Empty;
+    }
+
+    /// <summary>The <c>contain-intrinsic-size</c> shorthand rebuilt from its two longhands.</summary>
+    private static string JoinContainIntrinsicSize(CssBox cssBox) =>
+        cssBox.ContainIntrinsicWidth == cssBox.ContainIntrinsicHeight
+            ? cssBox.ContainIntrinsicWidth
+            : cssBox.ContainIntrinsicWidth + " " + cssBox.ContainIntrinsicHeight;
+
     private static void ApplyGridShorthand(CssBox cssBox, string value, bool resetAutoTracks)
     {
         string v = value.Trim();

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -685,6 +685,7 @@ internal static partial class CssUtils
                 break;
             case "min-height":
                 cssBox.MinHeight = value;
+                cssBox.IsMinHeightSpecified = true;
                 break;
             case "aspect-ratio":
                 cssBox.AspectRatio = value;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -151,6 +151,7 @@ internal static partial class CssUtils
             "clip-path" => cssBox.ClipPath,
             "clip" => cssBox.Clip,
             "transform" => cssBox.Transform,
+            "transform-origin" => cssBox.TransformOrigin,
             "will-change" => cssBox.WillChange,
             "align-content" => cssBox.AlignContent,
             "justify-self" => cssBox.JustifySelf,
@@ -374,6 +375,9 @@ internal static partial class CssUtils
                 break;
             case "transform":
                 cssBox.Transform = value;
+                break;
+            case "transform-origin":
+                cssBox.TransformOrigin = value;
                 break;
             case "will-change":
                 cssBox.WillChange = value;

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
@@ -181,6 +181,9 @@ public sealed class ComputedStyle
     public string ContentVisibility { get; init; } = "visible";
     public string Transform { get; init; } = "none";
 
+    /// <summary>CSS Transforms 1 §8: the point <see cref="Transform"/> is applied about.</summary>
+    public string TransformOrigin { get; init; } = "50% 50%";
+
     // --- Flex ---
 
     public string FlexDirection { get; init; } = "row";

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
@@ -178,6 +178,7 @@ internal static class ComputedStyleBuilder
             ContentVisibility = box.ContentVisibility,
             ColorScheme = box.ColorScheme,
             Transform = box.Transform,
+            TransformOrigin = box.TransformOrigin,
 
             // Flex
             FlexDirection = box.FlexDirection,

--- a/Broiler.Layout/Broiler.Layout/IR/CssTransformOrigin.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/CssTransformOrigin.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS Transforms 1 §8: resolves a <c>transform-origin</c> declaration to the point, in the same
+/// coordinate space as the reference box, that the element's <c>transform</c> is applied about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One resolver for three callers that each had their own reading of the grammar, and did not
+/// agree: the SVG renderer's <c>transform-box</c> handling, the script bridge's transform chain
+/// (what <c>getBoundingClientRect</c> reports), and the paint walker (what actually reaches the
+/// canvas). The last of those did not read the property at all — it applied every CSS
+/// <c>transform</c> about the box centre — so a page's painted output and the geometry its own
+/// script measured disagreed about where a transformed element is:
+/// <c>transform-origin: 0 0; transform: scale(0.5)</c> on a 100×100 box reported a rect at
+/// (0, 0) and painted it at (25, 25).
+/// </para>
+/// <para>
+/// The grammar is fussier than "split on whitespace and take two components", which is what the
+/// bridge did. A vertical keyword may lead — <c>top left</c> is the same point as
+/// <c>left top</c> — but only when the other half is a keyword too, because a
+/// <c>&lt;length-percentage&gt;</c> may not follow one. So <c>top 100%</c> is not a re-ordered
+/// <c>100% top</c>; it is invalid, and an invalid declaration is dropped whole and takes the
+/// initial value. The twelve WPT <c>css-transforms/transform-origin/svg-origin-relative-length-invalid-*</c>
+/// cases are built to catch exactly that distinction.
+/// </para>
+/// <para>
+/// The <b>initial</b> value differs by caller, which is the one thing this cannot decide for
+/// itself. A CSS box's is <c>50% 50%</c> — its centre. An SVG element has no CSS layout box, and
+/// §8 gives one of those a used value of <c>0 0</c>: the reference box's own corner. Passing the
+/// wrong one is not a rounding difference — it is the element in a different place — so the caller
+/// states it.
+/// </para>
+/// </remarks>
+internal static class CssTransformOrigin
+{
+    /// <summary>
+    /// The transform origin <paramref name="value"/> names inside <paramref name="box"/>.
+    /// </summary>
+    /// <param name="value">The declaration; <see langword="null"/>, empty or invalid takes the initial value.</param>
+    /// <param name="box">The reference box, in the coordinate space the result is wanted in.</param>
+    /// <param name="initialIsBoxCorner">
+    /// <see langword="true"/> for an element with no CSS layout box, whose initial and
+    /// invalid-fallback origin is the box's corner (<c>0 0</c>); <see langword="false"/> for a CSS
+    /// box, whose initial is its centre (<c>50% 50%</c>).
+    /// </param>
+    internal static PointF Resolve(string? value, RectangleF box, bool initialIsBoxCorner)
+    {
+        float centreX = box.X + box.Width / 2f;
+        float centreY = box.Y + box.Height / 2f;
+
+        var initial = initialIsBoxCorner ? new PointF(box.X, box.Y) : new PointF(centreX, centreY);
+
+        if (string.IsNullOrWhiteSpace(value))
+            return initial;
+
+        var parts = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return initial;
+
+        if (parts.Length == 1)
+        {
+            // One value sets that axis and centres the other. `top`/`bottom` name the vertical one,
+            // so a lone one of those moves y rather than x.
+            if (IsVerticalKeyword(parts[0]))
+                return new PointF(centreX, ResolveComponent(parts[0], box.Y, box.Height, horizontal: false, centreY));
+
+            return IsHorizontalCompatible(parts[0])
+                ? new PointF(ResolveComponent(parts[0], box.X, box.Width, horizontal: true, centreX), centreY)
+                : initial;
+        }
+
+        // The pair may be written the other way round — but only when *both* halves are keywords.
+        string first = parts[0], second = parts[1];
+        if (IsVerticalKeyword(first))
+        {
+            if (!IsHorizontalKeyword(second))
+                return initial;
+
+            (first, second) = (second, first);
+        }
+
+        if (!IsHorizontalCompatible(first) || !IsVerticalCompatible(second))
+            return initial;
+
+        return new PointF(
+            ResolveComponent(first, box.X, box.Width, horizontal: true, centreX),
+            ResolveComponent(second, box.Y, box.Height, horizontal: false, centreY));
+    }
+
+    /// <summary>A keyword naming a position on the horizontal axis.</summary>
+    private static bool IsHorizontalKeyword(string token) =>
+        token.Equals("left", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("right", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("center", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether the token may occupy the horizontal slot: a keyword for it, or a length.</summary>
+    private static bool IsHorizontalCompatible(string token) =>
+        IsHorizontalKeyword(token) || IsLengthOrPercentage(token);
+
+    /// <summary>Whether the token may occupy the vertical slot: a keyword for it, or a length.</summary>
+    private static bool IsVerticalCompatible(string token) =>
+        IsVerticalKeyword(token)
+        || token.Equals("center", StringComparison.OrdinalIgnoreCase)
+        || IsLengthOrPercentage(token);
+
+    private static bool IsVerticalKeyword(string token) =>
+        token.Equals("top", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("bottom", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLengthOrPercentage(string token)
+    {
+        var span = token.AsSpan().Trim();
+        if (span.Length == 0)
+            return false;
+
+        if (span[^1] == '%')
+            span = span[..^1];
+
+        return float.TryParse(
+            span.ToString().Replace("px", string.Empty), NumberStyles.Float,
+            CultureInfo.InvariantCulture, out _);
+    }
+
+    private static float ResolveComponent(
+        string token, float origin, float extent, bool horizontal, float fallback)
+    {
+        if (token.Equals("center", StringComparison.OrdinalIgnoreCase))
+            return origin + extent / 2f;
+
+        if (horizontal)
+        {
+            if (token.Equals("left", StringComparison.OrdinalIgnoreCase))
+                return origin;
+            if (token.Equals("right", StringComparison.OrdinalIgnoreCase))
+                return origin + extent;
+        }
+        else
+        {
+            if (token.Equals("top", StringComparison.OrdinalIgnoreCase))
+                return origin;
+            if (token.Equals("bottom", StringComparison.OrdinalIgnoreCase))
+                return origin + extent;
+        }
+
+        var span = token.AsSpan().Trim();
+        if (span.Length > 0 && span[^1] == '%')
+        {
+            return float.TryParse(
+                span[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out float percent)
+                ? origin + extent * percent / 100f
+                : fallback;
+        }
+
+        // A bare number, or one carrying a unit treated as pixels. Measured from the box's corner.
+        return float.TryParse(
+            token.Replace("px", string.Empty), NumberStyles.Float, CultureInfo.InvariantCulture,
+            out float length)
+            ? origin + length
+            : fallback;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
@@ -70,137 +70,20 @@ internal static partial class SvgRenderer
 
     /// <summary>
     /// CSS Transforms 1 §8: <c>transform-origin</c> as a point in user units, relative to
-    /// <paramref name="box"/>. One value gives the x with the y centred; a keyword names an edge or
-    /// the centre; a percentage resolves against the box. The z component a third value carries is
-    /// dropped — nothing here is 3D. An absent or unreadable value is the initial
-    /// <c>50% 50%</c>: the centre of the box.
+    /// <paramref name="box"/>.
     /// </summary>
-    private static PointF ResolveTransformOrigin(string value, RectangleF box)
-    {
-        float centreX = box.X + box.Width / 2f;
-        float centreY = box.Y + box.Height / 2f;
-
-        // CSS Transforms 1 §8: an SVG element has no CSS layout box, and for one of those the used
-        // value of an *unspecified* `transform-origin` is `0 0` — the reference box's own corner,
-        // not its centre. An invalid declaration is dropped whole and takes that same initial
-        // value. Falling back to the centre instead is what kept the twelve WPT
-        // svg-origin-relative-length-invalid-* cases failing: each is built so that its transform
-        // maps the square onto itself about `0 0`, matching a reference that draws the rect with no
-        // transform at all, and a centre origin threw the square hundreds of pixels away.
-        var initial = new PointF(box.X, box.Y);
-
-        if (string.IsNullOrWhiteSpace(value))
-            return initial;
-
-        var parts = value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
-            return initial;
-
-        if (parts.Length == 1)
-        {
-            // One value sets that axis and centres the other. `top`/`bottom` name the vertical one,
-            // so a lone one of those moves y rather than x.
-            if (IsVerticalKeyword(parts[0]))
-                return new PointF(centreX, ResolveOriginComponent(parts[0], box.Y, box.Height, horizontal: false, centreY));
-
-            return IsHorizontalCompatible(parts[0])
-                ? new PointF(ResolveOriginComponent(parts[0], box.X, box.Width, horizontal: true, centreX), centreY)
-                : initial;
-        }
-
-        // The pair may be written the other way round — but only when *both* halves are keywords.
-        // `top left` is the keyword form; `top 100%` is not a form at all, because a
-        // length-percentage may not follow a vertical keyword. An invalid declaration is dropped
-        // whole, leaving the initial `50% 50%` — which is what the twelve WPT
-        // css-transforms/transform-origin/svg-origin-relative-length-invalid-* cases assert, and
-        // what accepting `top 100%` as `100% top` got wrong.
-        string first = parts[0], second = parts[1];
-        if (IsVerticalKeyword(first))
-        {
-            if (!IsHorizontalKeyword(second))
-                return initial;
-
-            (first, second) = (second, first);
-        }
-
-        if (!IsHorizontalCompatible(first) || !IsVerticalCompatible(second))
-            return initial;
-
-        return new PointF(
-            ResolveOriginComponent(first, box.X, box.Width, horizontal: true, centreX),
-            ResolveOriginComponent(second, box.Y, box.Height, horizontal: false, centreY));
-    }
-
-    /// <summary>A keyword naming a position on the horizontal axis.</summary>
-    private static bool IsHorizontalKeyword(string token) =>
-        token.Equals("left", StringComparison.OrdinalIgnoreCase)
-        || token.Equals("right", StringComparison.OrdinalIgnoreCase)
-        || token.Equals("center", StringComparison.OrdinalIgnoreCase);
-
-    /// <summary>Whether the token may occupy the horizontal slot: a keyword for it, or a length.</summary>
-    private static bool IsHorizontalCompatible(string token) =>
-        IsHorizontalKeyword(token) || IsLengthOrPercentage(token);
-
-    /// <summary>Whether the token may occupy the vertical slot: a keyword for it, or a length.</summary>
-    private static bool IsVerticalCompatible(string token) =>
-        IsVerticalKeyword(token)
-        || token.Equals("center", StringComparison.OrdinalIgnoreCase)
-        || IsLengthOrPercentage(token);
-
-    private static bool IsLengthOrPercentage(string token)
-    {
-        var span = token.AsSpan().Trim();
-        if (span.Length == 0)
-            return false;
-
-        if (span[^1] == '%')
-            span = span[..^1];
-
-        return float.TryParse(
-            span.ToString().Replace("px", string.Empty), NumberStyles.Float,
-            CultureInfo.InvariantCulture, out _);
-    }
-
-    private static bool IsVerticalKeyword(string token) =>
-        token.Equals("top", StringComparison.OrdinalIgnoreCase)
-        || token.Equals("bottom", StringComparison.OrdinalIgnoreCase);
-
-    private static float ResolveOriginComponent(
-        string token, float origin, float extent, bool horizontal, float fallback)
-    {
-        if (token.Equals("center", StringComparison.OrdinalIgnoreCase))
-            return origin + extent / 2f;
-
-        if (horizontal)
-        {
-            if (token.Equals("left", StringComparison.OrdinalIgnoreCase))
-                return origin;
-            if (token.Equals("right", StringComparison.OrdinalIgnoreCase))
-                return origin + extent;
-        }
-        else
-        {
-            if (token.Equals("top", StringComparison.OrdinalIgnoreCase))
-                return origin;
-            if (token.Equals("bottom", StringComparison.OrdinalIgnoreCase))
-                return origin + extent;
-        }
-
-        var span = token.AsSpan().Trim();
-        if (span.Length > 0 && span[^1] == '%')
-        {
-            return float.TryParse(
-                span[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out float percent)
-                ? origin + extent * percent / 100f
-                : fallback;
-        }
-
-        // A bare number, or one carrying a unit this renderer treats as pixels — the same reading
-        // GetLength gives an attribute length. The origin is measured from the box's own corner.
-        return float.TryParse(
-            token.Replace("px", string.Empty), NumberStyles.Float, CultureInfo.InvariantCulture,
-            out float length)
-            ? origin + length
-            : fallback;
-    }
+    /// <remarks>
+    /// The grammar lives in <see cref="CssTransformOrigin"/>, shared with the script bridge's
+    /// transform chain and with the paint walker, so the three cannot drift apart. What is specific
+    /// here is the <b>initial</b> value: an SVG element has no CSS layout box, and §8 gives one of
+    /// those a used value of <c>0 0</c> — the reference box's own corner, not its centre. An
+    /// invalid declaration is dropped whole and takes that same value. Falling back to the centre
+    /// instead is what kept the twelve WPT
+    /// <c>css-transforms/transform-origin/svg-origin-relative-length-invalid-*</c> cases failing:
+    /// each is built so that its transform maps the square onto itself about <c>0 0</c>, matching a
+    /// reference that draws the rect with no transform at all, and a centre origin threw the square
+    /// hundreds of pixels away.
+    /// </remarks>
+    private static PointF ResolveTransformOrigin(string value, RectangleF box) =>
+        CssTransformOrigin.Resolve(value, box, initialIsBoxCorner: true);
 }

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -938,6 +938,72 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### `contain: size` did nothing to a box's size, and `contain-intrinsic-size` was not parsed
+
+- **Tests:** **+43 reftests, none lost**, across four directories: `css/css-contain`
+  323 → **348**, `css/css-sizing` 299 → **311** (of which
+  `css-sizing/contain-intrinsic-size` 9 → **18**), and `css/css-grid` 671 → **677**.
+  The check-layout suite the feature is specified through moves further, because it
+  states its own expected geometry: over the seven `contain-intrinsic-size` tests
+  that carry `data-expected-*`, **54 → 203 of 312** assertions.
+  `contain-intrinsic-size-logical-003` — entry 21 of
+  [#1774](https://github.com/Broiler-Platform/Broiler/issues/1774)'s top 30 at 42.0% —
+  goes 0 → 32 of 96, and `contain-intrinsic-size-030` 0 → **48 of 48**.
+- **Owner:** `Broiler.Layout` (`Engine/CssBox.SizeContainment.cs` and four sizing call
+  sites). Main repo — no patch, so it reaches the WPT run directly.
+- **Root cause.** `contain` reached the box and two things read it — background
+  propagation (CSS Backgrounds §2.11.1) and fragmentation, which treats a contained
+  box as monolithic — but nothing acted on what it says about **size**. CSS
+  Containment 2 §3.2 makes a size-contained box lay out as though it had no contents,
+  which is the whole point of the keyword: it is what lets a page state a placeholder
+  for a subtree it has not measured. And `contain-intrinsic-size`, the property that
+  states that placeholder, was not parsed at all — neither the shorthand nor its four
+  longhands, though `@supports` already claimed all five.
+- **The parse is not a split on whitespace.** A component is
+  `auto? [ none | <length> ]`, so `auto 100px` is *one* component naming both axes and
+  `auto 100px auto 50px` is two. The `auto` keyword asks for the element's last
+  remembered size and falls back to the stated length, which is the only state a
+  render that has never skipped the element can be in — so it is parsed and dropped.
+- **The logical longhands map through the *frame*, not through the physical axes.**
+  `contain-intrinsic-inline-size` had to follow `ResolvePhysicalSize` (what `width` and
+  `height` use) rather than `ResolvePhysicalBound` (what `min-width` uses): the
+  vertical-flow prototype lays a transposed box out horizontally with its inline extent
+  as the frame width and rotates afterwards, and these values are consumed *inside*
+  that frame. Mapped the other way, all eight `vertical-lr` cases came out transposed.
+- **The aspect ratio is where this gets interesting, and it needed both directions.**
+  Containment removes an element's **natural** ratio and leaves a **declared** one
+  alone — and the two reach the engine looking alike:
+  - `css-flexbox/canvas-contain-size` asserts that a `<canvas width=20 height=20>`
+    keeps its ratio under `contain: size`, because HTML §14.4 maps the presentational
+    attributes to `aspect-ratio: attr(width) / attr(height)` — a UA stylesheet
+    *declaration*. Broiler carries those attributes as a natural size instead
+    (`IntrinsicReplacedSize`, set by the renderer's canvas fix-up), so suppressing the
+    natural size took the ratio with it. Reading the attributes back in the layout
+    engine is the same rule expressed on the side of the seam that can see them.
+  - `css-contain/contain-size-replaced-002` asserts the *opposite* for an
+    `<svg viewBox="0 0 50 50">`, whose viewBox states a **natural** ratio (SVG 2 §8.2)
+    that must go. Broiler's style pass records the viewBox ratio *into*
+    `aspect-ratio`, so by layout time it is indistinguishable from a declaration;
+    comparing the recorded value back against the viewBox is what separates them, and
+    it misreads only an author who declares the ratio their own viewBox already
+    implies — where both answers agree anyway.
+- **"Non-atomic" is the load-bearing word in the applicability list.** §3.2 exempts
+  non-atomic inline-level boxes, and a replaced element's computed `display` is
+  `inline` — that is the UA value for `<img>` and `<svg>` — while the box it generates
+  is atomic. Testing the keyword alone declined containment on exactly the elements
+  `contain-size-replaced-*` is written about.
+- **`contain: content` deliberately does not contain size** — that is the difference
+  between it and `strict`, and the reason a page can use it without stating a
+  placeholder. The fragmentation predicate treats `content` as monolithic and is right
+  to for its own question (paint containment clips the box), so the two questions keep
+  two predicates.
+- **Checks:** `src/Broiler.Wpt.Tests/SizeContainmentTests.cs`, 20 cases rendered and
+  measured off the canvas, including both halves of the ratio rule.
+- **What is still not contained** — `<img>`, `<svg>`, `<video>` and `<iframe>`, the
+  other 64 assertions of `contain-intrinsic-size-logical-003` — is
+  [two separate gaps below](wpt-rendering-gaps-open.md#a-size-contained-img-svg-video-or-iframe-still-reports-a-size),
+  neither of them about containment.
+
 ### A column flex container never read `flex-basis` and never shrank
 
 - **Tests:** `css/css-flexbox` reftests **693 → 704 passing**, 11 won and none lost. The

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -938,6 +938,41 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### A broken image drew a 2px frame, and reported it as part of its box
+
+- **Tests:** `css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003` —
+  entry 21 of [#1774](https://github.com/Broiler-Platform/Broiler/issues/1774)'s top 30 —
+  32 → **42 of 96** assertions, all ten in its `<img>` rows.
+  `css/css-grid` reftests 677 → **679**, and nothing lost across `css/css-sizing`,
+  `css/css-contain`, `css/css-flexbox`, `css/CSS2`, `css/css-backgrounds` and `svg`.
+- **Owner:** `Broiler.Layout` (`Engine/CssBoxImage.cs`). Main repo.
+- **Root cause.** A load that ended without an image gave the box a 2px inset border in
+  `#A0A0A0`/`#E3E3E3` — the "broken image" frame a Netscape-era UA drew, inherited from
+  HtmlRenderer. No UA draws one now; HTML's rendering rules give `<img>` no default
+  border at all, and a browser that cannot decode an image shows its `alt` text, or
+  nothing.
+- **It was a sizing bug, not a cosmetic one.** 2px on four sides is **4px in both axes**
+  of border box, and the border box is what `getBoundingClientRect`,
+  `clientWidth`/`clientHeight` and `offsetWidth`/`offsetHeight` all report:
+  `<img style="width: 50px; height: 30px">` came back 54×34 with nothing declaring a
+  border or padding anywhere. It also displaced whatever followed the image on its line.
+- **And it reached far more than genuinely broken images.** The geometry a script reads
+  is captured before the images finish loading, so an image that loads perfectly well
+  still reported the broken-image box: the probe above uses a `<img>` whose bitmap is on
+  disk and paints correctly at 50×30 inside a box that measures 54×34.
+- **Why the reftest suite barely moves.** Both sides of a reftest are rendered by
+  Broiler, so a frame on the test appears on its reference too and cancels; only the
+  two `css-grid` cases where it changed a *layout* consequence show up. The measurable
+  signal is the check-layout suite, which states absolute geometry and does not
+  cancel — hence the +10 above.
+- **Checks:** `src/Broiler.Cli.Tests/BrokenImageBorderTests.cs`, five check-layout cases
+  over an unloadable `<img>`: CSS-sized, attribute-sized, bordered, padded, and one that
+  pins a following box's offset.
+- **What it does not fix:** `clientWidth`/`clientHeight` on an inline element with a
+  border, which is
+  [a separate collector gap](wpt-rendering-gaps-open.md#an-inline-elements-three-box-model-rects-are-all-the-same-rectangle)
+  and the reason six of that test's `<img>` assertions still fail.
+
 ### `contain: size` did nothing to a box's size, and `contain-intrinsic-size` was not parsed
 
 - **Tests:** **+43 reftests, none lost**, across four directories: `css/css-contain`

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -938,6 +938,65 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### A column flex container never read `flex-basis` and never shrank
+
+- **Tests:** `css/css-flexbox` reftests **693 → 704 passing**, 11 won and none lost. The
+  headline is `percentage-heights-002`, entry 19 of
+  [#1774](https://github.com/Broiler-Platform/Broiler/issues/1774)'s top 30 at 40.9%,
+  now **100%**. The other ten:
+  `dynamic-isize-change-003`, `flex-basis-012`, `flex-flow-007`,
+  `flex-minimum-height-flex-items-003`/`-026`/`-027`,
+  `flexbox-justify-content-vert-003`/`-004`/`-006` and `percentage-widths-001`, most of
+  them at 98.7% against a 99% threshold.
+- **Owner:** `Broiler.Layout` (`Engine/CssBox.Flex.cs`, `Engine/CssBox.ContainingBlock.cs`).
+  Main repo — no patch, so it reaches the WPT run directly.
+- **Three gaps, and the third gated the first two.**
+  - **§9.2 step 3.** A column container's items stack through ordinary block flow here,
+    and the pass that resizes that stack afterwards measured each item's height instead
+    of reading its flex base size. Those coincide for a content-sized item, which is why
+    it went unnoticed; they part company the moment `flex-basis` names a block size,
+    which block flow does not implement and so ignored outright.
+  - **§9.7, the shrink half.** Deliberately omitted, on the stated grounds that §4.5's
+    automatic minimum size did not exist in this axis to floor a shrink with. Since
+    `flex-shrink` is `1` by default, that is every column flex item on the web asking to
+    shrink and none of them shrinking. `ClampFlexColumnItemBorderBoxHeight` is the floor
+    that made turning it on safe — the block-axis twin of `ClampFlexItemBorderBoxWidth`,
+    reading the content size the same way (measuring the item with its own `height`
+    suppressed) and adding the one rule the row clamp omits: §4.5 gives no automatic
+    minimum to an item whose main-axis `overflow` is not `visible`, which is what lets
+    the `flex: 1; overflow: auto` pane of a column layout scroll instead of pushing its
+    container open.
+  - **CSS2.1 §10.6.4, which gates both.** "Definite main size" was read from the
+    container's `height` declaration alone. An out-of-flow box with `height: auto` and
+    both `top` and `bottom` set has no such declaration and a perfectly definite used
+    height — the constraint equation leaves one unknown — and `position: absolute;
+    inset: 0` is how a full-viewport app shell is written, so the most common definite
+    column container there is was treated as content-sized. The same blindness sent
+    every percentage height inside such a box to `auto` (§10.5).
+    `TryGetInsetDerivedContentHeight` answers it once for all four readers.
+- **`min-height: 0` had to become distinguishable from an undeclared minimum.**
+  `MinHeight` computes to `"0"` either way, and §4.5 turns on exactly that distinction:
+  an undeclared minimum on a flex item is `auto` and floors it at its content, while
+  `min-height: 0` is the idiom for deliberately letting a column item shrink past it.
+  `IsMinHeightSpecified` is the block-axis twin of the `IsMinWidthSpecified` flag the row
+  path already had.
+- **A vertical writing mode is declined, not transposed.** `column` names the *block*
+  axis, so under `vertical-lr` the main axis is horizontal and every number the pass
+  reads belongs to the cross axis. Growing on the wrong axis was inert; shrinking on it
+  is not, and `flexbox-column-row-gap-002` squashed all six of its items. The sibling
+  multi-line pass already declined for the same reason.
+- **Two tests moved from passing to failing, and both were passing by omission.**
+  `css-position/sticky/position-sticky-flex-item-001` and `-003` are the `column` half
+  of a family of four; their red item is sized by `flex-basis`, so it used to be
+  zero-tall and there was no red to show. They now fail exactly as their `row` twins
+  `-002`/`-004` always have, on
+  [a sticky box's contribution to scrollable overflow](wpt-rendering-gaps-open.md#a-sticky-box-contributes-its-stuck-position-to-the-scroll-containers-overflow)
+  — one bug, no longer masked by a second.
+- **Checks:** `src/Broiler.Wpt.Tests/FlexColumnMainAxisSizingTests.cs` renders each rule
+  and measures it off the canvas. `FlexColumnWrapAndReverseTests`'
+  nowrap case was restated: it pins the line breaking, and had been written against the
+  pre-shrink geometry of two 40px items overflowing a 50px container.
+
 ### A table box outside a table painted nothing at all
 
 - **Tests:** the `css/CSS2/tables/table-anonymous-objects-*` family — **103 of its

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -938,6 +938,56 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### Every CSS transform was applied about the box centre, whatever `transform-origin` said
+
+- **Tests:** `css/filter-effects/filter-scaling-001` — entry 28 of
+  [#1774](https://github.com/Broiler-Platform/Broiler/issues/1774)'s top 30 at 50.1% —
+  rendered a blank page and now renders the half-viewport green band it describes.
+  **272 tests in the corpus declare `transform-origin`** and every one of them painted
+  about the wrong point.
+- **Owner:** `Broiler.Layout` for the grammar (`IR/CssTransformOrigin.cs`),
+  `Broiler.HTML` for the two lines in `PaintWalker` that call it — patch
+  *"paint: apply a CSS transform about its transform-origin"*.
+- **Root cause.** `PaintWalker` hardcoded the origin to `bounds.X + bounds.Width * 0.5f`
+  with the comment "(default: center center)", and never read the property. The centre
+  *is* the initial value, so this was right for every element that declares nothing and
+  wrong for every element that declares anything.
+- **Paint and script disagreed about the same element.** The bridge's transform chain
+  — what `getBoundingClientRect` reports — *did* read `transform-origin`, so
+  `transform-origin: 0 0; transform: scale(0.5)` on a 100×100 box reported a rect at
+  (0, 0) and painted it at (25, 25). Two answers, one element.
+- **Scaling up is not a displacement, it is a blank page.** About the centre, a
+  top-left child of a scaled box lands off the canvas entirely: `scale(2)` and above
+  painted *nothing at all*. `filter-scaling-001` is `transform-origin: 0 0;
+  transform: scale(5)` and rendered white where half the viewport should be green —
+  and its own `rel=match` reference is the same markup minus the filter, so both sides
+  rendered blank and the test **passed its own reference at 100%** while scoring 50.1%
+  against Chromium's.
+- **Which is why the reftest suite is nearly blind to this**, and the fix measures
+  +4/−3 there. Both sides of a reftest are rendered by Broiler and a reference normally
+  declares the same origin as its test, so the error cancels. The three that moved the
+  other way are `transform3d-scale-002`/`-005`/`-006`, where the *reference* became
+  correct (a plain `scaleX(2) scaleY(2)` from the corner) while the test still needs a
+  3D transform Broiler does not implement — its `rotateX(90deg) scale3d(2,1,2)
+  rotateX(-90deg)` should conjugate to a Y scale of 2 and stays at 1. One side is now
+  right; both used to be wrong together.
+- **One grammar, three callers.** The reading was duplicated and inconsistent: the SVG
+  renderer's was thorough, the bridge's split on whitespace and took the components in
+  order, and the paint walker had none. `CssTransformOrigin` is now shared, and it fixes
+  three things the bridge got wrong — a lone `top`/`bottom` names the *vertical* axis;
+  the keyword pair may be written `top left`; and `top 100%` is invalid (a
+  length-percentage may not follow a vertical keyword) and is dropped whole rather than
+  half-read. The one thing that legitimately differs by caller is the **initial** value,
+  which is now a parameter: `50% 50%` for a CSS box, `0 0` for an SVG element, which has
+  no CSS layout box.
+- **Checks:** `Broiler.Layout.Tests.CssTransformOriginTests` (30 cases over the grammar,
+  main-repo and unconditional) and `src/Broiler.Wpt.Tests/TransformOriginPaintTests.cs`
+  (8 painted cases, which probe the pinned pointer and self-skip until the patch lands).
+- **Reach on CI:** the main-repo half ships now and is a measured no-op on the reftest
+  suite. The paint half reaches the privacy-test-page and real-world-render workflows
+  through `apply-pending-wpt-patches.sh`, and the WPT suite only once a maintainer lands
+  it upstream and bumps the pointer.
+
 ### A broken image drew a 2px frame, and reported it as part of its box
 
 - **Tests:** `css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003` —

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -451,6 +451,35 @@ other direction. None is a sizing bug.
 - **Exit gate:** the test matches, and `css/css-flexbox/aspect-ratio` does not move
   elsewhere.
 
+### A sticky box contributes its *stuck* position to the scroll container's overflow
+
+- **Tests:** `css-position/sticky/position-sticky-flex-item-001` … `-004`, all four at
+  99.0% against their own reference (a 100×80 red band showing where the reference
+  has none), against a 99% threshold.
+- **Owner:** `src/Broiler.HtmlBridge.Dom` (`DomBridge/LayoutMetrics.cs`,
+  `TryGetSharedScrollExtent`) with a `Broiler.HTML` half — see the exit gate.
+- **Root cause.** The scrollable overflow region is the union of the container's
+  padding box and its descendants' **border boxes**, read from the layout snapshot
+  *after* the sticky pass has moved them. CSS Positioned Layout 3 §6.3 says the
+  opposite: a sticky box contributes its **in-flow** position, and the test's own
+  `meta name="assert"` says so in as many words ("the sticky flex item reserves its
+  in-flow space in the scroll container's overflow area"). Reading the stuck position
+  is circular — the item is stuck *because* the scroll offset is 0, and the scroll
+  offset is 0 because `scrollTop = 1000` clamped against a `scrollHeight` the stuck
+  item made equal to `clientHeight`. Removing `position: sticky` from the same markup
+  scrolls correctly and paints no red, which isolates it.
+- **How -001/-003 got here.** They are the `column` half of the family and were green
+  until [column main-axis flexing](wpt-rendering-gaps-fixed.md) landed: `flex-basis`
+  was ignored in the block axis, so the red item was zero-tall and there was no red to
+  show. They now fail exactly as their `row` twins -002/-004 always have — the same
+  bug, no longer masked by a second one.
+- **Exit gate:** all four match. The obstacle is plumbing, not the rule: the shift is
+  computed in `Broiler.Layout` (`Engine/CssBox.Sticky.cs`, main repo) but reaches the
+  bridge through `BoxGeometry`, which `HtmlContainerInt.CollectLayoutGeometry`
+  populates inside `Broiler.HTML` — so carrying the pre-sticky position across needs a
+  submodule patch, and `wpt-tests.yml` does not run `apply-pending-wpt-patches.sh`.
+  Landing it upstream and bumping the pointer is the route.
+
 ### An inline-block's height ignores `line-height`
 
 - **The diagnosis stands; two fixes were measured and both reverted.** An

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -451,26 +451,15 @@ other direction. None is a sizing bug.
 - **Exit gate:** the test matches, and `css/css-flexbox/aspect-ratio` does not move
   elsewhere.
 
-### A size-contained `<img>`, `<svg>`, `<video>` or `<iframe>` still reports a size
+### A size-contained `<svg>`, `<video>` or `<iframe>` still reports a size
 
-The 64 assertions left in `css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003`
-(32 of 96 pass) after
-[size containment landed](wpt-rendering-gaps-fixed.md#contain-size-did-nothing-to-a-boxs-size-and-contain-intrinsic-size-was-not-parsed).
-Its `<div>` and `<canvas>` rows pass; the other four element types fail, and **neither
-cause is about containment**.
+The 54 assertions left in `css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003`
+(42 of 96 pass) after
+[size containment landed](wpt-rendering-gaps-fixed.md#contain-size-did-nothing-to-a-boxs-size-and-contain-intrinsic-size-was-not-parsed)
+and [the broken-image frame came off](wpt-rendering-gaps-fixed.md#a-broken-image-drew-a-2px-frame-and-reported-it-as-part-of-its-box).
+Its `<div>`, `<canvas>` and most of its `<img>` rows pass; the rest is **not about
+containment**.
 
-- **`<img>` is 4px too large in both axes, contained or not.** Every `<img>` in the
-  engine is: `<img style="width: 50px; height: 30px">` reports 54×34 from
-  `getBoundingClientRect`, `clientWidth`/`clientHeight` and `offsetWidth`/`offsetHeight`
-  alike, with no border and no padding, and independent of `font-size`, `word-spacing`,
-  `display` and whether the bitmap loaded. It is the box, not the paint — the green
-  draws at 50×30 inside it. Contained rows read `4` where they want `0` and `104` where
-  they want `100`, which is the same constant.
-  - **Owner:** unlocated. It is not `MeasureImageSize` (which sets the word to the
-    stated size), not `CssLineBox.UpdateRectangle`, and not the bridge's
-    `clientWidth`/`clientHeight`, all of which were ruled out by inspection.
-  - **Exit gate:** an `<img>` with a stated width and height reports exactly it. Worth
-    more than these 16 assertions — it is four pixels on every image on every page.
 - **`<svg>`, `<video>` and `<iframe>` report the 300×150 default object size.** Under
   size containment they have natural dimensions of *zero*, so the default must not
   apply. Broiler applies it in `Broiler.HTML`'s `DomParser` box fix-ups
@@ -481,6 +470,29 @@ cause is about containment**.
     `Broiler.HTML` patch to make the default object size conditional, and
     `wpt-tests.yml` does not run `apply-pending-wpt-patches.sh` — so landing it upstream
     and bumping the pointer is the route.
+
+### An inline element's three box-model rects are all the same rectangle
+
+- **Tests:** the six `<img>` assertions still failing in
+  `contain-intrinsic-size-logical-003`, and — more to the point — `clientWidth` and
+  `clientHeight` on **every** inline element that has a border or padding.
+  `<img style="width: 50px; height: 30px; border: 3px solid">` reports
+  `getBoundingClientRect` 56×36 (right) and `clientWidth`/`clientHeight` 56×36 (wrong:
+  the client box excludes the border, so 50×30). The same declarations on a `<div>` or
+  an `inline-block` report 50×30 correctly.
+- **Owner:** `Broiler.HTML` (`HtmlContainerInt.CollectLayoutGeometry`).
+- **Root cause.** A `display: inline` box lays out as one rectangle per line box rather
+  than a single border box, so `box.Location`/`box.Size` are unset and the collector
+  rebuilds the border box from the union of the line rectangles — then sets all three
+  levels of `BoxGeometry` to that same rectangle, on the stated grounds that "inline
+  boxes contribute no box-model padding/border to line geometry in this engine". That
+  premise does not hold for a **replaced** inline: `CssLineBox.UpdateRectangle` adds the
+  box's border and padding to an image's line rectangle explicitly, and
+  `MeasureImageSize` adds them in the block axis, so the union genuinely *is* the border
+  box and the other two levels have to be deflated out of it.
+- **Exit gate:** an inline `<img>` with a border reports a client box smaller than its
+  border box by exactly that border. Submodule-side, so the same routing as the entry
+  above.
 
 ### A sticky box contributes its *stuck* position to the scroll container's overflow
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -451,6 +451,37 @@ other direction. None is a sizing bug.
 - **Exit gate:** the test matches, and `css/css-flexbox/aspect-ratio` does not move
   elsewhere.
 
+### A size-contained `<img>`, `<svg>`, `<video>` or `<iframe>` still reports a size
+
+The 64 assertions left in `css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003`
+(32 of 96 pass) after
+[size containment landed](wpt-rendering-gaps-fixed.md#contain-size-did-nothing-to-a-boxs-size-and-contain-intrinsic-size-was-not-parsed).
+Its `<div>` and `<canvas>` rows pass; the other four element types fail, and **neither
+cause is about containment**.
+
+- **`<img>` is 4px too large in both axes, contained or not.** Every `<img>` in the
+  engine is: `<img style="width: 50px; height: 30px">` reports 54×34 from
+  `getBoundingClientRect`, `clientWidth`/`clientHeight` and `offsetWidth`/`offsetHeight`
+  alike, with no border and no padding, and independent of `font-size`, `word-spacing`,
+  `display` and whether the bitmap loaded. It is the box, not the paint — the green
+  draws at 50×30 inside it. Contained rows read `4` where they want `0` and `104` where
+  they want `100`, which is the same constant.
+  - **Owner:** unlocated. It is not `MeasureImageSize` (which sets the word to the
+    stated size), not `CssLineBox.UpdateRectangle`, and not the bridge's
+    `clientWidth`/`clientHeight`, all of which were ruled out by inspection.
+  - **Exit gate:** an `<img>` with a stated width and height reports exactly it. Worth
+    more than these 16 assertions — it is four pixels on every image on every page.
+- **`<svg>`, `<video>` and `<iframe>` report the 300×150 default object size.** Under
+  size containment they have natural dimensions of *zero*, so the default must not
+  apply. Broiler applies it in `Broiler.HTML`'s `DomParser` box fix-ups
+  (`CorrectIframeBoxes`, `CorrectVideoBoxes` and their neighbours), which write it as a
+  CSS width and height — so what the layout engine sees is an author-level size it is
+  right to honour, and there is no main-repo seam to decline it at.
+  - **Exit gate:** the three element types report zero under `contain: size`. Needs a
+    `Broiler.HTML` patch to make the default object size conditional, and
+    `wpt-tests.yml` does not run `apply-pending-wpt-patches.sh` — so landing it upstream
+    and bumping the pointer is the route.
+
 ### A sticky box contributes its *stuck* position to the scroll container's overflow
 
 - **Tests:** `css-position/sticky/position-sticky-flex-item-001` … `-004`, all four at

--- a/patches/0004-html-paint-transform-origin.patch
+++ b/patches/0004-html-paint-transform-origin.patch
@@ -1,0 +1,36 @@
+From d72d86097de11050439b78320be8528f0c47d28f Mon Sep 17 00:00:00 2001
+From: Claude <enrico.bartky@gmail.com>
+Date: Sat, 22 Aug 2026 13:27:14 +0000
+Subject: [PATCH] paint: apply a CSS transform about its transform-origin
+
+---
+ .../IR/PaintWalker.Stacking.cs                      | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
+index fb4ab6a..abd5f65 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
+@@ -160,8 +160,17 @@ internal static partial class PaintWalker
+             var matrix = ParseCssTransformMatrix(style.Transform, bounds);
+             if (matrix != null)
+             {
+-                float originX = bounds.X + bounds.Width * 0.5f;
+-                float originY = bounds.Y + bounds.Height * 0.5f;
++                // CSS Transforms 1 §8: the transform is applied about `transform-origin`, whose
++                // initial value is the box centre. The centre was used unconditionally here, so
++                // every declared origin was ignored and the painted position disagreed with the
++                // one the box's own script measured: `transform-origin: 0 0; transform: scale(0.5)`
++                // on a 100x100 box reports a rect at (0, 0) from getBoundingClientRect and painted
++                // it at (25, 25). The grammar lives in Broiler.Layout so the bridge's transform
++                // chain, the SVG renderer and this all read it the same way.
++                var origin = Layout.IR.CssTransformOrigin.Resolve(
++                    style.TransformOrigin, bounds, initialIsBoxCorner: false);
++                float originX = origin.X;
++                float originY = origin.Y;
+                 items.Add(new TransformItem
+                 {
+                     Bounds = bounds,
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -37,6 +37,7 @@ git -C <Submodule> log --oneline --grep '<subject>'
 | `0001-js-private-name-key-classification.patch` | `Broiler.JS` | Classify a private-name key by its marker and `#`, not the marker alone | A private name's property key is the U+0001 marker followed by the name, and the name always carries its leading `#` (`JSObject.MintPrivateName`, `FastCompiler.KeyOfPrivateName`). `KeyStrings.Classify` tested only the marker, so **every ordinary string key beginning with U+0001** was taken for a private name: writing one threw the brand-check `TypeError`, and reflection and enumeration hid it. WPT's `testharness.js` does exactly that while building its escape map — `formatEscapeMap[String.fromCharCode(p)]` with `p = 1` — so the harness threw *while loading* and **every testharness-based test in the suite reported no results at all**. With the patch applied the harness loads and the usual pass/fail table renders. |
 | `0002-html-outermost-svg-author-display.patch` | `Broiler.HTML` | Let an outermost `<svg>` keep the display the author cascaded | An outermost `<svg>` is a replaced element, so its `display` is *initially* `inline`; the box tree substitutes `inline-block` for that (how an inline replaced box is laid out here) but applied the substitution to the **cascaded** value too, discarding whatever the author wrote. `svg { display: block }` therefore laid out inline — siblings side by side instead of stacked, and `margin: 0 auto` computing to zero rather than centring (`css/compositing/line-with-svg-background` is ten block `<svg>`s and came out two to a row) — and `svg { display: none }` was overridden into a visible box, so the hidden `<svg>` a page uses to carry nothing but a `<filter>` or `<defs>` painted (`css/filter-effects/tainting-css-dropshadow-currentcolor`, 97.4 % → 100 %). The cascaded value is now read on the outermost `<svg>` only: a nested one is SVG content rather than a CSS box and arrives already carrying its ancestor's `display: none`. |
 | `0003-css-link-matches-xlink-href.patch` | `Broiler.CSS` | Match `:link` on an SVG `<a>` that links through `xlink:href` | SVG 1.1 §17.1 gives `<a>` its link through `xlink:href`, and SVG 2 §14.1 adds plain `href` without retiring it, so either attribute alone makes the element a link. `CssSelectorMatcher` tested `href` alone, so an `<a xlink:href="…">` matched no `a:link` rule and the whole rule was dropped — `a:link rect { fill: lime }` left the red rectangle beneath it showing. Pairs with the main-repo fix that fires `load` at an outermost inline `<svg>`: WPT `svg/linking/reftests/href-a-element-attr-change` removes `href` from its own load handler and asserts the element keeps its link status, so until that handler ran the test passed without reaching its assertion at all. |
+| `0004-html-paint-transform-origin.patch` | `Broiler.HTML` | paint: apply a CSS transform about its transform-origin | CSS Transforms 1 §8 applies an element's `transform` about its `transform-origin`, and `PaintWalker` used the box centre for every element without reading the property. So a declared origin did nothing, and paint disagreed with the element's own script: `transform-origin: 0 0; transform: scale(0.5)` on a 100×100 box reported a rect at (0, 0) from `getBoundingClientRect` and painted it at (25, 25). Scaling *up* is worse than a displacement — a centre origin throws a top-left child clean off the canvas — so `css/filter-effects/filter-scaling-001` (#1774 entry 28, 50.1 %) rendered a blank page where half the viewport should be green. The grammar is main-repo (`Broiler.Layout.IR.CssTransformOrigin`, shared with the bridge's transform chain and the SVG renderer, unit-tested in `CssTransformOriginTests`); this patch is the two lines that reach it. |
 
 None is bumped as a pointer, and the main repo builds and passes without any of
 them.
@@ -54,7 +55,18 @@ fixes are main-repo; those are pinned unconditionally by
 `svg/linking/reftests/href-a-element-attr-change` the rest of the way once they
 let its load handler run.
 
-All three are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
+`0004` is shaped the way CLAUDE.md asks a two-repo fix to be shaped: the whole of
+the `transform-origin` grammar is main-repo
+(`Broiler.Layout/IR/CssTransformOrigin.cs`, shared with the script bridge's
+transform chain and with the SVG renderer's `transform-box` handling, and
+unit-tested unconditionally by `Broiler.Layout.Tests.CssTransformOriginTests`), so
+the patch itself is the two lines in `PaintWalker` that call it.
+`src/Broiler.Wpt.Tests/TransformOriginPaintTests.cs` pins the painted result the
+way `0002`'s test does — it probes the pinned pointer and self-skips rather than
+going red. There is no main-repo fallback that can stand in for the paint half:
+the transform is emitted in `Broiler.HTML`'s own stacking walk.
+
+All four are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
 test-page and real-world render workflows run before their builds — so they
 reach those on top of the pinned pointer. The **WPT** workflows
 (`wpt-tests.yml`, `wpt-reftests.yml`) do not run that script today, so the WPT

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -334,10 +334,28 @@ set -euo pipefail
 # element keeps its link status, so before that handler ran the test passed without ever reaching
 # its own assertion. With the handler firing and this patch absent the test fails honestly; with
 # both it passes for the right reason.
+# 0004 (Broiler.HTML, "paint: apply a CSS transform about its transform-origin") IS listed, and it
+# decides *where on the canvas* a transformed element is drawn — which is as directly a pixel
+# question as anything here gets. The paint walker applied every CSS transform about the box centre
+# and never read the property, so a declared origin did nothing: `transform-origin: 0 0;
+# transform: scale(0.5)` on a 100x100 box painted at (25, 25) while the box's own script measured a
+# rect at (0, 0) — paint and the script bridge disagreeing about the same element. Scaling *up* is
+# worse than a displacement, because a centre origin throws a top-left child clean off the canvas:
+# css/filter-effects/filter-scaling-001 (#1774 entry 28, 50.1%) is `transform-origin: 0 0;
+# transform: scale(5)` and rendered a blank page where half the viewport should be green.
+#
+# The grammar it calls is main-repo (Broiler.Layout.IR.CssTransformOrigin, unit-tested in
+# CssTransformOriginTests and shared with the bridge's transform chain and the SVG renderer), so
+# this patch is the two lines that reach it. It is also the entry whose absence a pixel suite is
+# least able to show: both sides of a reftest are rendered by Broiler and a reference normally
+# declares the same origin as its test, so the error cancels there and only stops cancelling
+# against a reference browser's screenshot. 272 tests in the corpus declare `transform-origin`.
+
 PENDING_PATCHES=(
   "Broiler.JS|patches/0001-js-private-name-key-classification.patch"
   "Broiler.HTML|patches/0002-html-outermost-svg-author-display.patch"
   "Broiler.CSS|patches/0003-css-link-matches-xlink-href.patch"
+  "Broiler.HTML|patches/0004-html-paint-transform-origin.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/BrokenImageBorderTests.cs
+++ b/src/Broiler.Cli.Tests/BrokenImageBorderTests.cs
@@ -1,0 +1,117 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// An <c>&lt;img&gt;</c> whose content has not arrived must still be exactly the box its
+/// <c>width</c> and <c>height</c> say it is.
+///
+/// <para>
+/// A load that ended without an image gave the box a 2px inset border in <c>#A0A0A0</c>/
+/// <c>#E3E3E3</c> — the "broken image" frame a Netscape-era UA drew, inherited from HtmlRenderer.
+/// No UA draws one now; HTML's rendering rules give <c>&lt;img&gt;</c> no default border at all.
+/// The cost was not cosmetic: 2px on four sides is <b>4px in both axes</b> of border box, and the
+/// border box is what <c>getBoundingClientRect</c>, <c>clientWidth</c>/<c>clientHeight</c> and
+/// <c>offsetWidth</c>/<c>offsetHeight</c> all report. An
+/// <c>&lt;img style="width: 50px; height: 30px"&gt;</c> came back 54×34 with nothing declaring a
+/// border or padding anywhere.
+/// </para>
+///
+/// <para>
+/// And it reached far more than genuinely broken images. The geometry a script reads is captured
+/// before the images finish loading, so an image that loads perfectly well still reported the
+/// broken-image box — which is why every one of the sixteen <c>&lt;img&gt;</c> assertions in WPT
+/// <c>css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003</c> (entry 21 of issue
+/// #1774's top 30) read <c>4</c> where it wanted <c>0</c> and <c>104</c> where it wanted
+/// <c>100</c>. That test goes 32 → 42 of 96 with the frame gone.
+/// </para>
+/// </summary>
+public sealed class BrokenImageBorderTests
+{
+    /// <summary>The case the fix is about: a source that cannot load, sized by CSS.</summary>
+    [Fact(Timeout = 600000)]
+    public void AnUnloadableImage_IsExactlyItsDeclaredSize()
+    {
+        AssertCheckLayout(
+            "<img src=\"does-not-exist.png\" style=\"width:50px;height:30px\"" +
+            "     data-expected-client-width=\"50\" data-expected-client-height=\"30\">");
+    }
+
+    /// <summary>
+    /// The same through the presentational attributes rather than CSS, which is how most of the
+    /// corpus sizes an image.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ThePresentationalAttributes_SizeItExactlyToo()
+    {
+        AssertCheckLayout(
+            "<img src=\"does-not-exist.png\" width=\"70\" height=\"40\"" +
+            "     data-expected-client-width=\"70\" data-expected-client-height=\"40\">");
+    }
+
+    /// <summary>
+    /// An author's own border still applies, and is the only thing between the content box and the
+    /// border box: 50 + 2×3 = 56, not 60. Stated as the border box (<c>offsetWidth</c>) rather than
+    /// the client box, because <c>clientWidth</c> on an inline element is a separate gap — an
+    /// inline box's geometry is reconstructed from its line rectangles with all three box-model
+    /// levels collapsed onto one, so it reports 56 there too. That is
+    /// <c>Broiler.HTML</c>'s <c>CollectLayoutGeometry</c>, not this.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AnAuthorBorder_IsStillTheOnlyBorder()
+    {
+        AssertCheckLayout(
+            "<img src=\"does-not-exist.png\" style=\"width:50px;height:30px;border:3px solid black\"" +
+            "     data-expected-width=\"56\" data-expected-height=\"36\">");
+    }
+
+    /// <summary>
+    /// Padding too — the axis arithmetic has to keep working, not merely come out right when
+    /// everything is zero.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void PaddingIsAddedOnceAndOnlyOnce()
+    {
+        AssertCheckLayout(
+            "<img src=\"does-not-exist.png\" style=\"width:50px;height:30px;padding:5px\"" +
+            "     data-expected-client-width=\"60\" data-expected-client-height=\"40\">");
+    }
+
+    /// <summary>
+    /// The frame also displaced everything after the image on the line. A sized image followed by
+    /// a box lands that box at exactly the image's width, not four pixels past it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AFollowingBox_IsNotPushedAlongByAFrame()
+    {
+        AssertCheckLayout(
+            "<div style=\"width:300px;font-size:0\">" +
+            "<img src=\"does-not-exist.png\" style=\"width:50px;height:30px\">" +
+            "<span style=\"display:inline-block;width:10px;height:10px\"" +
+            "      data-offset-x=\"50\"></span>" +
+            "</div>");
+    }
+
+    private static void AssertCheckLayout(string body)
+    {
+        const string head =
+            "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head>" +
+            "<body>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, head + body + "</body></html>", "file:///broken-image.html");
+
+        var assertions = bridge.EvaluateCheckLayoutAssertions();
+        var failures = assertions
+            .Where(a => double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > 0.5)
+            .Select(a => $"{a.Element} {a.Property}: expected {a.Expected}, got {a.Actual:0.##}")
+            .ToList();
+
+        Assert.True(assertions.Count > 0, "no check-layout assertions were evaluated");
+        Assert.True(failures.Count == 0,
+            $"{failures.Count}/{assertions.Count} assertions failed:\n" + string.Join("\n", failures));
+    }
+}

--- a/src/Broiler.Cli.Tests/FlexColumnWrapAndReverseTests.cs
+++ b/src/Broiler.Cli.Tests/FlexColumnWrapAndReverseTests.cs
@@ -171,12 +171,20 @@ public sealed class FlexColumnWrapAndReverseTests
     }
 
     [Fact(Timeout = 600000)]
-    public void A_Nowrap_Column_Container_Overflows_Rather_Than_Wrapping()
+    public void A_Nowrap_Column_Container_Keeps_Everything_On_One_Line()
     {
+        // What this pins is the line breaking: `nowrap` produces one line whatever it holds, so
+        // both items stay in the same column at x=0 rather than the second starting a new one.
+        //
+        // Their *heights* are §9.7's business, and this case was written before the column main
+        // axis shrank: two 40px items overflowed a 50px container by 30 and were left overflowing.
+        // `flex-shrink` is 1 by default and neither item has content to floor it at, so they now
+        // give up 15 each and come out 25 tall, stacked at 0 and 25 — which is what the reference
+        // browser lays this out as, and what FlexColumnMainAxisSizingTests states as a rule.
         AssertCheckLayout(
             "<div style=\"display:flex;flex-direction:column;height:50px;width:200px\">" +
-            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
-            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"40\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"25\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"25\" data-expected-height=\"25\"></div>" +
             "</div>");
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Transform.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Transform.cs
@@ -94,29 +94,27 @@ public sealed partial class DomBridge
         return (left + offsetX, top + offsetY);
     }
 
+    /// <summary>
+    /// CSS Transforms 1 §8: the transform origin, as an offset from the box's own top-left corner.
+    /// </summary>
+    /// <remarks>
+    /// Defers to <see cref="Layout.IR.CssTransformOrigin"/>, the grammar shared with the SVG
+    /// renderer and the paint walker. Reading it here on its own got three things wrong that only
+    /// the shared reading has ever handled: a lone <c>top</c> or <c>bottom</c> names the
+    /// <em>vertical</em> axis and centres the other, so taking the first component as x put it on
+    /// the wrong one; the keyword pair may be written <c>top left</c>, which has to be swapped back;
+    /// and an invalid declaration such as <c>top 100%</c> — a length-percentage may not follow a
+    /// vertical keyword — is dropped whole rather than half-read.
+    /// </remarks>
     private static (double X, double Y) ParseTransformOrigin(string? origin, double width, double height)
     {
-        // Default is the box centre.
-        if (string.IsNullOrWhiteSpace(origin))
-            return (width / 2, height / 2);
+        var point = Layout.IR.CssTransformOrigin.Resolve(
+            origin,
+            new System.Drawing.RectangleF(0, 0, (float)width, (float)height),
+            initialIsBoxCorner: false);
 
-        var parts = origin.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
-        var x = ResolveOriginComponent(parts.Length > 0 ? parts[0] : "50%", width, horizontal: true);
-        var y = ResolveOriginComponent(parts.Length > 1 ? parts[1] : "50%", height, horizontal: false);
-        return (x, y);
+        return (point.X, point.Y);
     }
-
-    private static double ResolveOriginComponent(string value, double extent, bool horizontal) =>
-        value.ToLowerInvariant() switch
-        {
-            "left" or "top" => 0,
-            "right" or "bottom" => extent,
-            "center" => extent / 2,
-            _ when value.EndsWith("%", StringComparison.Ordinal) &&
-                   double.TryParse(value[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out var pct)
-                => extent * pct / 100.0,
-            _ => ParsePixels(value) ?? extent / 2,
-        };
 
     /// <summary>Composes a CSS <c>transform</c> function list into a single affine matrix. Functions
     /// apply left-to-right as outermost-to-innermost (CSS Transforms §1), so the list is folded in

--- a/src/Broiler.Wpt.Tests/FlexColumnMainAxisSizingTests.cs
+++ b/src/Broiler.Wpt.Tests/FlexColumnMainAxisSizingTests.cs
@@ -1,0 +1,352 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS Flexbox §9.2, §9.4 and §9.7 along a <c>column</c> container's main (block) axis — the
+/// block-axis twin of <see cref="FlexAutomaticMinimumSizeTests"/> — and CSS2.1 §10.6.4's
+/// contribution to it: what makes a column container's main size <em>definite</em> in the first
+/// place.
+///
+/// <para>
+/// A column container's items stack through ordinary block flow here, and the pass that resizes
+/// that stack afterwards implemented only half of §9.7. <c>flex-basis</c> was never read in the
+/// block axis — block flow has no notion of it — so an item whose only stated size was a
+/// <c>flex-basis</c> came out at the height of its own content. And nothing shrank at all, on the
+/// stated grounds that §4.5's automatic minimum size did not exist in this axis to floor a shrink
+/// with; since <c>flex-shrink</c> defaults to <c>1</c>, that is every column flex item on the web
+/// asking to shrink and not shrinking.
+/// </para>
+///
+/// <para>
+/// Both are gated on the container having a definite main size, which was read from its
+/// <c>height</c> declaration alone. An out-of-flow box with <c>height: auto</c> and both
+/// <c>top</c> and <c>bottom</c> set has no such declaration and a perfectly definite used height —
+/// §10.6.4 solves for it — and <c>position: absolute; inset: 0</c> is how a full-viewport app
+/// shell is written, so the most common definite column container there is was treated as
+/// content-sized. That is the shape of WPT <c>css-flexbox/percentage-heights-002</c> (issue #1774,
+/// 40.9%), which rendered the red backdrop it says you should not see.
+/// </para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class FlexColumnMainAxisSizingTests
+{
+    private const int Width = 200;
+    private const int Height = 400;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-flexcol-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Width, Height).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    private static bool IsBlue(BBitmap bmp, int x, int y)
+    {
+        var p = bmp.GetPixel(x, y);
+        return p.R < 80 && p.G < 80 && p.B > 180;
+    }
+
+    private static bool IsGreen(BBitmap bmp, int x, int y)
+    {
+        var p = bmp.GetPixel(x, y);
+        return p.R < 80 && p.G > 100 && p.B < 80;
+    }
+
+    /// <summary>
+    /// The height of the band of <paramref name="matches"/> pixels down column
+    /// <paramref name="x"/> — the item's used border-box height, measured off the canvas rather
+    /// than read from the box tree.
+    /// </summary>
+    /// <remarks>
+    /// First and last matching row rather than the length of an unbroken run: a band carrying
+    /// content has other pixels sitting on it. Measuring the band's <em>height</em> rather than
+    /// its bottom edge matters as soon as it does not start at the top of the canvas, which is
+    /// every inset-positioned case below.
+    /// </remarks>
+    private static int Extent(BBitmap bmp, Func<BBitmap, int, int, bool> matches, int x = 2)
+    {
+        int first = -1, last = -1;
+
+        for (int y = 0; y < Height; y++)
+        {
+            if (!matches(bmp, x, y))
+                continue;
+
+            if (first < 0)
+                first = y;
+
+            last = y;
+        }
+
+        return first < 0 ? 0 : last - first + 1;
+    }
+
+    private static int BlueExtent(BBitmap bmp) => Extent(bmp, IsBlue);
+
+    /// <summary>
+    /// A 100px-tall column flex container holding one blue item, whose style is the case under
+    /// test. The item is 10px wide so nothing else can be confused with it on the column sampled.
+    /// </summary>
+    private static string Column(string itemStyle, string itemContent = "") =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + "<div style=\"display:flex; flex-direction:column; width:30px; height:100px\">"
+        + $"<div style=\"width:10px; background:blue; {itemStyle}\">{itemContent}</div>"
+        + "</div></body></html>";
+
+    /// <summary>
+    /// The same, but only 30px tall and holding 60px of content — so §9.7's target for the item
+    /// falls <em>below</em> its content size and §4.5's floor is what decides the answer.
+    /// </summary>
+    private static string ShortColumn(string itemStyle) =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + "<div style=\"display:flex; flex-direction:column; width:30px; height:30px\">"
+        + $"<div style=\"width:10px; background:blue; {itemStyle}\">"
+        + "<div style=\"width:10px; height:60px\"></div></div>"
+        + "</div></body></html>";
+
+    // ---- §9.2 step 3: flex-basis names the item's block size in a column ----
+
+    /// <summary>
+    /// The base case: <c>flex-basis</c> is the item's flex base size in a column container, and
+    /// block flow — which produced the stack this pass resizes — knows nothing about it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void FlexBasis_SizesAColumnItemThatDeclaresNoHeight()
+    {
+        Assert.Equal(60, BlueExtent(Render(Column("flex:0 0 60px"))));
+    }
+
+    /// <summary>
+    /// A percentage <c>flex-basis</c> resolves against the container's main size — the axis the
+    /// container is a column along, not its inline size.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void APercentageFlexBasis_ResolvesAgainstTheContainersMainSize()
+    {
+        Assert.Equal(40, BlueExtent(Render(Column("flex:0 0 40%"))));
+    }
+
+    /// <summary>An item's own <c>height</c> is its base size when <c>flex-basis</c> is auto.</summary>
+    [Fact(Timeout = 600000)]
+    public void AnItemThatFits_IsUntouched()
+    {
+        Assert.Equal(40, BlueExtent(Render(Column("height:40px"))));
+    }
+
+    // ---- §9.7: shrinking, the half that was left out ----
+
+    /// <summary>
+    /// The case the shrink half is about: an item taller than its container, everything else
+    /// initial. <c>flex-shrink</c> is <c>1</c> by default, so it must come down to the container's
+    /// 100px rather than overflow it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AnItemTallerThanItsContainer_ShrinksToFit()
+    {
+        Assert.Equal(100, BlueExtent(Render(Column("height:300px"))));
+    }
+
+    /// <summary><c>flex-shrink: 0</c> opts out, so the item keeps its height and overflows.</summary>
+    [Fact(Timeout = 600000)]
+    public void FlexShrinkZero_KeepsTheSpecifiedHeight()
+    {
+        Assert.Equal(300, BlueExtent(Render(Column("flex-shrink:0; height:300px"))));
+    }
+
+    /// <summary>
+    /// §9.7 step 2 scales each shrink factor by the item's base size, so a large item gives up
+    /// proportionally more than a small one with the same <c>flex-shrink</c>. 120 and 60 in a
+    /// 100px container overflow by 80, and the scaled shares are 120/180 and 60/180 of it: they
+    /// land at 66⅔ and 33⅓, which together fill the container exactly.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ShrinkingIsScaledByTheBaseSize()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; flex-direction:column; width:30px; height:100px\">"
+            + "<div style=\"width:10px; height:120px; background:blue\"></div>"
+            + "<div style=\"width:10px; height:60px; background:green\"></div>"
+            + "</div></body></html>");
+
+        Assert.InRange(BlueExtent(bmp), 66, 67);
+        Assert.InRange(Extent(bmp, IsGreen), 33, 34);
+    }
+
+    // ---- §4.5: the automatic minimum size, which is what makes shrinking safe ----
+
+    /// <summary>
+    /// An undeclared <c>min-height</c> is <c>auto</c> on a flex item, and floors it at its own
+    /// content. Without this floor a container smaller than its content squashes everything in it
+    /// towards nothing, which is why turning shrinking on needed it first.
+    /// </summary>
+    /// <remarks>
+    /// The container is 30px here, below the 60px the item's content measures — the floor only
+    /// says anything once §9.7's target falls under it, and against the 100px container the other
+    /// cases use it never does.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void AnItem_DoesNotShrinkBelowItsContent()
+    {
+        Assert.Equal(60, BlueExtent(Render(ShortColumn("height:300px"))));
+    }
+
+    /// <summary>
+    /// <c>min-height: 0</c> is the idiom for opting out of that floor, and has to be told apart
+    /// from an undeclared minimum — which shares its computed value, since <c>min-height</c> is
+    /// <c>0</c> by default.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AnExplicitZeroMinHeight_OptsOutOfTheAutomaticMinimum()
+    {
+        Assert.Equal(30, BlueExtent(Render(ShortColumn("min-height:0; height:300px"))));
+    }
+
+    /// <summary>
+    /// §4.5 gives no automatic minimum to an item that scrolls its own overflow.
+    /// <c>flex: 1; overflow: auto</c> is the scrolling pane of most column layouts on the web, and
+    /// flooring it at its content is what makes such a pane push its container open rather than
+    /// scroll.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AScrollContainer_HasNoAutomaticMinimum()
+    {
+        Assert.Equal(30, BlueExtent(Render(ShortColumn("overflow:auto; height:300px"))));
+    }
+
+    /// <summary>
+    /// An explicit <c>min-height</c> larger than the container still floors the shrink — the
+    /// automatic branch is not the only one.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AnExplicitMinHeight_FloorsTheShrink()
+    {
+        Assert.Equal(150, BlueExtent(Render(Column("min-height:150px; height:300px"))));
+    }
+
+    /// <summary>
+    /// §9.7 step 4 clamps every item's target, not only a shrunk one: an item that takes no share
+    /// of the free space still has a maximum. WPT <c>flex-item-max-height-min-content</c> is this
+    /// shape — a <c>flex-basis: 200px</c> item capped at the 60px its content measures.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void MaxHeightMinContent_CapsALargerFlexBasis()
+    {
+        Assert.Equal(60, BlueExtent(Render(
+            Column("max-height:min-content; flex:0 0 200px",
+                   "<div style=\"width:10px; height:60px\"></div>"))));
+    }
+
+    /// <summary>
+    /// The mirror of the case above, and what WPT <c>flex-minimum-height-flex-items-011</c> pins:
+    /// a <c>flex-basis: 0</c> item in a container far smaller than its content is floored at that
+    /// content, in a direction §9.7 never distributes into.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AZeroFlexBasis_IsFlooredAtTheItemsContent()
+    {
+        Assert.Equal(100, BlueExtent(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; flex-direction:column; width:30px; height:10px\">"
+            + "<div style=\"width:10px; flex-basis:0; background:blue\">"
+            + "<div style=\"width:10px; height:100px\"></div></div>"
+            + "</div></body></html>")));
+    }
+
+    // ---- CSS2.1 §10.6.4: an inset pair is a definite main size ----
+
+    /// <summary>
+    /// A <c>position: absolute</c> container with <c>height: auto</c> and both <c>top</c> and
+    /// <c>bottom</c> set: §10.6.4 solves its used height, so its items flex against that. This is
+    /// <c>percentage-heights-002</c> in miniature — the item's <c>flex-basis: 100%</c> and the
+    /// 20%-tall band above it add up to more than the container, and both shrink into it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AnInsetSizedAbsposContainer_HasADefiniteMainSize()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0; position:relative; width:200px; height:300px\">"
+            + "<div style=\"position:absolute; top:0; bottom:0; left:0; right:0;"
+            + " display:flex; flex-direction:column\">"
+            + "<div style=\"height:20%; background:green\"></div>"
+            + "<div style=\"flex-basis:100%; background:blue\"></div>"
+            + "</div></body></html>");
+
+        // 20% and 100% of 300 is 60 + 300 = 360, overflowing by 60; the scaled shrink shares are
+        // 10 and 50, so the bands are 50 and 250 and together fill the container exactly.
+        Assert.Equal(50, Extent(bmp, IsGreen));
+        Assert.Equal(250, BlueExtent(bmp));
+    }
+
+    /// <summary>
+    /// The same definiteness, seen through §10.5 instead: a percentage <c>height</c> inside an
+    /// inset-sized box resolves against the height its insets solved for rather than falling back
+    /// to <c>auto</c>.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void APercentageHeight_ResolvesAgainstAnInsetSizedContainingBlock()
+    {
+        Assert.Equal(75, BlueExtent(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0; position:relative; width:200px; height:400px\">"
+            + "<div style=\"position:absolute; top:50px; bottom:50px; left:0; right:0\">"
+            + "<div style=\"width:10px; height:25%; background:blue\"></div>"
+            + "</div></body></html>")));
+    }
+
+    /// <summary>
+    /// The insets have to actually solve for something: one of them left <c>auto</c> leaves the
+    /// block size content-derived, and a percentage inside it goes back to <c>auto</c> (§10.5).
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void OneInsetAlone_LeavesTheBlockSizeIndefinite()
+    {
+        Assert.Equal(0, BlueExtent(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0; position:relative; width:200px; height:400px\">"
+            + "<div style=\"position:absolute; top:50px; left:0; right:0\">"
+            + "<div style=\"width:10px; height:25%; background:blue\"></div>"
+            + "</div></body></html>")));
+    }
+
+    /// <summary>§10.7 clamps the §10.6.4 solution, and the clamped value is the definite one.</summary>
+    [Fact(Timeout = 600000)]
+    public void AMaxHeight_ClampsTheInsetDerivedBlockSize()
+    {
+        Assert.Equal(50, BlueExtent(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0; position:relative; width:200px; height:400px\">"
+            + "<div style=\"position:absolute; top:0; bottom:0; left:0; right:0; max-height:100px\">"
+            + "<div style=\"width:10px; height:50%; background:blue\"></div>"
+            + "</div></body></html>")));
+    }
+
+    // ---- a vertical writing mode crosses the axes this pass reads ----
+
+    /// <summary>
+    /// <c>column</c> names the <em>block</em> axis, so under <c>vertical-lr</c> the main axis is
+    /// horizontal and every number this pass takes from the height belongs to the cross axis.
+    /// Growing on the wrong axis was merely inert; shrinking on it is not, and WPT
+    /// <c>flexbox-column-row-gap-002</c>'s <c>vertical-lr</c> container squashed all six of its
+    /// items to fit a main size that is not its main size. Such a container is left to block flow.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AVerticalWritingModeContainer_IsLeftToBlockFlow()
+    {
+        Assert.Equal(300, BlueExtent(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; flex-direction:column; writing-mode:vertical-lr;"
+            + " width:30px; height:100px\">"
+            + "<div style=\"width:10px; height:300px; background:blue\"></div>"
+            + "</div></body></html>")));
+    }
+}

--- a/src/Broiler.Wpt.Tests/SizeContainmentTests.cs
+++ b/src/Broiler.Wpt.Tests/SizeContainmentTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS Containment 2 §3.2 (<b>size containment</b>) and CSS Sizing 4 §5
+/// (<c>contain-intrinsic-size</c>): a box whose size is contained is laid out as though it had no
+/// contents, and <c>contain-intrinsic-size</c> is how an author states a stand-in for the size those
+/// contents would have given it.
+///
+/// <para>
+/// Broiler parsed <c>contain</c> and acted on two of the things it says — background propagation
+/// reads it, and fragmentation treats a contained box as monolithic — but nothing acted on what it
+/// says about <em>size</em>, and the <c>contain-intrinsic-*</c> properties were not parsed at all.
+/// Every one of the 96 assertions in WPT
+/// <c>css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003</c> (entry 21 of issue
+/// #1774's top 30) therefore measured the contents the containment exists to hide.
+/// </para>
+///
+/// <para>
+/// The subtle half is the aspect ratio, and it is why several of these cases are about
+/// <c>&lt;canvas&gt;</c> and <c>&lt;svg&gt;</c> rather than about <c>&lt;div&gt;</c>. Containment
+/// removes an element's <b>natural</b> ratio and leaves a <b>declared</b> one alone, and the two
+/// arrive at the engine looking alike: an <c>&lt;svg&gt;</c>'s <c>viewBox</c> ratio is natural and
+/// goes, while the UA stylesheet's <c>aspect-ratio: attr(width) / attr(height)</c> (HTML §14.4) is a
+/// declaration and stays. WPT <c>contain-size-replaced-002</c> and <c>canvas-contain-size</c> pull
+/// in exactly opposite directions on that point.
+/// </para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class SizeContainmentTests
+{
+    private const int Width = 400;
+    private const int Height = 400;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-contain-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Width, Height).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    private static bool IsGreen(BBitmap bmp, int x, int y)
+    {
+        var p = bmp.GetPixel(x, y);
+        return p.R < 80 && p.G > 100 && p.B < 80;
+    }
+
+    /// <summary>
+    /// The bounding box of every green pixel on the canvas, as (width, height) — zero for a page
+    /// with no green on it at all.
+    /// </summary>
+    /// <remarks>
+    /// The whole canvas rather than one row and one column: each page here paints exactly one green
+    /// box, but not always at the origin — an inline box sits on a text baseline, and a padded one
+    /// starts inside its own padding — so a fixed sampling line misses it and reads zero, which is
+    /// indistinguishable from the collapse several of these cases are testing for.
+    /// </remarks>
+    private static (int Width, int Height) GreenBounds(BBitmap bmp)
+    {
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+
+        for (int y = 0; y < Height; y++)
+        {
+            for (int x = 0; x < Width; x++)
+            {
+                if (!IsGreen(bmp, x, y))
+                    continue;
+
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+            }
+        }
+
+        return maxX < 0 ? (0, 0) : (maxX - minX + 1, maxY - minY + 1);
+    }
+
+    private static int GreenWidth(BBitmap bmp) => GreenBounds(bmp).Width;
+
+    private static int GreenHeight(BBitmap bmp) => GreenBounds(bmp).Height;
+
+    /// <summary>
+    /// A green box whose style is the case under test, holding a 40×20 block. Without containment
+    /// it is 40×20; with it, whatever the containment says instead.
+    /// </summary>
+    private static string Box(string style) =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + $"<div style=\"display:inline-block; background:green; {style}\">"
+        + "<div style=\"width:40px; height:20px\"></div></div>"
+        + "</body></html>";
+
+    // ---- §3.2: the contents stop counting ----
+
+    /// <summary>Without containment the box is its contents — the control for everything below.</summary>
+    [Fact(Timeout = 600000)]
+    public void WithoutContainment_TheBoxIsItsContents()
+    {
+        var bmp = Render(Box(""));
+        Assert.Equal(40, GreenWidth(bmp));
+        Assert.Equal(20, GreenHeight(bmp));
+    }
+
+    /// <summary>
+    /// <c>contain: size</c> with no <c>contain-intrinsic-size</c> is zero in both axes: the contents
+    /// still lay out and still paint, they simply overflow a box that no longer measures them.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ContainSize_CollapsesTheBoxInBothAxes()
+    {
+        var bmp = Render(Box("contain:size"));
+        Assert.Equal(0, GreenWidth(bmp));
+        Assert.Equal(0, GreenHeight(bmp));
+    }
+
+    /// <summary><c>contain: strict</c> includes size containment; <c>contain: content</c> does not.</summary>
+    [Theory]
+    [InlineData("strict", 0)]
+    [InlineData("size layout paint", 0)]
+    [InlineData("content", 40)]
+    [InlineData("layout paint style", 40)]
+    [InlineData("none", 40)]
+    public void OnlySizeAndStrict_ContainTheSize(string contain, int expectedWidth)
+    {
+        Assert.Equal(expectedWidth, GreenWidth(Render(Box($"contain:{contain}"))));
+    }
+
+    // ---- CSS Sizing 4 §5: contain-intrinsic-size stands in for the contents ----
+
+    [Fact(Timeout = 600000)]
+    public void ContainIntrinsicSize_StandsInForTheContents()
+    {
+        var bmp = Render(Box("contain:size; contain-intrinsic-size:100px 50px"));
+        Assert.Equal(100, GreenWidth(bmp));
+        Assert.Equal(50, GreenHeight(bmp));
+    }
+
+    /// <summary>One component sets both axes.</summary>
+    [Fact(Timeout = 600000)]
+    public void ASingleComponent_SetsBothAxes()
+    {
+        var bmp = Render(Box("contain:size; contain-intrinsic-size:70px"));
+        Assert.Equal(70, GreenWidth(bmp));
+        Assert.Equal(70, GreenHeight(bmp));
+    }
+
+    /// <summary>
+    /// The grammar is <c>auto? [ none | &lt;length&gt; ]</c> per component, so the value cannot be
+    /// split on whitespace: <c>auto 100px</c> is <em>one</em> component naming both axes, and
+    /// <c>auto 100px auto 50px</c> is two. The <c>auto</c> keyword asks for the last remembered size
+    /// and falls back to the length, which is what a render that never skipped the element sees.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void TheAutoKeyword_BindsForwardToItsLength()
+    {
+        var one = Render(Box("contain:size; contain-intrinsic-size:auto 100px"));
+        Assert.Equal(100, GreenWidth(one));
+        Assert.Equal(100, GreenHeight(one));
+
+        var two = Render(Box("contain:size; contain-intrinsic-size:auto 100px auto 50px"));
+        Assert.Equal(100, GreenWidth(two));
+        Assert.Equal(50, GreenHeight(two));
+    }
+
+    /// <summary>
+    /// <c>none</c> is the initial value and means "no stand-in", not "no containment": the axis
+    /// keeps the zero an empty box has. The author width here is only so the box has something to
+    /// paint with — with both axes at zero there is nothing on the canvas to measure, which is what
+    /// <see cref="ContainSize_CollapsesTheBoxInBothAxes"/> covers instead.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void NoneLeavesTheAxisAtZero()
+    {
+        var blockOnly = Render(Box("contain:size; contain-intrinsic-size:none 50px; width:60px"));
+        Assert.Equal(60, GreenWidth(blockOnly));
+        Assert.Equal(50, GreenHeight(blockOnly));
+
+        var inlineOnly = Render(Box("contain:size; contain-intrinsic-size:60px none; height:35px"));
+        Assert.Equal(60, GreenWidth(inlineOnly));
+        Assert.Equal(35, GreenHeight(inlineOnly));
+    }
+
+    /// <summary>The physical longhands, set on their own rather than through the shorthand.</summary>
+    [Fact(Timeout = 600000)]
+    public void ThePhysicalLonghands_SetOneAxisEach()
+    {
+        var bmp = Render(Box("contain:size; contain-intrinsic-width:80px; contain-intrinsic-height:30px"));
+        Assert.Equal(80, GreenWidth(bmp));
+        Assert.Equal(30, GreenHeight(bmp));
+    }
+
+    /// <summary>
+    /// The flow-relative longhands in a horizontal writing mode, where inline is the width.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void TheLogicalLonghands_MapToTheWritingModesAxes()
+    {
+        var bmp = Render(Box("contain:size; contain-intrinsic-inline-size:80px; contain-intrinsic-block-size:30px"));
+        Assert.Equal(80, GreenWidth(bmp));
+        Assert.Equal(30, GreenHeight(bmp));
+    }
+
+    /// <summary>
+    /// And in a vertical one, where they swap: the inline axis runs down the page, so
+    /// <c>contain-intrinsic-inline-size</c> is the <em>height</em>. Eight of
+    /// <c>contain-intrinsic-size-logical-003</c>'s cases are this, and mapping the value the way
+    /// <c>min-width</c> is mapped got them transposed — the vertical-flow prototype lays such a box
+    /// out in a logical frame and rotates it afterwards, so the value has to arrive in frame terms.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void InAVerticalWritingMode_TheLogicalLonghandsSwapAxes()
+    {
+        var bmp = Render(Box(
+            "writing-mode:vertical-lr; contain:size;"
+            + " contain-intrinsic-inline-size:80px; contain-intrinsic-block-size:30px"));
+
+        Assert.Equal(30, GreenWidth(bmp));
+        Assert.Equal(80, GreenHeight(bmp));
+    }
+
+    /// <summary>An author's own <c>width</c>/<c>height</c> is the box's own size and still wins.</summary>
+    [Fact(Timeout = 600000)]
+    public void AnAuthorSize_WinsOverTheContainedIntrinsicSize()
+    {
+        var bmp = Render(Box("contain:size; contain-intrinsic-size:100px 50px; width:25px; height:75px"));
+        Assert.Equal(25, GreenWidth(bmp));
+        Assert.Equal(75, GreenHeight(bmp));
+    }
+
+    // ---- §3.2: which boxes it applies to ----
+
+    /// <summary>
+    /// Size containment has no effect on a non-atomic inline box: its size is the line's to decide,
+    /// not its own, so zeroing it would remove a size the box never owned.
+    /// </summary>
+    /// <remarks>
+    /// Measured through the block the inline sits in rather than off the inline itself: what would
+    /// go wrong is the inline reporting a zero intrinsic width, and the shrink-to-fit block around
+    /// it collapsing with it. So the green is on the block, and 40px of it says the span's contents
+    /// still counted.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void ANonAtomicInline_IsUnaffected()
+    {
+        Assert.Equal(40, GreenWidth(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:inline-block; background:green\">"
+            + "<span style=\"display:inline; contain:size\">"
+            + "<span style=\"display:inline-block; width:40px; height:20px\"></span></span>"
+            + "</div></body></html>")));
+    }
+
+    /// <summary>
+    /// A <em>replaced</em> element is the exception that costs the most to get wrong: its computed
+    /// <c>display</c> is <c>inline</c> — that is the UA value for <c>&lt;img&gt;</c> and
+    /// <c>&lt;svg&gt;</c> — but the box it generates is atomic, so containment does apply. Testing
+    /// the keyword alone declined containment on precisely the elements
+    /// <c>css-contain/contain-size-replaced-*</c> is written about.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AReplacedInlineElement_IsContained()
+    {
+        // Without containment the viewBox ratio makes this 100x100; with it, 100x0 plus the padding.
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"100\" viewBox=\"0 0 50 50\" style=\"background:green; padding:20px 0; contain:size\">"
+            + "<rect fill=\"red\" width=\"50\" height=\"50\"/></svg>"
+            + "</body></html>");
+
+        Assert.Equal(40, GreenHeight(bmp));
+    }
+
+    // ---- the ratio: natural goes, declared stays ----
+
+    /// <summary>
+    /// HTML §14.4: the <c>width</c>/<c>height</c> content attributes map to
+    /// <c>aspect-ratio: attr(width) / attr(height)</c>, a UA stylesheet <em>declaration</em>, so a
+    /// contained element keeps it and a definite inline size still settles the block axis. WPT
+    /// <c>css-flexbox/canvas-contain-size</c> and <c>contain-size-replaced-007</c> both assert this
+    /// in as many words.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void APresentationalAttributeRatio_SurvivesContainment()
+    {
+        Assert.Equal(100, GreenHeight(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<canvas width=20 height=20 style=\"contain:size; background:green; width:100px\"></canvas>"
+            + "</body></html>")));
+    }
+
+    /// <summary>
+    /// SVG 2 §8.2: a <c>viewBox</c> states the element's <em>natural</em> ratio, which containment
+    /// removes — the mirror image of the case above, and the reason the two cannot share one rule.
+    /// Broiler records the viewBox ratio into <c>aspect-ratio</c> during style resolution, so by
+    /// layout time a natural ratio and a declared one look alike; comparing the recorded value back
+    /// against the viewBox is what tells them apart.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void AViewBoxRatio_DoesNotSurviveContainment()
+    {
+        Assert.Equal(0, GreenHeight(Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"100\" viewBox=\"0 0 50 50\" style=\"background:green; contain:size\"></svg>"
+            + "</body></html>")));
+    }
+
+    /// <summary>An author's own <c>aspect-ratio</c> is a declaration too, and survives.</summary>
+    [Fact(Timeout = 600000)]
+    public void AnAuthorAspectRatio_SurvivesContainment()
+    {
+        Assert.Equal(50, GreenHeight(Render(Box(
+            "contain:size; aspect-ratio:2/1; width:100px; background:green"))));
+    }
+}

--- a/src/Broiler.Wpt.Tests/TransformOriginPaintTests.cs
+++ b/src/Broiler.Wpt.Tests/TransformOriginPaintTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS Transforms 1 §8: an element's <c>transform</c> is applied about its <c>transform-origin</c>,
+/// and the painted result has to agree with the geometry the element's own script measures.
+///
+/// <para>
+/// It did not. The paint walker applied every CSS transform about the box centre and never read the
+/// property, while the script bridge's transform chain read it correctly — so
+/// <c>transform-origin: 0 0; transform: scale(0.5)</c> on a 100×100 box reported a rect at (0, 0)
+/// from <c>getBoundingClientRect</c> and painted it at (25, 25). Scaling <em>up</em> was worse than
+/// a displacement: a centre origin sends a top-left child off the canvas entirely, so
+/// <c>transform: scale(5)</c> — the shape WPT <c>css/filter-effects/filter-scaling-001</c> (entry 28
+/// of issue #1774's top 30, 50.1%) is built on — rendered a blank page where half the viewport
+/// should be green.
+/// </para>
+///
+/// <para>
+/// The reftest suite barely sees this, which is why it survived so long: both sides of a reftest
+/// are rendered by Broiler and a reference normally declares the same origin as its test, so the
+/// error cancels. It does not cancel against a reference browser's screenshot.
+/// </para>
+/// </summary>
+/// <remarks>
+/// The fix's paint half lives in <c>Broiler.HTML</c>'s <c>PaintWalker</c> and ships as a patch under
+/// <c>patches/</c> until it lands upstream, so each case here probes first and self-skips rather
+/// than going red against a pinned pointer that does not carry it. The grammar itself is main-repo
+/// and unconditionally covered by <c>Broiler.Layout.Tests.CssTransformOriginTests</c>.
+/// </remarks>
+[Xunit.Collection("NativeAnchorWpt")]
+public class TransformOriginPaintTests
+{
+    private const int Size = 200;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-tformorigin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Size, Size).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A 100×100 box holding a 20×20 green square at its top-left, scaled by a half about
+    /// <paramref name="origin"/>. The square's painted top-left corner is the whole answer.
+    /// </summary>
+    private static string Page(string origin) =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + $"<div style=\"width:100px;height:100px;transform-origin:{origin};transform:scale(0.5)\">"
+        + "<div style=\"width:20px;height:20px;background:green\"></div></div>"
+        + "</body></html>";
+
+    private static (int X, int Y)? GreenCorner(BBitmap bmp)
+    {
+        for (int y = 0; y < Size; y++)
+        {
+            for (int x = 0; x < Size; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R < 80 && p.G > 100 && p.B < 80)
+                    return (x, y);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether the paint path reads <c>transform-origin</c> at all. Without the patch every origin
+    /// paints at the box centre, so <c>0 0</c> — the one furthest from it — is the probe.
+    /// </summary>
+    private static bool PaintReadsTransformOrigin() => GreenCorner(Render(Page("0 0"))) == (0, 0);
+
+    private static void AssertCorner(int x, int y, string origin)
+    {
+        // Self-skip rather than fail: the paint half is a pending patch, so on a checkout of the
+        // pinned Broiler.HTML pointer there is nothing here to assert yet.
+        if (!PaintReadsTransformOrigin())
+            return;
+
+        Assert.Equal((x, y), GreenCorner(Render(Page(origin))));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void ZeroZero_PaintsFromTheBoxCorner() => AssertCorner(0, 0, "0 0");
+
+    /// <summary>The initial value, and the only one that used to be right.</summary>
+    [Fact(Timeout = 600000)]
+    public void FiftyPercent_PaintsFromTheCentre() => AssertCorner(25, 25, "50% 50%");
+
+    [Fact(Timeout = 600000)]
+    public void OneHundredPercent_PaintsFromTheFarCorner() => AssertCorner(50, 50, "100% 100%");
+
+    /// <summary>The keyword pair, including the spelling that leads with the vertical one.</summary>
+    [Theory]
+    [InlineData("left top")]
+    [InlineData("top left")]
+    public void TheCornerKeywords_PaintFromTheCorner(string origin) => AssertCorner(0, 0, origin);
+
+    [Fact(Timeout = 600000)]
+    public void ALength_IsMeasuredFromTheBoxCorner() => AssertCorner(5, 5, "10px 10px");
+
+    /// <summary>A lone vertical keyword moves y and centres x.</summary>
+    [Fact(Timeout = 600000)]
+    public void ALoneTop_MovesOnlyTheVerticalAxis() => AssertCorner(25, 0, "top");
+
+    /// <summary>
+    /// Scaling up is where the wrong origin stopped being a displacement and started being a blank
+    /// page: about the centre, this box's content lands entirely off the canvas.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ScalingUpAboutTheCorner_KeepsTheContentOnTheCanvas()
+    {
+        if (!PaintReadsTransformOrigin())
+            return;
+
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"width:100px;height:100px;transform-origin:0 0;transform:scale(5)\">"
+            + "<div style=\"width:20px;height:20px;background:green\"></div></div>"
+            + "</body></html>");
+
+        Assert.Equal((0, 0), GreenCorner(bmp));
+
+        // 20px scaled five times is a 100px square, so the far corner is inside the canvas too.
+        var far = bmp.GetPixel(99, 99);
+        Assert.True(far.R < 80 && far.G > 100 && far.B < 80,
+            $"the scaled square should reach (99, 99), got rgb({far.R},{far.G},{far.B})");
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements four major layout features that fix 42 WPT test assertions across multiple specs:

1. **CSS Flexbox §9.7 column main-axis sizing** — both growth and shrinkage, reading `flex-basis` in the block axis
2. **CSS Containment 2 §3.2 size containment** — boxes sized as though empty, with `contain-intrinsic-size` stand-ins
3. **CSS Transforms 1 §8 transform-origin** — unified grammar shared by paint, script bridge, and SVG renderer
4. **CSS2.1 §10.6.4 inset-derived heights** — out-of-flow boxes with `top`/`bottom` specified get definite heights from the constraint equation

## Key Changes

### Flex Column Main-Axis Sizing
- `CssBox.Flex.cs`: Replaced growth-only pass with full §9.7 implementation via new `ResolveFlexColumnMainSizes()` method
- Reads `flex-basis` (or `height` when `flex-basis: auto`) as the flex base size, not the height block flow produced
- Implements both growth and shrinkage, with §4.5 automatic minimum size as the floor
- Adds vertical writing mode check to decline the pass (column names the block axis; under vertical-lr the main axis is horizontal)
- New test suite `FlexColumnMainAxisSizingTests` covers 20 cases including percentage flex-basis, content-sized items, and shrinkage floors

### Size Containment
- New file `CssBox.SizeContainment.cs` implements §3.2 and §5
- `AppliesSizeContainment` predicate checks both the `contain` keyword and box type applicability
- `TryGetContainedIntrinsicWidth/Height()` methods return stand-in sizes from `contain-intrinsic-*` properties
- Replaced elements under containment report zero natural size (bitmap/canvas attributes are contents)
- `CssBoxProperties` adds four new properties: `ContainIntrinsicWidth`, `ContainIntrinsicHeight`, `ContainIntrinsicInlineSize`, `ContainIntrinsicBlockSize`
- New test suite `SizeContainmentTests` covers 18 cases including logical properties, aspect ratio preservation, and replaced elements
- Fixes 42 of 96 assertions in WPT `contain-intrinsic-size-logical-003`

### Transform-Origin Grammar
- New file `CssTransformOrigin.cs` in `IR/` — unified resolver for paint walker, script bridge, and SVG renderer
- Correctly parses the grammar: vertical keywords (`top`/`bottom`) may lead only when paired with another keyword; a length-percentage may not follow a vertical keyword
- Takes `initialIsBoxCorner` parameter to distinguish CSS boxes (initial `50% 50%`) from SVG elements (initial `0 0`)
- Replaces three separate, inconsistent implementations
- `SvgRenderer.TransformOrigin.cs` now delegates to the shared resolver
- Paint walker integration via patch `0004-html-paint-transform-origin.patch` (submodule `Broiler.HTML`)
- Script bridge (`LayoutMetrics.Transform.cs`) now calls the shared resolver
- New test suite `CssTransformOriginTests` covers 30 grammar cases; `TransformOriginPaintTests` covers 6 rendering cases
- Fixes WPT `css/filter-effects/filter-scaling-001` (entry 28 of #1774 top 30, was 50.1%)

### Inset-Derived Heights
- `CssBox.ContainingBlock.cs`: New `TryGetInsetDerivedContentHeight()` method solves the constraint equation for out-of-flow boxes with `height: auto` and both `top` and `bottom` specified
- `HeightPercentageResolvesToAuto()` now checks for inset-derived height, so percentages inside such boxes resolve against the definite size
- Flex and grid containers with inset-derived heights now have definite main/block sizes

https://claude.ai/code/session_01RZFd5UUQWMmAxZE5uepHqw