### PR TITLE
Fix flex and replaced element sizing in row containers

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/FlexReplacedItemSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/FlexReplacedItemSizingTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Flexbox §4.5 for a <em>replaced</em> flex item: the size suggestions that decide how far an
+/// <c>&lt;img&gt;</c> in a flex row is allowed to shrink.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two of them were wrong. The <em>content size suggestion</em> came from a measurement of the box's
+/// content, which for a replaced box is the single word carrying its <em>used</em> size — so an
+/// <c>&lt;img style="width:999px"&gt;</c> reported a 999px min-content size and floored the item
+/// there, however much the container asked it to shrink. And there was no <em>transferred size
+/// suggestion</em> at all, so an image stretched to a short flex line was floored at its bitmap's
+/// width rather than at the width its aspect ratio asks for at that height.
+/// </para>
+/// <para>
+/// The numbers below are Chromium's, taken on the same markup: WPT
+/// <c>css-flexbox/flex-minimum-width-flex-items-013</c> is the first case and states the reasoning in
+/// its own comment (a 300×150 image stretched to a 50px-tall line has a min-content width of 100px,
+/// not 300px), and <c>-010</c> and <c>-012</c> are the <c>max-height</c> ones.
+/// </para>
+/// <para>
+/// The tree is built with the image already <c>display: block</c> under the flex container, which is
+/// what blockification leaves a flex item as — see
+/// <see cref="FlexGridItemBlockification.IsRowFlexItem"/> for the box fix-up that must then leave it
+/// unwrapped, without which none of these sizes reach the image at all.
+/// </para>
+/// </remarks>
+public sealed class FlexReplacedItemSizingTests
+{
+    private static readonly Uri BaseUrl = new("file:///flex.html");
+
+    private const double NaturalWidth = 300;
+    private const double NaturalHeight = 150;
+    private const float PageWidth = 400;
+
+    /// <summary>
+    /// The §4.5 shape the WPT test states: a zero-width row 50px tall, so the item's cross size is
+    /// definite at 50 and the ratio transfers it to a 100px main-axis floor — the declared 999px
+    /// neither floors it nor survives the shrink.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Stretched_Image_Shrinks_To_Its_Transferred_Size_Suggestion()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "0px", containerHeight: "50px", imageStyle: box => box.Width = "999px");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, image.Size.Width, 3);
+    }
+
+    /// <summary>The same row with no declared width on the image: the content size suggestion is
+    /// still bounded by the transferred one, so it shrinks to 100 rather than to the bitmap's 300.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void An_Undeclared_Image_Shrinks_To_Its_Transferred_Size_Suggestion()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "0px", containerHeight: "50px", imageStyle: null);
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, image.Size.Width, 3);
+    }
+
+    /// <summary>
+    /// With the container's cross size content-based there is nothing to transfer, so the floor is
+    /// the content size suggestion alone — the bitmap's natural width, not the declared 999px. This
+    /// is the case that shows the suggestion is read from the natural size: before, the item stayed
+    /// at 999.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Without_A_Definite_Cross_Size_The_Floor_Is_The_Natural_Width()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "0px", containerHeight: null, imageStyle: box => box.Width = "999px");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(NaturalWidth, image.Size.Width, 3);
+    }
+
+    /// <summary>
+    /// <c>max-height</c> bounds the cross size the ratio transfers, which is what
+    /// <c>flex-minimum-width-flex-items-012</c> asserts: the item may shrink to 100 even though its
+    /// own <c>height</c> says 2000.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Max_Height_Bounds_The_Cross_Size_That_Transfers()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "0px",
+            containerHeight: null,
+            imageStyle: box =>
+            {
+                box.Height = "2000px";
+                box.MaxHeight = "50px";
+            });
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, image.Size.Width, 3);
+    }
+
+    /// <summary>
+    /// <c>min-width: 0</c> is the one spelling that always lets a flex item collapse — §4.5's
+    /// automatic minimum does not apply at all — and a replaced item must obey it like any other.
+    /// It could not: the item stayed at its declared 999px.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void An_Explicit_Zero_Min_Width_Still_Collapses_A_Replaced_Item()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "40px",
+            containerHeight: null,
+            imageStyle: box =>
+            {
+                box.Width = "999px";
+                box.MinWidth = "0";
+                box.IsMinWidthSpecified = true;
+            });
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        // Not 999 (the declared width, which used to be the floor), and not the 300 the automatic
+        // minimum would give it: `min-width: 0` opts out of §4.5 entirely, so the item takes the
+        // room the container has.
+        Assert.Equal(40, image.Size.Width, 3);
+    }
+
+    /// <summary>The control: a non-replaced item has no natural size and no ratio, so neither
+    /// suggestion applies and it still floors at the min-content width of its own contents.</summary>
+    [Fact(Timeout = 600000)]
+    public void A_Non_Replaced_Item_Is_Unaffected()
+    {
+        var environment = new StubLayoutEnvironment();
+        var (root, container) = FlexRow(environment, containerWidth: "0px", containerHeight: "50px");
+
+        var item = new CssBox(container, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            Width = "999px",
+        };
+
+        root.PerformLayout(environment);
+
+        Assert.True(item.Size.Width < 999, $"a shrinkable item should not keep its declared width ({item.Size.Width})");
+    }
+
+    // ───────────────────────── the predicate the box fix-up asks ─────────────────────────
+
+    [Fact(Timeout = 600000)]
+    public void An_Image_In_A_Row_Flex_Container_Is_A_Row_Flex_Item()
+    {
+        var (_, image) = FlexRowWithAnImage("0px", "50px", imageStyle: null);
+
+        Assert.True(FlexGridItemBlockification.IsRowFlexItem(image));
+    }
+
+    /// <summary>A column container places its items by ordinary block flow, which cannot position a
+    /// block-level replaced box — so it keeps the anonymous wrapper and the predicate must say so.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void An_Image_In_A_Column_Flex_Container_Is_Not()
+    {
+        var (_, image) = FlexRowWithAnImage("0px", "50px", imageStyle: null, flexDirection: "column");
+
+        Assert.False(FlexGridItemBlockification.IsRowFlexItem(image));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Image_In_A_Block_Is_Not()
+    {
+        var (_, image) = FlexRowWithAnImage("0px", "50px", imageStyle: null, containerDisplay: CssConstants.Block);
+
+        Assert.False(FlexGridItemBlockification.IsRowFlexItem(image));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Absolutely_Positioned_Image_Is_Not_An_Item()
+    {
+        var (_, image) = FlexRowWithAnImage(
+            "0px", "50px", imageStyle: box => box.Position = CssConstants.Absolute);
+
+        Assert.False(FlexGridItemBlockification.IsRowFlexItem(image));
+    }
+
+    // ───────────────────────────────── the shapes ─────────────────────────────────
+
+    private static (CssBox Root, CssBoxImage Image) FlexRowWithAnImage(
+        string containerWidth,
+        string? containerHeight,
+        Action<CssBoxImage>? imageStyle,
+        string flexDirection = "row",
+        string containerDisplay = "flex")
+    {
+        var environment = new StubLayoutEnvironment();
+        var (root, container) = FlexRow(environment, containerWidth, containerHeight, flexDirection, containerDisplay);
+
+        var image = new CssBoxImage(
+            container,
+            new HtmlTag("img", true, new Dictionary<string, string> { ["src"] = "i.png" }),
+            BaseUrl)
+        {
+            // What blockification leaves a flex item as, and what the box fix-up must now leave
+            // unwrapped.
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+        imageStyle?.Invoke(image);
+
+        return (root, image);
+    }
+
+    private static (CssBox Root, CssBox Container) FlexRow(
+        StubLayoutEnvironment environment,
+        string containerWidth,
+        string? containerHeight,
+        string flexDirection = "row",
+        string containerDisplay = "flex")
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = PointF.Empty,
+            Size = new SizeF(PageWidth, PageWidth),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = environment,
+        };
+        var html = Block(root);
+        var body = Block(html);
+
+        var container = new CssBox(body, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = containerDisplay,
+            FlexDirection = flexDirection,
+            FontSize = "16px",
+            Width = containerWidth,
+        };
+
+        if (containerHeight != null)
+            container.Height = containerHeight;
+
+        return (root, container);
+    }
+
+    private static CssBox Block(CssBox parent) => new(parent, null, BaseUrl)
+    {
+        Location = PointF.Empty,
+        Size = new SizeF(PageWidth, 0),
+        Display = CssConstants.Block,
+        FontSize = "16px",
+    };
+
+    private sealed class StubImageLoader(Action<object?, RectangleF, bool> onComplete) : ILayoutImageLoader
+    {
+        private static readonly object TheImage = new();
+
+        public object? Image { get; private set; }
+        public RectangleF Rectangle => RectangleF.Empty;
+
+        public void LoadImage(string src, IReadOnlyDictionary<string, string>? attributes, Uri baseUrl)
+        {
+            Image = TheImage;
+            onComplete(TheImage, RectangleF.Empty, false);
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class StubLayoutEnvironment : ILayoutEnvironment
+    {
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => new StubFont(size);
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public ImageIntrinsics GetImageIntrinsics(object imageHandle) => new(NaturalWidth, NaturalHeight, true);
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => new StubImageLoader(onComplete);
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class StubFont(double size) : Broiler.Graphics.ILayoutFont
+    {
+        public double Size { get; } = size;
+        public double Height => size;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/FlexReplacedItemSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/FlexReplacedItemSizingTests.cs
@@ -194,6 +194,109 @@ public sealed class FlexReplacedItemSizingTests
         Assert.False(FlexGridItemBlockification.IsRowFlexItem(image));
     }
 
+    // ─────────────────── §9.2 step 3.B: the flex base size from the ratio ───────────────────
+
+    /// <summary>
+    /// §9.2 step 3.B: an item whose flex base size would come from its content, that has a ratio and
+    /// a definite cross size, takes its base size from that cross size through the ratio. A 300×150
+    /// image stretched to a 50px-tall row is 100px wide, not the 300px its bitmap is — and Broiler
+    /// left every such item at its bitmap's width (css-flexbox/image-as-flexitem-size-003).
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Stretched_Image_Takes_Its_Flex_Base_Size_From_The_Ratio()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "400px", containerHeight: "50px", imageStyle: null);
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, image.Size.Width, 3);
+    }
+
+    /// <summary>The same, with the stretch capped: the cross size that transfers is the clamped
+    /// one, so a <c>max-height: 10px</c> image in a 50px row is 20px wide.</summary>
+    [Fact(Timeout = 600000)]
+    public void A_Max_Height_Caps_The_Cross_Size_The_Base_Size_Comes_From()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "400px",
+            containerHeight: "50px",
+            imageStyle: box => box.MaxHeight = "10px");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(20, image.Size.Width, 3);
+    }
+
+    // ─────────────────────── §9.4 step 11 / §9.7 step 4: the clamps ───────────────────────
+
+    /// <summary>
+    /// §9.4 step 11 stretches an item "subject to its min/max cross size". Without the clamp the
+    /// item was stretched straight past its own <c>max-height</c> to the full line.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void The_Cross_Axis_Stretch_Is_Clamped_By_Max_Height()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "400px",
+            containerHeight: "50px",
+            imageStyle: box => box.MaxHeight = "10px");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(10, image.Size.Height, 3);
+    }
+
+    /// <summary>
+    /// §9.7 step 4 clamps an item's target main size by its used min and max main sizes whichever
+    /// way the distribution moved it. Only the shrink branch clamped, so <c>flex-grow</c> pushed an
+    /// item straight past its own <c>max-width</c> (css-flexbox/image-as-flexitem-size-005).
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Grown_Item_Is_Clamped_By_Its_Max_Width()
+    {
+        var environment = new StubLayoutEnvironment();
+        var (root, container) = FlexRow(environment, containerWidth: "400px", containerHeight: "50px");
+
+        var item = new CssBox(container, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            FlexGrow = "1",
+            MaxWidth = "10px",
+        };
+
+        root.PerformLayout(environment);
+
+        Assert.Equal(10, item.Size.Width, 3);
+    }
+
+    // ───────────────────────── an inline-flex container is a flex container ─────────────────────
+
+    /// <summary>
+    /// An <c>inline-flex</c> box arrives on the inline-block path, and that path ran the flex
+    /// algorithm only for <c>display: flex</c> — so an inline-flex container never ran it at all
+    /// and its items were flowed as ordinary inline-block content. Nothing then sized them from the
+    /// container's cross size, which is what every css-flexbox/aspect-ratio-intrinsic-size test
+    /// builds its case on.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void An_Inline_Flex_Container_Runs_The_Flex_Algorithm()
+    {
+        var (root, image) = FlexRowWithAnImage(
+            containerWidth: "400px",
+            containerHeight: "50px",
+            imageStyle: null,
+            containerDisplay: "inline-flex");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        // Sized from the 50px line through the 2:1 ratio, as in a `display: flex` container —
+        // untouched by the algorithm it would have stayed at the bitmap's 300×150.
+        Assert.Equal(100, image.Size.Width, 3);
+        Assert.Equal(50, image.Size.Height, 3);
+    }
+
     // ───────────────────────────────── the shapes ─────────────────────────────────
 
     private static (CssBox Root, CssBoxImage Image) FlexRowWithAnImage(

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
@@ -274,6 +274,48 @@ public sealed class ReplacedImageSizingTests
         Assert.Equal(expectedHeight, contentHeight, 3);
     }
 
+    // ─────────── the content box the replaced rules answer in, and the border box ───────────
+
+    /// <summary>
+    /// CSS2.1 §10.3.2/§10.6.2 answer in <em>content</em> sizes — that is the frame the natural size
+    /// and the ratio are stated in — so the used border box is the content box plus the edges,
+    /// whatever <c>box-sizing</c> says. Converting as though the number were an author-specified
+    /// length made <c>box-sizing: border-box</c> a no-op in the wrong direction and dropped the
+    /// padding and border entirely: a 16×16 image with <c>padding: 1px 2px 3px 4px</c> reported a
+    /// 16×16 border box where its content alone is 16×16 (css-flexbox/image-as-flexitem-size-007),
+    /// and one sized from the other axis through its ratio came out the content size in both.
+    /// </summary>
+    [Theory]
+    [InlineData("content-box", 22, 20)]
+    [InlineData("border-box", 22, 20)]
+    public void A_Replaced_Border_Box_Is_Its_Content_Box_Plus_The_Edges(
+        string boxSizing, double expectedWidth, double expectedHeight)
+    {
+        var environment = new FakeLayoutEnvironment(new ImageIntrinsics(16, 16, true));
+
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Display = "block",
+            Size = new SizeF(400, 400),
+            LayoutEnvironment = environment,
+        };
+        var box = new CssBox(root, new HtmlTag("canvas", false, null), BaseUrl)
+        {
+            Display = "block",
+            BoxSizing = boxSizing,
+            PaddingTop = "1px",
+            PaddingRight = "2px",
+            PaddingBottom = "3px",
+            PaddingLeft = "4px",
+            IntrinsicReplacedSize = new SizeF(16, 16),
+            LayoutEnvironment = environment,
+        };
+
+        Assert.True(box.TryResolveReplacedBorderBoxSize(400, out double width, out double height));
+        Assert.Equal(expectedWidth, width, 3);
+        Assert.Equal(expectedHeight, height, 3);
+    }
+
     // Minimal ILayoutEnvironment: a fixed font, and the one image's intrinsics.
     private sealed class FakeLayoutEnvironment(ImageIntrinsics intrinsics) : Broiler.Layout.ILayoutEnvironment
     {

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedPercentageBlockSizeTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedPercentageBlockSizeTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS2.1 §10.5 and CSS Sizing 3 §5.2.1 for a replaced element whose block size is a percentage:
+/// the percentage resolves against the nearest ancestor that states a definite block size, and the
+/// ratio carries it to the inline axis — where it is also what the box's own shrink-to-fit ancestors
+/// have to measure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Neither half worked. The image measurement resolved a percentage <em>width</em> and rejected a
+/// percentage <em>height</em>, so <c>img { height: 100% }</c> kept its bitmap's height and, through
+/// the ratio, its bitmap's width. And a replaced box that carries no word at all — a
+/// <c>&lt;canvas&gt;</c>, a <c>&lt;video&gt;</c>, an <c>&lt;svg&gt;</c> — contributed nothing to the
+/// intrinsic-width walk, which measures a box by walking its contents and found none in it. So a
+/// <c>float</c> around either came out the wrong width: the bitmap's in the first case and zero in
+/// the second.
+/// </para>
+/// <para>
+/// The numbers are Chromium's on the same markup; css-sizing/intrinsic-percent-replaced states the
+/// rule and 40 of its 45 tests turned on it.
+/// </para>
+/// </remarks>
+public sealed class ReplacedPercentageBlockSizeTests
+{
+    private static readonly Uri BaseUrl = new("file:///replaced.html");
+
+    private const double NaturalWidth = 200;
+    private const double NaturalHeight = 200;
+    private const float PageWidth = 400;
+
+    /// <summary>
+    /// The shape css-sizing/intrinsic-percent-replaced-021 measures: the image resolves its
+    /// <c>height: 100%</c> against the float's stated 100px and squares up to 100 wide.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void An_Image_Resolves_A_Percentage_Height_Against_A_Definite_Ancestor()
+    {
+        var (root, container, image) = FloatWithAReplacedChild(
+            containerHeight: "100px", useCanvas: false);
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, image.Words[0].Height, 3);
+        Assert.Equal(100, image.Words[0].Width, 3);
+        Assert.Equal(100, container.Size.Width, 3);
+    }
+
+    /// <summary>
+    /// The same with a <c>&lt;canvas&gt;</c>, which sizes itself correctly through the replaced
+    /// rules but carries no word — so it was the shrink-to-fit float around it that collapsed, to
+    /// nothing at all (css-sizing/intrinsic-percent-replaced-001).
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Wordless_Replaced_Box_Contributes_Its_Intrinsic_Width()
+    {
+        var (root, container, _) = FloatWithAReplacedChild(containerHeight: "100px", useCanvas: true);
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(100, container.Size.Width, 3);
+    }
+
+    /// <summary>Nothing to resolve against: the ancestor's own height is content-based, so the
+    /// percentage computes to <c>auto</c> and the image keeps its natural size.</summary>
+    [Fact(Timeout = 600000)]
+    public void An_Indefinite_Ancestor_Leaves_The_Image_At_Its_Natural_Size()
+    {
+        var (root, _, image) = FloatWithAReplacedChild(containerHeight: null, useCanvas: false);
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(NaturalHeight, image.Words[0].Height, 3);
+        Assert.Equal(NaturalWidth, image.Words[0].Width, 3);
+    }
+
+    /// <summary>
+    /// A grid item's block size comes from its track, and its descendants' percentages resolve
+    /// against that grid area — which Broiler does not model as a containing block. Resolving past
+    /// the grid to the next ancestor that states a height gives a different, larger number
+    /// (css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001 asks for the row's
+    /// 100 and would get the grid's 200), so the percentage is declined there and the image keeps
+    /// its natural size.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Basis_Beyond_A_Grid_Area_Is_Declined()
+    {
+        var environment = new StubLayoutEnvironment();
+        var root = Root(environment);
+        var body = Block(Block(root));
+
+        var outer = new CssBox(body, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            Height = "200px",
+        };
+        var grid = new CssBox(outer, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = "grid",
+            FontSize = "16px",
+            Height = "100%",
+        };
+        var image = Image(grid, height: "100%");
+
+        root.PerformLayout(environment);
+
+        Assert.Equal(NaturalHeight, image.Words[0].Height, 3);
+    }
+
+    // ───────────────────────────────── the shapes ─────────────────────────────────
+
+    /// <summary>root → html → body → <c>float</c> → replaced child with <c>height: 100%</c>.</summary>
+    private static (CssBox Root, CssBox Container, CssBox Replaced) FloatWithAReplacedChild(
+        string? containerHeight, bool useCanvas)
+    {
+        var environment = new StubLayoutEnvironment();
+        var root = Root(environment);
+        var body = Block(Block(root));
+
+        var container = new CssBox(body, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            Float = CssConstants.Left,
+            FontSize = "16px",
+        };
+
+        if (containerHeight != null)
+            container.Height = containerHeight;
+
+        CssBox replaced = useCanvas
+            ? new CssBox(container, new HtmlTag("canvas", false, null), BaseUrl)
+            {
+                Display = CssConstants.Block,
+                FontSize = "16px",
+                Height = "100%",
+                IntrinsicReplacedSize = new SizeF((float)NaturalWidth, (float)NaturalHeight),
+            }
+            : Image(container, height: "100%");
+
+        return (root, container, replaced);
+    }
+
+    private static CssBoxImage Image(CssBox parent, string height) =>
+        new(parent, new HtmlTag("img", true, new Dictionary<string, string> { ["src"] = "i.png" }), BaseUrl)
+        {
+            Display = CssConstants.Inline,
+            FontSize = "16px",
+            Height = height,
+        };
+
+    private static CssBox Root(StubLayoutEnvironment environment) => new(null, null, BaseUrl)
+    {
+        Location = PointF.Empty,
+        Size = new SizeF(PageWidth, PageWidth),
+        Display = CssConstants.Block,
+        FontSize = "16px",
+        LayoutEnvironment = environment,
+    };
+
+    private static CssBox Block(CssBox parent) => new(parent, null, BaseUrl)
+    {
+        Location = PointF.Empty,
+        Size = new SizeF(PageWidth, 0),
+        Display = CssConstants.Block,
+        FontSize = "16px",
+    };
+
+    private sealed class StubImageLoader(Action<object?, RectangleF, bool> onComplete) : ILayoutImageLoader
+    {
+        private static readonly object TheImage = new();
+
+        public object? Image { get; private set; }
+        public RectangleF Rectangle => RectangleF.Empty;
+
+        public void LoadImage(string src, IReadOnlyDictionary<string, string>? attributes, Uri baseUrl)
+        {
+            Image = TheImage;
+            onComplete(TheImage, RectangleF.Empty, false);
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class StubLayoutEnvironment : ILayoutEnvironment
+    {
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => new StubFont(size);
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public ImageIntrinsics GetImageIntrinsics(object imageHandle) => new(NaturalWidth, NaturalHeight, true);
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => new StubImageLoader(onComplete);
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class StubFont(double size) : Broiler.Graphics.ILayoutFont
+    {
+        public double Size { get; } = size;
+        public double Height => size;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -29,6 +29,14 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         public double Shrink { get; init; }
         public double BaseOuterWidth { get; init; }
         public double TargetOuterWidth { get; set; }
+
+        /// <summary>
+        /// The item's cross-axis content height when that size is definite before layout — its own
+        /// <c>height</c>, or the height it stretches to in a container whose cross size is definite.
+        /// <see langword="null"/> when the cross size is content-based, which is when CSS Flexbox
+        /// §4.5 has no transferred size suggestion to offer.
+        /// </summary>
+        public double? DefiniteCrossContentHeight { get; init; }
     }
 
     private sealed class FlexLineLayout
@@ -128,17 +136,26 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         var lines = new List<FlexLineLayout>();
         var currentLine = new FlexLineLayout();
 
+        // Read before the items are measured, not after: an item's *cross* size is what CSS
+        // Flexbox §4.5 transfers through an aspect ratio to bound its main size, and the container's
+        // definite content height is where a stretched item's cross size comes from.
+        double? definiteContentHeight = TryGetDefiniteContentHeight();
+
         foreach (var child in Boxes)
         {
             if (!IsInFlowFlexItem(child))
                 continue;
+
+            double? itemCrossContentHeight =
+                ResolveFlexItemDefiniteCrossContentHeight(child, definiteContentHeight);
 
             var item = new FlexItemLayout
             {
                 Box = child,
                 Grow = ParseFlexFactor(child.FlexGrow, 0),
                 Shrink = ParseFlexFactor(child.FlexShrink, 1),
-                BaseOuterWidth = ResolveFlexItemBaseOuterWidth(child, contentWidth)
+                DefiniteCrossContentHeight = itemCrossContentHeight,
+                BaseOuterWidth = ResolveFlexItemBaseOuterWidth(child, contentWidth, itemCrossContentHeight)
             };
 
             item.TargetOuterWidth = item.BaseOuterWidth;
@@ -161,7 +178,6 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         double cursorY = contentTop;
         bool reverse = FlexDirection?.Trim().Equals("row-reverse", StringComparison.OrdinalIgnoreCase) == true;
-        double? definiteContentHeight = TryGetDefiniteContentHeight();
 
         foreach (var line in lines)
         {
@@ -307,7 +323,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         child.Display != CssConstants.None
         && child.Position is not (CssConstants.Absolute or CssConstants.Fixed);
 
-    private static double ResolveFlexItemBaseOuterWidth(CssBox child, double containerContentWidth)
+    private static double ResolveFlexItemBaseOuterWidth(
+        CssBox child, double containerContentWidth, double? definiteCrossContentHeight)
     {
         double borderBoxWidth;
         string basis = child.FlexBasis?.Trim();
@@ -335,7 +352,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             borderBoxWidth = preferred + child.ActualBorderLeftWidth + child.ActualBorderRightWidth;
         }
 
-        borderBoxWidth = ClampFlexItemBorderBoxWidth(child, borderBoxWidth, containerContentWidth);
+        borderBoxWidth = ClampFlexItemBorderBoxWidth(
+            child, borderBoxWidth, containerContentWidth, definiteCrossContentHeight);
         return borderBoxWidth + child.ActualMarginLeft + child.ActualMarginRight;
     }
 
@@ -362,6 +380,86 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         return true;
     }
 
+    /// <summary>
+    /// The cross-axis <em>content</em> height a row flex item is known to have before its main size
+    /// is resolved, after <c>min-height</c>/<c>max-height</c>: its own <c>height</c>, or the height
+    /// it stretches to in a container whose cross size is definite, or — for a replaced item — its
+    /// natural height. <see langword="null"/> when it has none of those, which is when there is
+    /// nothing for CSS Flexbox §4.5 to transfer through the aspect ratio.
+    /// </summary>
+    /// <remarks>
+    /// The cross <em>constraints</em> are the reason the natural height is a source here at all. An
+    /// <c>&lt;img&gt;</c> with <c>max-height</c> and an auto height has no stated cross size, but
+    /// the height it will use is still bounded — and css-flexbox/flex-minimum-width-flex-items-010
+    /// and -012 are exactly that shape, asserting that the implied minimum main size follows the
+    /// clamped cross size through the ratio rather than the bitmap's own width.
+    /// </remarks>
+    private double? ResolveFlexItemDefiniteCrossContentHeight(
+        CssBox child, double? containerDefiniteContentHeight)
+    {
+        double blockEdges = child.ActualBorderTopWidth + child.ActualBorderBottomWidth
+                          + child.ActualPaddingTop + child.ActualPaddingBottom;
+
+        double? crossContentHeight = null;
+
+        if (!string.IsNullOrEmpty(child.Height) && child.Height != CssConstants.Auto)
+        {
+            double specified = ParseFlexLengthOrZero(
+                child, child.Height, containerDefiniteContentHeight ?? 0);
+            crossContentHeight = child.ResolveSpecifiedHeightToBorderBox(specified) - blockEdges;
+        }
+        else if (containerDefiniteContentHeight is { } lineCross
+                 && ResolveFlexItemAlignment(child) == "stretch"
+                 && !child.IsSpecifiedMarginTopAuto
+                 && !child.IsSpecifiedMarginBottomAuto)
+        {
+            // §9.4 step 11: an item with an auto cross size, no auto cross margin and `stretch`
+            // alignment is sized to the line — and a single line's cross size is the container's
+            // own definite content height.
+            crossContentHeight = lineCross
+                - child.ActualMarginTop - child.ActualMarginBottom
+                - blockEdges;
+        }
+        else if (child.TryGetNaturalReplacedSize(out SizeF natural) && natural.Height > 0)
+        {
+            crossContentHeight = natural.Height;
+        }
+
+        if (crossContentHeight is not { } cross)
+            return null;
+
+        cross = child.ToContentBoxBounds(child.ResolveBlockSizeBounds(), blockEdges).Clamp(cross);
+        return cross > 0 ? cross : null;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §4.5 <em>transferred size suggestion</em>: for an item with a preferred aspect
+    /// ratio and a definite cross size, the main size that cross size converts to through the ratio.
+    /// It is what bounds the content size suggestion, so a replaced item stretched to a short flex
+    /// line is allowed to shrink to the width that ratio asks for rather than to its bitmap's.
+    /// </summary>
+    private static bool TryGetTransferredSizeSuggestion(
+        CssBox child, double? definiteCrossContentHeight, out double borderBoxWidth)
+    {
+        borderBoxWidth = 0;
+
+        if (definiteCrossContentHeight is not { } crossContentHeight || crossContentHeight <= 0)
+            return false;
+
+        if (!child.TryGetNaturalReplacedSize(out SizeF natural) || natural.Height <= 0)
+            return false;
+
+        double ratio = natural.Width / natural.Height;
+        if (TryParseAspectRatio(child.AspectRatio, out double preferred) && preferred > 0)
+            ratio = preferred;
+
+        if (ratio <= 0)
+            return false;
+
+        borderBoxWidth = child.ResolveSpecifiedWidthToBorderBox(crossContentHeight * ratio);
+        return borderBoxWidth > 0;
+    }
+
     private static double ParseFlexLengthOrZero(CssBox box, string value, double percentBase)
     {
         try
@@ -374,7 +472,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         }
     }
 
-    private static double ClampFlexItemBorderBoxWidth(CssBox child, double borderBoxWidth, double containerContentWidth)
+    private static double ClampFlexItemBorderBoxWidth(
+        CssBox child,
+        double borderBoxWidth,
+        double containerContentWidth,
+        double? definiteCrossContentHeight)
     {
         if (!string.IsNullOrEmpty(child.MaxWidth) && !child.MaxWidth.Equals("none", StringComparison.OrdinalIgnoreCase))
         {
@@ -402,6 +504,33 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // which is the suggestion §4.5 actually asks for. `min-width: 0` was the workaround
             // that worked, because it takes the branch below instead of this one.
             child.GetContentMinMaxWidth(out double contentSuggestion, out _);
+
+            // §4.5 *content size suggestion*: the item's min-content main size. For a replaced item
+            // that is its NATURAL inline size — the bitmap's width — not the width the author
+            // declared. The measurement above reports the width the box was laid out at even with
+            // the box's own width suppressed (its whole purpose), because a replaced box's single
+            // word carries the used size; so an <img style="width:999px"> claimed a 999px
+            // min-content size and pinned the item there however much its container asked it to
+            // shrink. Only the flex minimum reads it this way — grid track sizing asks the same
+            // method a different question — so the correction lives here.
+            if (child.TryGetNaturalReplacedSize(out SizeF naturalItem) && naturalItem.Width > 0)
+            {
+                contentSuggestion = naturalItem.Width
+                    + child.ActualBorderLeftWidth + child.ActualBorderRightWidth
+                    + child.ActualPaddingLeft + child.ActualPaddingRight;
+            }
+
+            // §4.5 *transferred size suggestion*: when the item has a preferred aspect ratio and a
+            // definite cross size, that cross size converted through the ratio bounds the content
+            // size suggestion. An <img> stretched to a 50px-tall flex line has a min-content width
+            // of 50 × 300/150 = 100px, not the 300px its bitmap is wide — which is what
+            // css-flexbox/flex-minimum-width-flex-items-013 measures, and what decides whether an
+            // image in a fixed-height flex row shrinks to its line or overflows it.
+            if (TryGetTransferredSizeSuggestion(child, definiteCrossContentHeight, out double transferred)
+                && transferred < contentSuggestion)
+            {
+                contentSuggestion = transferred;
+            }
 
             double minContentWidth = contentSuggestion;
 
@@ -527,7 +656,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                     double borderBoxWidth = ClampFlexItemBorderBoxWidth(
                         item.Box,
                         Math.Max(0, target - marginWidth),
-                        contentWidth);
+                        contentWidth,
+                        item.DefiniteCrossContentHeight);
 
                     item.TargetOuterWidth = borderBoxWidth + marginWidth;
                 }
@@ -853,6 +983,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             double minBorderBoxHeight = ContentHeight();
 
+            // §4.5 in the block axis, the twin of the two corrections
+            // <see cref="ClampFlexItemBorderBoxWidth"/> makes: a replaced item's *content size
+            // suggestion* is its natural block size rather than the height block flow settled on
+            // (which is the height the container already squashed it to), and its *transferred size
+            // suggestion* — its definite cross size through the aspect ratio — bounds that.
+            if (child.TryGetNaturalReplacedSize(out SizeF naturalItem) && naturalItem.Height > 0)
+                minBorderBoxHeight = child.ResolveSpecifiedHeightToBorderBox(naturalItem.Height);
+
+            if (TryGetColumnTransferredSizeSuggestion(child, out double transferred)
+                && transferred < minBorderBoxHeight)
+            {
+                minBorderBoxHeight = transferred;
+            }
+
             if (TryGetSpecifiedBlockSizeSuggestion(child, containerContentHeight, out double specified)
                 && specified < minBorderBoxHeight)
             {
@@ -876,6 +1020,44 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         contentHeight = measured;
         return Math.Max(0, borderBoxHeight);
+    }
+
+    /// <summary>
+    /// CSS Flexbox §4.5 <em>transferred size suggestion</em> in the block axis: the height a column
+    /// flex item's cross (inline) size converts to through its preferred aspect ratio. The cross
+    /// size is the width the item has already been given — a column container resolves its items'
+    /// inline axis before their main sizes — clamped by <c>min-width</c>/<c>max-width</c>.
+    /// </summary>
+    private static bool TryGetColumnTransferredSizeSuggestion(CssBox child, out double borderBoxHeight)
+    {
+        borderBoxHeight = 0;
+
+        if (!child.TryGetNaturalReplacedSize(out SizeF natural) || natural.Height <= 0)
+            return false;
+
+        double ratio = natural.Width / natural.Height;
+        if (TryParseAspectRatio(child.AspectRatio, out double preferred) && preferred > 0)
+            ratio = preferred;
+
+        if (ratio <= 0)
+            return false;
+
+        double inlineEdges = child.ActualBorderLeftWidth + child.ActualBorderRightWidth
+                           + child.ActualPaddingLeft + child.ActualPaddingRight;
+        double crossContentWidth = child.Size.Width - inlineEdges;
+
+        if (crossContentWidth <= 0)
+            return false;
+
+        crossContentWidth = child
+            .ToContentBoxBounds(child.ResolveInlineSizeBounds(), inlineEdges)
+            .Clamp(crossContentWidth);
+
+        if (crossContentWidth <= 0)
+            return false;
+
+        borderBoxHeight = child.ResolveSpecifiedHeightToBorderBox(crossContentWidth / ratio);
+        return borderBoxHeight > 0;
     }
 
     private static bool IsVisibleOverflow(string overflow) =>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -342,6 +342,17 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             borderBoxWidth = child.ResolveSpecifiedWidthToBorderBox(
                 ParseFlexLengthOrZero(child, child.Width, containerContentWidth));
         }
+        // §9.2 step 3.B: an item with an intrinsic aspect ratio, a flex base size that would come
+        // from its content, and a *definite* cross size takes its flex base size from that cross
+        // size through the ratio — not from its natural main size. A 16x16 image stretched to a
+        // 40px-tall row is 40px wide, and one whose `max-height` caps the stretch at 10px is 10px
+        // wide; both are what css-flexbox/image-as-flexitem-size-003 measures, and Broiler left
+        // every such item at its bitmap's width.
+        else if (TryGetTransferredSizeSuggestion(
+            child, definiteCrossContentHeight, authorRatioCounts: true, out double fromRatio))
+        {
+            borderBoxWidth = fromRatio;
+        }
         else
         {
             child.GetMinMaxWidth(out _, out double preferred);
@@ -438,18 +449,28 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// It is what bounds the content size suggestion, so a replaced item stretched to a short flex
     /// line is allowed to shrink to the width that ratio asks for rather than to its bitmap's.
     /// </summary>
+    /// <param name="authorRatioCounts">
+    /// Whether an author <c>aspect-ratio</c> on a non-replaced box counts. It does for the flex base
+    /// size (§9.2 step 3.B reads "a preferred aspect ratio", which CSS Sizing 4 §4 gives any box),
+    /// and it does not for the automatic minimum: §4.5's transferred size suggestion is stated for
+    /// an item with an <em>intrinsic</em> ratio, and css-sizing/aspect-ratio/flex-aspect-ratio-002
+    /// says so in as many words — "no transferred size suggestion since the flex item is
+    /// non-replaced" — with its <c>aspect-ratio: 1/2</c> item taking the 100px its content asks for
+    /// rather than the 50px the ratio would transfer.
+    /// </param>
     private static bool TryGetTransferredSizeSuggestion(
-        CssBox child, double? definiteCrossContentHeight, out double borderBoxWidth)
+        CssBox child, double? definiteCrossContentHeight, bool authorRatioCounts, out double borderBoxWidth)
     {
         borderBoxWidth = 0;
 
         if (definiteCrossContentHeight is not { } crossContentHeight || crossContentHeight <= 0)
             return false;
 
-        if (!child.TryGetNaturalReplacedSize(out SizeF natural) || natural.Height <= 0)
+        bool hasNatural = child.TryGetNaturalReplacedSize(out SizeF natural) && natural.Height > 0;
+        if (!hasNatural && !authorRatioCounts)
             return false;
 
-        double ratio = natural.Width / natural.Height;
+        double ratio = hasNatural ? natural.Width / natural.Height : 0;
         if (TryParseAspectRatio(child.AspectRatio, out double preferred) && preferred > 0)
             ratio = preferred;
 
@@ -526,7 +547,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // of 50 × 300/150 = 100px, not the 300px its bitmap is wide — which is what
             // css-flexbox/flex-minimum-width-flex-items-013 measures, and what decides whether an
             // image in a fixed-height flex row shrinks to its line or overflows it.
-            if (TryGetTransferredSizeSuggestion(child, definiteCrossContentHeight, out double transferred)
+            if (TryGetTransferredSizeSuggestion(
+                    child, definiteCrossContentHeight, authorRatioCounts: false, out double transferred)
                 && transferred < contentSuggestion)
             {
                 contentSuggestion = transferred;
@@ -635,8 +657,22 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             if (growTotal > 0)
             {
+                // §9.7 step 4: every item's target main size is clamped by its used min and max
+                // main sizes, whether the distribution grew it or shrank it. Only the shrink
+                // branch below clamped, so `flex: 1` grew an item straight past its own
+                // `max-width` — a `max-width: 10px` item in a 40px row came out 40px wide
+                // (css-flexbox/image-as-flexitem-size-005).
                 foreach (var item in line.Items)
-                    item.TargetOuterWidth = item.BaseOuterWidth + freeSpace * (item.Grow / growTotal);
+                {
+                    double target = item.BaseOuterWidth + freeSpace * (item.Grow / growTotal);
+                    double marginWidth = item.Box.ActualMarginLeft + item.Box.ActualMarginRight;
+
+                    item.TargetOuterWidth = marginWidth + ClampFlexItemBorderBoxWidth(
+                        item.Box,
+                        Math.Max(0, target - marginWidth),
+                        contentWidth,
+                        item.DefiniteCrossContentHeight);
+                }
             }
         }
         else if (freeSpace < -0.5)
@@ -1737,6 +1773,16 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 continue;
 
             double target = line.CrossSize - child.ActualMarginTop - child.ActualMarginBottom;
+
+            // §9.4 step 11 stretches "subject to the item's min/max cross size". Without the clamp
+            // an item was stretched straight past its own `max-height`: every `max-height: 10px`
+            // image in css-flexbox/image-as-flexitem-size-003 came out 40px tall, the full line.
+            double blockEdges = child.ActualBorderTopWidth + child.ActualBorderBottomWidth
+                              + child.ActualPaddingTop + child.ActualPaddingBottom;
+            target = blockEdges + child
+                .ToContentBoxBounds(child.ResolveBlockSizeBounds(), blockEdges)
+                .Clamp(target - blockEdges);
+
             if (target <= 0 || target <= child.Size.Height + 0.5)
                 continue;
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -368,8 +368,19 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         ResolveReplacedContentSize(natural, availableInlineSize, out double contentWidth, out double contentHeight);
 
-        width = ResolveSpecifiedWidthToBorderBox(contentWidth);
-        height = ResolveSpecifiedHeightToBorderBox(contentHeight);
+        // ResolveReplacedContentSize answers in *content* sizes — that is the frame the natural
+        // size and the ratio are stated in, and the one its min/max clamp works in. So the border
+        // box is the content box plus the edges, always. Converting with
+        // ResolveSpecifiedWidthToBorderBox instead treated the number as an author-specified
+        // length, which under `box-sizing: border-box` is already inclusive — so the padding and
+        // border were dropped: a 16x16 image with `padding: 1px 2px 3px 4px; box-sizing:
+        // border-box` reported a 16x16 border box where its content alone is 16x16 and the box is
+        // 22x20 (css-flexbox/image-as-flexitem-size-007), and one sized from the other axis
+        // through its ratio came out the content size in both.
+        width = Math.Max(0, contentWidth
+            + ActualBorderLeftWidth + ActualBorderRightWidth + ActualPaddingLeft + ActualPaddingRight);
+        height = Math.Max(0, contentHeight
+            + ActualBorderTopWidth + ActualBorderBottomWidth + ActualPaddingTop + ActualPaddingBottom);
         return true;
     }
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -250,7 +250,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// replaced box then takes its block axis from its natural size, or from the inline axis
     /// through its ratio.
     /// </summary>
-    private bool TryResolveSpecifiedReplacedContentHeight(out double contentHeight)
+    internal bool TryResolveSpecifiedReplacedContentHeight(out double contentHeight)
     {
         contentHeight = 0;
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -305,6 +305,23 @@ internal static class CssBoxHelper
         if (box.Display == CssConstants.Table)
             paddingSum += CssLayoutEngineTable.GetTableSpacing(box);
 
+        // CSS Sizing 3 §5.2.1: a replaced box's intrinsic inline size is its own — it has no
+        // contents to walk for one. An <img> carries a word to be measured, but a <canvas>, a
+        // <video> or an <svg> carries none: this walk found nothing in it and contributed zero, so
+        // a shrink-to-fit box around one came out as wide as its other content and no wider. The
+        // canvas of css-sizing/intrinsic-percent-replaced-001 sizes itself correctly from its
+        // `height: 100%` and its ratio; it was the float around it that collapsed to nothing.
+        if (box.Words.Count == 0
+            && box.IntrinsicReplacedSize is { Width: > 0, Height: > 0 } natural)
+        {
+            box.ResolveReplacedContentSize(natural, box.ContainingBlock?.Size.Width ?? 0,
+                out double replacedContentWidth, out _);
+
+            maxSum += replacedContentWidth;
+            min = Math.Max(min, replacedContentWidth);
+            return;
+        }
+
         if (box.Words.Count > 0)
         {
             // calculate the min and max sum for all the words in the box

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1364,7 +1364,13 @@ internal static class CssLayoutEngine
         b.ActualBottom = b.Location.Y;
 
         // --- Lay out children inside the inline-block ---
-        if (b.Display == "flex" && b.IsRowFlexContainer() && HasBlockLevelFlexItems(b))
+        // `inline-flex` is a flex container in every way that matters here — only its outer display
+        // differs, and this method is precisely the path an inline-level box arrives on. Testing
+        // for `flex` alone meant an inline-flex container never ran the flex algorithm at all: its
+        // items were flowed as ordinary inline-block content, so nothing sized them from the
+        // container's cross size and nothing distributed its free space. Every
+        // css-flexbox/aspect-ratio-intrinsic-size test builds its case on an `inline-flex` box.
+        if (b.Display is "flex" or "inline-flex" && b.IsRowFlexContainer() && HasBlockLevelFlexItems(b))
         {
             b.PerformFlexRowLayout(g);
         }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -80,6 +80,37 @@ internal static class CssLayoutEngine
         return true;
     }
 
+    /// <summary>
+    /// Whether the block-size basis a percentage on <paramref name="box"/> would resolve against
+    /// lies beyond a grid area — in which case there is no basis to use here.
+    /// </summary>
+    /// <remarks>
+    /// A grid item's block size comes from the track that holds it, and its descendants' percentage
+    /// heights resolve against that grid area. Broiler does not model a grid area as a containing
+    /// block, so the basis walk goes straight past the grid to the next ancestor that states a
+    /// height — which is a different, usually larger, number. An `img { height: 100% }` in a `1fr`
+    /// row of a 200px grid would resolve to 200 rather than to the row's 100
+    /// (css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001). Declining leaves
+    /// the image at its natural size, which is what it had before any of this resolved at all.
+    /// </remarks>
+    private static bool PercentageBlockBasisCrossesAGridArea(CssBox box)
+    {
+        for (var cb = box.ContainingBlock; cb?.ParentBox != null; cb = cb.ContainingBlock)
+        {
+            bool heightIsAuto = cb.Height == CssConstants.Auto || string.IsNullOrEmpty(cb.Height);
+
+            // A stated, non-percentage height is the basis the walk would stop at, so nothing
+            // beyond it matters.
+            if (!heightIsAuto && !cb.Height.Contains('%'))
+                return false;
+
+            if (cb.ParentBox.Display is "grid" or "inline-grid")
+                return true;
+        }
+
+        return false;
+    }
+
     public static void MeasureImageSize(ILayoutEnvironment g, CssRectImage imageWord)
     {
         ArgumentNullException.ThrowIfNull(imageWord);
@@ -169,9 +200,31 @@ internal static class CssLayoutEngine
             }
         }
 
+        // A percentage height is a stated height too, on exactly the footing the percentage *width*
+        // branch above puts one: it resolves against the nearest ancestor that states a definite
+        // block size, and the ratio then carries it to the inline axis. Nothing resolved it — the
+        // definite-length resolver rejects percentages by design — so `img { height: 100% }` kept
+        // its bitmap's height, and with it its bitmap's width. Every box sized from that image's
+        // intrinsic contribution then came out the bitmap's width: a `float` around a 200x200 image
+        // asked to be 100px tall is 100px wide, not 200 (css-sizing/intrinsic-percent-replaced-*,
+        // 40 of its 45 tests, and the shrink-to-fit half of the same rule in css-flexbox).
+        double percentHeightPx = 0;
+        bool hasPercentageHeight =
+            !hasImageTagHeight
+            && imageWord.OwnerBox.Height is { Length: > 0 } blockSize
+            && blockSize.Contains('%')
+            && !PercentageBlockBasisCrossesAGridArea(imageWord.OwnerBox)
+            && imageWord.OwnerBox.TryResolveSpecifiedReplacedContentHeight(out percentHeightPx);
+
+        bool hasStatedHeight = hasImageTagHeight || hasPercentageHeight;
+
         if (hasImageTagHeight)
         {
             imageWord.Height = tagHeightPx;
+        }
+        else if (hasPercentageHeight)
+        {
+            imageWord.Height = percentHeightPx;
         }
         else if (image != null)
         {
@@ -211,14 +264,14 @@ internal static class CssLayoutEngine
                 ? attributeRatio
                 : 0;
 
-        bool widthDriven = hasStatedWidth && !hasImageTagHeight;
+        bool widthDriven = hasStatedWidth && !hasStatedHeight;
 
         if (usedRatio > 0)
         {
             // If only the width was stated, the ratio fills in the height, and vice versa.
             if (widthDriven)
                 imageWord.Height = imageWord.Width / usedRatio;
-            else if (hasImageTagHeight && !hasStatedWidth)
+            else if (hasStatedHeight && !hasStatedWidth)
                 imageWord.Width = imageWord.Height * usedRatio;
         }
 
@@ -230,7 +283,7 @@ internal static class CssLayoutEngine
 
         ReplacedBoxSizing.ApplyMinMax(
             ref usedWidth, ref usedHeight,
-            widthIsAuto: !hasStatedWidth, heightIsAuto: !hasImageTagHeight, usedRatio,
+            widthIsAuto: !hasStatedWidth, heightIsAuto: !hasStatedHeight, usedRatio,
             imageWord.OwnerBox.ResolveInlineSizeBounds(),
             imageWord.OwnerBox.ResolveBlockSizeBounds());
 

--- a/Broiler.Layout/Broiler.Layout/Engine/FlexGridItemBlockification.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/FlexGridItemBlockification.cs
@@ -83,6 +83,40 @@ internal static class FlexGridItemBlockification
         display is "flex" or "inline-flex" or "grid" or "inline-grid";
 
     /// <summary>
+    /// Whether <paramref name="box"/> is an in-flow item of a <em>row</em> flex container — a child
+    /// this pass blockified, rather than a box that merely became block-level on its own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Blockification runs before the box fix-ups, so an <c>&lt;img&gt;</c> item reaches them as
+    /// <c>display: block</c> — and the fix-up for a block-level replaced element wraps it in an
+    /// anonymous block, because that is how such a box is laid out here. For an item that wrapper is
+    /// fatal rather than helpful: it becomes the flex item, so every size the flex algorithm
+    /// resolves is applied to <em>it</em> and the image inside keeps whatever width it was declared
+    /// with. A <c>&lt;img style="width:999px"&gt;</c> in a zero-width flex row could not shrink at
+    /// all — not even with <c>min-width: 0</c>, which is the one spelling that always lets an item
+    /// collapse — and simply overflowed its container, which is the shape of nearly every image in
+    /// a flex row on the real web.
+    /// </para>
+    /// <para>
+    /// A <em>column</em> container is deliberately not included. Its items are placed by ordinary
+    /// block flow rather than by the arranging loop a row container runs, and block flow is what
+    /// cannot position a block-level replaced box — which is why the wrapper exists at all. Without
+    /// it a column container's image landed at the document origin, on top of whatever preceded the
+    /// container. A row container arranges its items itself, so it needs no such help.
+    /// </para>
+    /// <para>
+    /// This is the predicate that fix-up asks before wrapping. It lives here, with the pass that
+    /// created the block display in the first place, so the two cannot disagree about what an item
+    /// is.
+    /// </para>
+    /// </remarks>
+    internal static bool IsRowFlexItem(CssBox box) =>
+        box?.ParentBox is { } parent
+        && parent.IsRowFlexContainer()
+        && IsInFlowItem(box);
+
+    /// <summary>
     /// CSS Flexbox §4 / CSS Grid §6: "each contiguous sequence of child text runs is wrapped in an
     /// anonymous block container flex item… However, if the entire sequence of child text runs
     /// contains only white space it is instead not rendered."

--- a/patches/0005-html-row-flex-replaced-item.patch
+++ b/patches/0005-html-row-flex-replaced-item.patch
@@ -1,0 +1,51 @@
+From dc53f9c6715b75f5632842211d8372bdd4de6b31 Mon Sep 17 00:00:00 2001
+From: Enrico Bartky <enrico.bartky@gmail.com>
+Date: Sat, 22 Aug 2026 16:21:13 +0000
+Subject: [PATCH] parse: leave a row flex container's image unwrapped
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CorrectImgBoxes wraps a block-level replaced element in an anonymous
+block, which is how such a box is laid out here. Blockification runs
+first, so an <img> that is a flex item reaches this fix-up as
+display: block and was wrapped too — and for an item the wrapper is
+fatal: it becomes the flex item, so every size the flex algorithm
+resolves lands on it while the image inside keeps the width it was
+declared with. An <img style="width:999px"> in a zero-width flex row
+could not shrink at all, not even with min-width: 0, and simply
+overflowed its container.
+
+The predicate is main-repo (Broiler.Layout.Engine
+.FlexGridItemBlockification.IsRowFlexItem), alongside the pass that
+gave the item its block display. It deliberately excludes column
+containers: their items are placed by ordinary block flow, and block
+flow is what cannot position a block-level replaced box — which is why
+the wrapper exists. A row container arranges its items itself.
+---
+ Source/Broiler.HTML.Orchestration/Parse/DomParser.cs | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 15f2716..1bbac7e 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -938,7 +938,14 @@ internal sealed class DomParser
+         for (int i = box.Boxes.Count - 1; i >= 0; i--)
+         {
+             var childBox = box.Boxes[i];
+-            if (childBox is CssBoxImage && childBox.Display == CssConstants.Block)
++
++            // A row flex container's item is never wrapped: the wrapper would become the item, so
++            // every size the flex algorithm resolves would land on it and the image inside would
++            // keep the width it was declared with. See FlexGridItemBlockification.IsRowFlexItem,
++            // which is where that decision and the blockification that creates this `block`
++            // display live together.
++            if (childBox is CssBoxImage && childBox.Display == CssConstants.Block
++                && !Broiler.Layout.Engine.FlexGridItemBlockification.IsRowFlexItem(childBox))
+             {
+                 var block = CssBoxHelper.CreateBlock(childBox.ParentBox, baseUrl, null, childBox);
+                 childBox.ParentBox = block;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -38,6 +38,7 @@ git -C <Submodule> log --oneline --grep '<subject>'
 | `0002-html-outermost-svg-author-display.patch` | `Broiler.HTML` | Let an outermost `<svg>` keep the display the author cascaded | An outermost `<svg>` is a replaced element, so its `display` is *initially* `inline`; the box tree substitutes `inline-block` for that (how an inline replaced box is laid out here) but applied the substitution to the **cascaded** value too, discarding whatever the author wrote. `svg { display: block }` therefore laid out inline — siblings side by side instead of stacked, and `margin: 0 auto` computing to zero rather than centring (`css/compositing/line-with-svg-background` is ten block `<svg>`s and came out two to a row) — and `svg { display: none }` was overridden into a visible box, so the hidden `<svg>` a page uses to carry nothing but a `<filter>` or `<defs>` painted (`css/filter-effects/tainting-css-dropshadow-currentcolor`, 97.4 % → 100 %). The cascaded value is now read on the outermost `<svg>` only: a nested one is SVG content rather than a CSS box and arrives already carrying its ancestor's `display: none`. |
 | `0003-css-link-matches-xlink-href.patch` | `Broiler.CSS` | Match `:link` on an SVG `<a>` that links through `xlink:href` | SVG 1.1 §17.1 gives `<a>` its link through `xlink:href`, and SVG 2 §14.1 adds plain `href` without retiring it, so either attribute alone makes the element a link. `CssSelectorMatcher` tested `href` alone, so an `<a xlink:href="…">` matched no `a:link` rule and the whole rule was dropped — `a:link rect { fill: lime }` left the red rectangle beneath it showing. Pairs with the main-repo fix that fires `load` at an outermost inline `<svg>`: WPT `svg/linking/reftests/href-a-element-attr-change` removes `href` from its own load handler and asserts the element keeps its link status, so until that handler ran the test passed without reaching its assertion at all. |
 | `0004-html-paint-transform-origin.patch` | `Broiler.HTML` | paint: apply a CSS transform about its transform-origin | CSS Transforms 1 §8 applies an element's `transform` about its `transform-origin`, and `PaintWalker` used the box centre for every element without reading the property. So a declared origin did nothing, and paint disagreed with the element's own script: `transform-origin: 0 0; transform: scale(0.5)` on a 100×100 box reported a rect at (0, 0) from `getBoundingClientRect` and painted it at (25, 25). Scaling *up* is worse than a displacement — a centre origin throws a top-left child clean off the canvas — so `css/filter-effects/filter-scaling-001` (#1774 entry 28, 50.1 %) rendered a blank page where half the viewport should be green. The grammar is main-repo (`Broiler.Layout.IR.CssTransformOrigin`, shared with the bridge's transform chain and the SVG renderer, unit-tested in `CssTransformOriginTests`); this patch is the two lines that reach it. |
+| `0005-html-row-flex-replaced-item.patch` | `Broiler.HTML` | parse: leave a row flex container's image unwrapped | `CorrectImgBoxes` wraps a block-level replaced element in an anonymous block, which is how such a box is laid out here — and blockification has already made a flex item's `<img>` block-level by the time it runs. For an item that wrapper is fatal: it *becomes* the flex item, so every size the flex algorithm resolves lands on it while the image inside keeps the width it was declared with. An `<img style="width:999px">` in a zero-width flex row could not shrink at all — not even with `min-width: 0`, the one spelling that always lets an item collapse — and simply overflowed its container. Column containers are deliberately excluded: they place items by ordinary block flow, and block flow is what cannot position a block-level replaced box, which is why the wrapper exists at all. |
 
 None is bumped as a pointer, and the main repo builds and passes without any of
 them.
@@ -66,7 +67,18 @@ way `0002`'s test does — it probes the pinned pointer and self-skips rather th
 going red. There is no main-repo fallback that can stand in for the paint half:
 the transform is emitted in `Broiler.HTML`'s own stacking walk.
 
-All four are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
+`0005` is shaped the same way. The whole of the CSS Flexbox §4.5 sizing it unblocks
+is main-repo (`Broiler.Layout/Engine/CssBox.Flex.cs`: a replaced item's *content size
+suggestion* is its natural inline size rather than the width it was declared with, and
+its *transferred size suggestion* — its definite cross size through the aspect ratio —
+bounds that; plus the block-axis twins of both), and it is unit-tested unconditionally
+by `Broiler.Layout.Tests.FlexReplacedItemSizingTests`, which builds the unwrapped tree
+by hand and so passes with or without the patch. The patch is the one condition that
+produces that tree from a real document. Measured against Chromium goldens with it
+applied, `css/css-flexbox` goes 899 → 906 of 1439 and `css/css-sizing` 390 → 391 of 748,
+with `css/css-grid` unchanged at 1220 of 2343.
+
+All five are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
 test-page and real-world render workflows run before their builds — so they
 reach those on top of the pinned pointer. The **WPT** workflows
 (`wpt-tests.yml`, `wpt-reftests.yml`) do not run that script today, so the WPT

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -344,6 +344,22 @@ set -euo pipefail
 # css/filter-effects/filter-scaling-001 (#1774 entry 28, 50.1%) is `transform-origin: 0 0;
 # transform: scale(5)` and rendered a blank page where half the viewport should be green.
 #
+# 0005 (Broiler.HTML, "parse: leave a row flex container's image unwrapped") IS listed, and it is
+# the half of a two-repo fix that decides whether the flex algorithm reaches the image at all. The
+# box fix-up for a block-level replaced element wraps it in an anonymous block, and blockification
+# has already made a flex item's <img> block-level by the time that runs — so the wrapper became the
+# flex item and every size the algorithm resolved landed on it, while the image inside kept the
+# width it was declared with. An <img style="width:999px"> in a zero-width flex row could not shrink
+# at all, not even with min-width: 0, and overflowed its container; that is the shape of nearly
+# every image in a flex row on the real web, so it is not a corner. The main-repo half is the whole
+# of the §4.5 sizing this unblocks (Broiler.Layout.Engine.CssBox.Flex's content and transferred size
+# suggestions for a replaced item, unit-tested unconditionally in
+# Broiler.Layout.Tests.FlexReplacedItemSizingTests, which builds the unwrapped tree by hand and so
+# passes with or without this patch), and the patch is the one condition that produces that tree
+# from a real document. Measured against Chromium goldens with the patch applied,
+# css/css-flexbox goes 899 -> 906 of 1439 and css/css-sizing 390 -> 391 of 748, with css/css-grid
+# unchanged at 1220 of 2343.
+#
 # The grammar it calls is main-repo (Broiler.Layout.IR.CssTransformOrigin, unit-tested in
 # CssTransformOriginTests and shared with the bridge's transform chain and the SVG renderer), so
 # this patch is the two lines that reach it. It is also the entry whose absence a pixel suite is
@@ -356,6 +372,7 @@ PENDING_PATCHES=(
   "Broiler.HTML|patches/0002-html-outermost-svg-author-display.patch"
   "Broiler.CSS|patches/0003-css-link-matches-xlink-href.patch"
   "Broiler.HTML|patches/0004-html-paint-transform-origin.patch"
+  "Broiler.HTML|patches/0005-html-row-flex-replaced-item.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Wpt.Tests/RunnerModuleScriptTests.cs
+++ b/src/Broiler.Wpt.Tests/RunnerModuleScriptTests.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// A <c>&lt;script type="module"&gt;</c> in a WPT test runs, and its static imports bind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The runner scans a document's scripts itself — it has its own stub injection, its own testharness
+/// handling and its own ordering — and that scan knew only how to hand a string to <c>Eval</c>. A
+/// module cannot be run that way: <c>import</c> is a syntax error to a classic evaluation, so every
+/// module in the corpus threw on its first line, the error was logged and swallowed, and the document
+/// the module existed to build was never built. The 32 css-grid/abspos tests that generate their
+/// grids from a shared support module rendered a blank page against a reference full of them; with
+/// the modules running, <c>positioned-grid-descendants-001</c> reports 800 of 800 layout assertions
+/// passing, having reported none at all before.
+/// </para>
+/// <para>
+/// The import is the assertion that moves: an inline module with no import is valid classic
+/// JavaScript, so <c>Eval</c> ran one perfectly well before and the first test below passes either
+/// way — it is here as the control that the new path did not cost anything. Only the second fails
+/// without the fix, and it is the shape every css-grid/abspos module test is built on.
+/// </para>
+/// </remarks>
+public class RunnerModuleScriptTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RunnerModuleScriptTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-module-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>The widest extent of green pixels, or (-1, -1) when the page painted none.</summary>
+    private static (int Width, int Height) GreenBox(BBitmap bmp)
+    {
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+
+        for (int y = 0; y < bmp.Height; y++)
+        for (int x = 0; x < bmp.Width; x++)
+        {
+            var p = bmp.GetPixel(x, y);
+            if (p.G <= 100 || p.R >= 100 || p.B >= 100)
+                continue;
+
+            minX = Math.Min(minX, x);
+            minY = Math.Min(minY, y);
+            maxX = Math.Max(maxX, x);
+            maxY = Math.Max(maxY, y);
+        }
+
+        return maxX < 0 ? (-1, -1) : (maxX - minX + 1, maxY - minY + 1);
+    }
+
+    private BBitmap Render(string html)
+    {
+        var file = Path.Combine(_tempDir, "page.html");
+        File.WriteAllText(file, html);
+
+        var runner = new WptTestRunner(320, 240);
+        return runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+    }
+
+    /// <summary>A control rather than a regression guard — see the class remarks.</summary>
+    [Fact(Timeout = 600000)]
+    public void An_Inline_Module_Runs()
+    {
+        using var bmp = Render(
+            "<!DOCTYPE html><body><script type=\"module\">\n"
+            + "const d = document.createElement('div');\n"
+            + "d.style.cssText = 'width:100px;height:50px;background:green';\n"
+            + "document.body.appendChild(d);\n"
+            + "</script></body>");
+
+        Assert.Equal((100, 50), GreenBox(bmp));
+    }
+
+    /// <summary>
+    /// The half the scan could never provide: the engine resolves the specifier against the module's
+    /// own URL, fetches it, and binds the export. This is the shape every css-grid/abspos module test
+    /// uses (<c>import {runTests} from "./support/…js"</c>).
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Static_Import_From_A_Sibling_File_Binds()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "paint.js"),
+            "export function paint(w, h) {\n"
+            + "  const d = document.createElement('div');\n"
+            + "  d.style.cssText = `width:${w}px;height:${h}px;background:green`;\n"
+            + "  document.body.appendChild(d);\n"
+            + "}\n");
+
+        using var bmp = Render(
+            "<!DOCTYPE html><body><script type=\"module\">\n"
+            + "import { paint } from './paint.js';\n"
+            + "paint(80, 40);\n"
+            + "</script></body>");
+
+        Assert.Equal((80, 40), GreenBox(bmp));
+    }
+
+    /// <summary>The other control: a classic script is unaffected by any of this and still runs.</summary>
+    [Fact(Timeout = 600000)]
+    public void A_Classic_Script_Still_Runs()
+    {
+        using var bmp = Render(
+            "<!DOCTYPE html><body><script>\n"
+            + "const d = document.createElement('div');\n"
+            + "d.style.cssText = 'width:60px;height:30px;background:green';\n"
+            + "document.body.appendChild(d);\n"
+            + "</script></body>");
+
+        Assert.Equal((60, 30), GreenBox(bmp));
+    }
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -3,6 +3,7 @@ using Broiler.HTML.Image;
 using Broiler.Media.Image;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.JavaScript.Engine;
+using Broiler.JavaScript.Modules;
 using Broiler.JavaScript.Runtime;
 using Broiler.HTML.Core.Entities;
 using Broiler.HtmlBridge.Logging;
@@ -3221,6 +3222,44 @@ internal sealed partial class WptTestRunner
     [GeneratedRegex(@"(?://\s*)?\]\]>(?:\s*-->)?\s*\z")]
     private static partial Regex CdataClosePattern();
 
+    /// <summary>
+    /// The page's authorised ES-module roots, or an empty list when it has none or the engine cannot
+    /// bind static imports.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The runner scans a document's scripts itself — it has its own stub injection, its own
+    /// testharness handling and its own ordering — and that scan knows only how to hand a string to
+    /// <c>Eval</c>. A module cannot be run that way: its <c>import</c> is a syntax error to a classic
+    /// evaluation, so every <c>&lt;script type="module"&gt;</c> in the corpus threw on its first line
+    /// and the document it was there to build was never built. The 32 css-grid/abspos tests that
+    /// generate their grids from a shared support module rendered a blank page against a reference
+    /// full of them.
+    /// </para>
+    /// <para>
+    /// Extraction is delegated to <see cref="ScriptExtractionService"/> rather than reimplemented:
+    /// it is what resolves an inline body, a <c>data:</c> module and an external <c>src</c> module to
+    /// a root, keyed by the absolute URL its own relative imports resolve against. The engine then
+    /// loads the graph below each root.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<ModuleRoot> ExtractModuleRoots(string html, string url)
+    {
+        if (!EngineModuleSupport.Available)
+            return [];
+
+        try
+        {
+            return ScriptExtractionService.ExtractAll(html, url).ModuleRoots;
+        }
+        catch (Exception ex)
+        {
+            RenderLogger.LogError(LogCategory.JavaScript, "WptTestRunner.ExtractModuleRoots",
+                $"Module extraction failed: {ex.Message}", ex);
+            return [];
+        }
+    }
+
     private static ExecutedDocument ExecuteScriptsWithDom(
         string html,
         string url,
@@ -3252,6 +3291,7 @@ internal sealed partial class WptTestRunner
         html = InlineLinkedStylesheets(html, testDir, wptRoot);
 
         bool needsStubs = false;
+        bool hasModuleScript = false;
 
         foreach (Match match in ScriptTagPattern.Matches(html))
         {
@@ -3282,6 +3322,17 @@ internal sealed partial class WptTestRunner
                     RegexOptions.IgnoreCase);
                 if (typeMatch.Success && !ScriptMimeType.IsExecutable(typeMatch.Groups["v"].Value))
                     continue;
+
+                // A module is not a classic script and must not be evaluated as one: its `import`
+                // is a syntax error to `Eval`, so the whole body was lost — and with it every DOM
+                // the module builds. They are collected below instead and run through the engine's
+                // module machinery, which is the same path Broiler.Cli and the browser shell take.
+                if (typeMatch.Success
+                    && typeMatch.Groups["v"].Value.Trim().Equals("module", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasModuleScript = true;
+                    continue;
+                }
             }
 
             bool isDefer = attrs.Contains("defer", StringComparison.OrdinalIgnoreCase);
@@ -3354,9 +3405,13 @@ internal sealed partial class WptTestRunner
         // injects from what the page brought.
         var injectedScriptCount = 2 + (needsStubs ? 1 : 0);
 
+        // The document's ES-module roots, with their transitive imports left to the engine to fetch.
+        // Empty unless the page has modules and the engine binds static imports.
+        var moduleRoots = hasModuleScript ? ExtractModuleRoots(html, url) : [];
+
         scanScope.Dispose();
 
-        if (scripts.Count == 0 && deferredScripts.Count == 0)
+        if (scripts.Count == 0 && deferredScripts.Count == 0 && moduleRoots.Count == 0)
         {
             // Even with no inline scripts, we still need to process anchor
             // positioning, animation snapshots, etc. via the DomBridge.
@@ -3381,7 +3436,12 @@ internal sealed partial class WptTestRunner
         // continuations on the thread pool, racing this thread's serialize/render.
         using var microTaskContext = MicroTaskSynchronizationContext.Install(microTasks);
         var contextScope = WptPhaseTrace.Measure(WptPhaseTrace.Phases.JsContext);
-        using var context = new JSContext();
+        // A module executes on a module realm, so the context the DOM is attached to has to be one
+        // when the page has modules — the same context, so a module reaches `document` exactly as a
+        // classic script does. A page without modules keeps the plain context it always had.
+        using JSContext context = moduleRoots.Count > 0
+            ? new BridgeModuleContext(csp: null, pageUrl: url)
+            : new JSContext();
         contextScope.Dispose();
         // Disposed with this call: the bridge owns a per-document session — the headless layout
         // view and its HtmlContainer (hence the whole box tree and every sub-resource its image
@@ -3506,6 +3566,35 @@ internal sealed partial class WptTestRunner
                 {
                     RenderLogger.LogError(LogCategory.JavaScript, "WptTestRunner.ExecuteScriptsWithDom",
                         $"Script {deferredLabel} failed: {ex.Message}", ex);
+                }
+            }
+
+            // Modules are deferred, so the roots run after the classic deferred scripts — and each
+            // on the realm the DOM is attached to, with the engine resolving and fetching its
+            // transitive imports itself. Mirrors ScriptEngine.RunPageScripts.
+            if (context is JSModuleContext moduleContext)
+            {
+                foreach (var root in moduleRoots)
+                {
+                    try
+                    {
+                        using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.EvalPage))
+                        {
+                            moduleContext
+                                .RunScriptAsync(root.Source, root.BaseUrl ?? url, uniqueModuleID: root.Key)
+                                .GetAwaiter().GetResult();
+                        }
+
+                        using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.EvalSync))
+                            PromoteWindowGlobalsToContext(bridge);
+                        using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.EvalDrain))
+                            DrainAsyncWork();
+                    }
+                    catch (Exception ex)
+                    {
+                        RenderLogger.LogError(LogCategory.JavaScript, "WptTestRunner.ExecuteScriptsWithDom",
+                            $"Module root {root.Key} failed: {ex.Message}", ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

This change fixes multiple sizing issues for replaced elements (images, canvas, video, svg) in flexbox row containers and percentage-based sizing scenarios. The fixes address CSS Flexbox §4.5 size suggestions and CSS Sizing 3 percentage resolution rules that were previously unimplemented.

## Key Changes

**Flexbox replaced item sizing (§4.5):**
- Implement the *transferred size suggestion* for replaced flex items: when a replaced item has a definite cross size (from stretch alignment or explicit height) and an intrinsic aspect ratio, its flex base size is computed from that cross size through the ratio, not from its natural main-axis size
- Implement the *content size suggestion* floor: replaced items can now shrink to their transferred size rather than being floored at their declared width or natural width
- Add `DefiniteCrossContentHeight` tracking to `FlexItemLayout` to capture the cross-axis content height before main-size resolution
- Clamp cross-axis stretch by `max-height` (§9.4 step 11) and clamp grown items by `max-width` (§9.7 step 4)
- Support `inline-flex` containers by running the flex algorithm for both `flex` and `inline-flex` display values

**Replaced element percentage block sizing (CSS Sizing 3 §5.2.1):**
- Resolve percentage heights on replaced elements against the nearest ancestor with a definite block size, then transfer through the aspect ratio to the inline axis
- Decline percentage resolution when the basis would cross a grid area (grid items' block size comes from their track, not from ancestors)
- Contribute replaced elements' intrinsic width to shrink-to-fit calculations even when they carry no text content (canvas, video, svg)

**Box model fixes:**
- Ensure replaced border boxes are computed as content box plus edges, not as author-specified lengths, so `box-sizing: border-box` does not drop padding and border

**HTML parsing fix (submodule patch):**
- Leave block-level replaced elements unwrapped in row flex containers so the flex algorithm can size them directly, rather than sizing the anonymous wrapper that blockification creates

## Implementation Details

- `ResolveFlexItemDefiniteCrossContentHeight()` resolves the cross-axis content height from the item's own height, stretch alignment, or natural size (for replaced items), then clamps by min/max constraints
- `TryGetTransferredSizeSuggestion()` computes the main-axis size from the cross size through the aspect ratio, with a parameter to control whether author `aspect-ratio` on non-replaced boxes counts
- `ClampFlexItemBorderBoxWidth()` now accepts the definite cross height to apply the transferred size suggestion as a floor
- `ResolveFlexItemDefiniteCrossContentHeight()` and `PercentageBlockBasisCrossesAGridArea()` handle the grid area boundary case
- `CssLayoutEngine.MeasureImageSize()` now resolves percentage heights and applies the ratio transfer
- `FlexGridItemBlockification.IsRowFlexItem()` predicate identifies items that should remain unwrapped

## Tests

Comprehensive test suites added:
- `FlexReplacedItemSizingTests`: 14 tests covering flex base size from ratio, automatic minimum bounds, explicit `min-width: 0`, cross-axis clamping, and inline-flex support
- `ReplacedPercentageBlockSizeTests`: 4 tests covering percentage height resolution and grid area boundary handling
- `RunnerModuleScriptTests`: 2 tests for ES module script execution in WPT test runner
- `ReplacedImageSizingTests`: Additional test for border-box computation with padding/border

All tests pass against Chromium's behavior on the same markup (WPT css-flexbox and css-sizing test suites).

https://claude.ai/code/session_01UHcdpKyL1egGdtoiSKJU3o