### PR TITLE
Sign thrown errors by name and message, not by stack

### DIFF
--- a/docs/privacy-test-pages.md
+++ b/docs/privacy-test-pages.md
@@ -244,6 +244,16 @@ the list into work: a probe that threw is reported once per probe, and
 normalizing the quoted values, URLs and numbers out of the message regroups every
 probe that a single missing API gates into one row.
 
+A thrown probe is stored as the error object itself, so it is signed by its
+`name` and `message` — the two fields that name the fault — and never by the
+stack or the serialized object around them. Signing the object cannot group
+anything: every field naming the fault is a quoted string, so the normalization
+above reduces the whole object to `{<value>: <value>, …}`, identical for every
+error, while the stack trailing it survives only as far as the excerpt limit and
+splits one missing API into a signature per truncation point. Each gap therefore
+records a `broilerSignature` taken from the error while it is still whole, beside
+the bounded `broilerValue` excerpt kept as evidence.
+
 `run-privacy-test-pages.py` decides all of this and writes the bodies —
 `--gap-issue-limit` and `--regression-issue-limit` bound them — so the rules live
 with the runner that measured them rather than in the workflow. `--github-output`

--- a/scripts/run-privacy-test-pages.py
+++ b/scripts/run-privacy-test-pages.py
@@ -129,6 +129,12 @@ ERROR_SIGNATURE_CHARS = 160
 ERROR_SIGNATURE_URL_RE = re.compile(r"\bhttps?://\S+")
 ERROR_SIGNATURE_QUOTED_RE = re.compile(r"""(['"`])(?:\\.|(?!\1).)*\1""")
 ERROR_SIGNATURE_NUMBER_RE = re.compile(r"\b(?:0x[0-9a-fA-F]+|\d+(?:\.\d+)?)\b")
+# A thrown error reaches the issue builder as the JSON excerpt describe_value
+# made of it, which the excerpt limit can cut mid-string.  These read the two
+# fields that identify the error back out of such a fragment, so a signature is
+# decided by what threw rather than by where the excerpt happened to end.
+ERROR_SIGNATURE_NAME_RE = re.compile(r'"name"\s*:\s*"((?:\\.|[^"\\])*)')
+ERROR_SIGNATURE_MESSAGE_RE = re.compile(r'"message"\s*:\s*"((?:\\.|[^"\\])*)')
 
 
 class ManifestError(ValueError):
@@ -652,6 +658,13 @@ def compare_to_reference(
                 "name": expected.get("name", test),
                 "broiler": "error" if broiler_threw else broiler.get("outcome", OUTCOME_MISSING),
                 "broilerValue": describe_value(broiler.get("value")) if broiler_threw else None,
+                # Signed from the error itself rather than from the excerpt
+                # beside it: the excerpt is bounded evidence for a reader, and
+                # a message long enough to be cut would otherwise group by
+                # where the cut landed.
+                "broilerSignature": (
+                    error_signature(broiler.get("value")) if broiler_threw else None
+                ),
                 "referenceType": json_type_name(expected.get("value")),
                 "referenceValue": describe_value(expected.get("value")),
             })
@@ -1349,6 +1362,65 @@ def issue_marker(kind: str) -> str:
     return f"<!-- broiler:privacy-test-pages:{kind} -->"
 
 
+def _normalize_incidental(text: str) -> str:
+    """Replace the detail that differs between two reports of the same fault."""
+
+    text = ERROR_SIGNATURE_URL_RE.sub("<url>", text)
+    text = ERROR_SIGNATURE_QUOTED_RE.sub("<value>", text)
+    text = ERROR_SIGNATURE_NUMBER_RE.sub("<n>", text)
+    return " ".join(text.split())
+
+
+def _truncated_json_string(text: str, pattern: re.Pattern[str]) -> str | None:
+    """Read one JSON string field out of an excerpt that may end mid-value."""
+
+    match = pattern.search(text)
+    if match is None:
+        return None
+    fragment = match.group(1)
+    try:
+        return json.loads(f'"{fragment}"')
+    except ValueError:
+        # The excerpt ended inside an escape, so the fragment is not decodable
+        # on its own; its literal text still identifies the error.
+        return fragment
+
+
+def error_identity(value: Any) -> tuple[str | None, str | None] | None:
+    """The ``name`` and ``message`` of a thrown error, however it arrives.
+
+    ``is_error_value`` recognizes a thrown probe by shape, so the error reaches
+    a report as that object — or, once ``describe_value`` has excerpted it, as a
+    JSON rendering of it that the excerpt limit may have cut mid-string.  Both
+    are read here, because those two fields are what names the fault; the stack
+    is where it was thrown from, which is not the same question.  ``None`` means
+    the value is not a serialized error, and is what sends a plain message to
+    the caller's own handling.
+    """
+
+    if isinstance(value, Mapping):
+        name = value.get("name")
+        message = value.get("message")
+        if not isinstance(name, str) and not isinstance(message, str):
+            return None
+        return (
+            name if isinstance(name, str) else None,
+            message if isinstance(message, str) else None,
+        )
+    text = str(value if value is not None else "").strip()
+    if not text.startswith("{"):
+        return None
+    try:
+        decoded = json.loads(text)
+    except ValueError:
+        decoded = None
+    if isinstance(decoded, Mapping):
+        return error_identity(decoded)
+    name = _truncated_json_string(text, ERROR_SIGNATURE_NAME_RE)
+    message = _truncated_json_string(text, ERROR_SIGNATURE_MESSAGE_RE)
+    return None if name is None and message is None else (name, message)
+
+
 def error_signature(value: Any, limit: int = ERROR_SIGNATURE_CHARS) -> str:
     """Group thrown errors that differ only in their incidental detail.
 
@@ -1357,22 +1429,31 @@ def error_signature(value: Any, limit: int = ERROR_SIGNATURE_CHARS) -> str:
     usually differ only in the value they passed it, which is why quoted
     fragments, URLs and numbers are normalized away: one signature should mean
     one fix.
+
+    An error object is signed by its ``name`` and ``message`` alone.  Signing
+    the whole serialized object instead cannot group anything: every field that
+    names the fault is a quoted string, so the rule above would reduce it to
+    ``{<value>: <value>, …}`` — identical for every error — while the stack that
+    follows survives only as far as the excerpt limit, splitting one missing API
+    into a signature per truncation point.
     """
 
-    text = " ".join(str(value if value is not None else "").split())
-    if len(text) >= 2 and text.startswith('"') and text.endswith('"'):
-        # describe_value JSON-encodes the stored value, so a plain error message
-        # arrives quoted; unwrap it before the quoted-detail rule below eats it.
-        try:
-            decoded = json.loads(text)
-        except ValueError:
-            text = text[1:-1]
-        else:
-            text = decoded if isinstance(decoded, str) else text
-    text = ERROR_SIGNATURE_URL_RE.sub("<url>", text)
-    text = ERROR_SIGNATURE_QUOTED_RE.sub("<value>", text)
-    text = ERROR_SIGNATURE_NUMBER_RE.sub("<n>", text)
-    text = " ".join(text.split())
+    identity = error_identity(value)
+    if identity is not None:
+        text = _normalize_incidental(": ".join(part for part in identity if part))
+    else:
+        text = " ".join(str(value if value is not None else "").split())
+        if len(text) >= 2 and text.startswith('"') and text.endswith('"'):
+            # describe_value JSON-encodes the stored value, so a plain error
+            # message arrives quoted; unwrap it before the quoted-detail rule
+            # below eats it.
+            try:
+                decoded = json.loads(text)
+            except ValueError:
+                text = text[1:-1]
+            else:
+                text = decoded if isinstance(decoded, str) else text
+        text = _normalize_incidental(text)
     if not text:
         return "(no message)"
     return text if len(text) <= limit else f"{text[: limit - 1]}…"
@@ -1435,7 +1516,9 @@ def build_gap_issue(
         for gap in gaps:
             if gap.get("broiler") != "error":
                 continue
-            signature = error_signature(gap.get("broilerValue"))
+            # A gap document written before the signature was recorded still
+            # has to group, so the excerpt remains the fallback.
+            signature = gap.get("broilerSignature") or error_signature(gap.get("broilerValue"))
             entry = signatures.setdefault(
                 signature,
                 {"signature": signature, "count": 0, "pages": [], "examples": []},

--- a/scripts/tests/test_run_privacy_test_pages.py
+++ b/scripts/tests/test_run_privacy_test_pages.py
@@ -567,6 +567,29 @@ class ReferenceComparisonTests(unittest.TestCase):
             MODULE.extract_test_outcomes({"results": [{"id": "x", "value": thrown}]}),
         )
 
+    def test_a_thrown_gap_records_the_signature_of_the_error_itself(self) -> None:
+        # The excerpt beside a gap is bounded evidence, so a message longer than
+        # the limit survives only in part.  Signing the error where it is still
+        # whole is what keeps such a probe from grouping by where the cut fell.
+        message = "Cannot read property 'measureText' of null " + "detail " * 60
+        thrown = {"name": "TypeError", "message": message, "stack": "\n at probe:1:2"}
+        broiler = MODULE.extract_test_entries({"results": [{"id": "canvas", "value": thrown}]})
+        reference = self.reference([{"id": "canvas", "value": {"width": 12}}])
+
+        gap = MODULE.compare_to_reference(broiler, reference)["gaps"][0]
+
+        self.assertEqual(MODULE.error_signature(thrown), gap["broilerSignature"])
+        self.assertTrue(gap["broilerSignature"].startswith("TypeError: Cannot read property"))
+        self.assertLessEqual(len(gap["broilerValue"]), MODULE.VALUE_EXCERPT_CHARS)
+
+    def test_a_gap_that_did_not_throw_records_no_signature(self) -> None:
+        broiler = MODULE.extract_test_entries({"results": [{"id": "audio", "value": None}]})
+        reference = self.reference([{"id": "audio", "value": "44100"}])
+
+        gap = MODULE.compare_to_reference(broiler, reference)["gaps"][0]
+
+        self.assertIsNone(gap["broilerSignature"])
+
     def test_a_probe_neither_engine_answers_is_not_a_gap(self) -> None:
         broiler = MODULE.extract_test_entries({"results": [{"id": "websocket", "value": None}]})
         reference = self.reference([{"id": "websocket", "value": None}])
@@ -714,6 +737,67 @@ class ErrorSignatureTests(unittest.TestCase):
 
     def test_a_probe_that_stored_nothing_still_has_a_signature(self) -> None:
         self.assertEqual("(no message)", MODULE.error_signature(None))
+
+    @staticmethod
+    def thrown(message: str, *frames: str) -> dict[str, str]:
+        """One probe's caught error, in the shape the pages actually store."""
+
+        return {
+            "name": "TypeError",
+            "message": message,
+            "stack": "\n at " + ",\n at ".join(frames),
+        }
+
+    def test_a_thrown_error_object_is_signed_by_what_it_threw(self) -> None:
+        # Every field naming the fault is a quoted string, so signing the
+        # serialized object would reduce it to "{<value>: <value>, …}" — the
+        # same signature every error would get.
+        error = self.thrown("navigator.storage.estimate is not a function", "probe:1:2")
+
+        self.assertEqual(
+            "TypeError: navigator.storage.estimate is not a function",
+            MODULE.error_signature(error),
+        )
+
+    def test_one_missing_api_is_one_signature_however_deep_the_stack(self) -> None:
+        # The excerpt limit cuts a serialized error mid-stack, leaving a
+        # different unterminated tail per probe; grouping on that reported one
+        # null WebGL context as four separate findings.
+        null_frame = "Item:/_/Broiler.JS/Broiler.JavaScript.BuiltIns/Null/JSNull.cs:118"
+        signatures = {
+            MODULE.error_signature(
+                MODULE.describe_value(
+                    self.thrown(f"Cannot read property '{probe}' of null", null_frame, *frames)
+                )
+            )
+            for probe, frames in (
+                ("getParameter", ("inline:deferred-3:41", "run:deferred-3:12", "at:1:2")),
+                ("getSupportedExtensions", ("inline:deferred-3:41", "run:deferred-3:12")),
+                ("getContextAttributes", ("inline:deferred-3:41",)),
+                ("getShaderPrecisionFormat", ("inline:deferred-3:41", "run:deferred-3:12", "x:3:4")),
+            )
+        }
+
+        self.assertEqual({"TypeError: Cannot read property <value> of null"}, signatures)
+
+    def test_an_excerpted_error_signs_the_same_as_the_error_itself(self) -> None:
+        error = self.thrown("navigator.userAgentData is not defined", "probe:1:2", "run:3:4")
+
+        self.assertEqual(
+            MODULE.error_signature(error),
+            MODULE.error_signature(MODULE.describe_value(error)),
+        )
+
+    def test_an_error_that_says_nothing_reads_as_saying_nothing(self) -> None:
+        # Better an honest "(no message)" than the stringified object, which
+        # would rank as though it were a distinct finding.
+        self.assertEqual("(no message)", MODULE.error_signature({"name": "", "message": ""}))
+
+    def test_two_different_faults_are_not_collapsed_into_one_signature(self) -> None:
+        first = MODULE.error_signature(self.thrown("webkitRTCPeerConnection is not a constructor"))
+        second = MODULE.error_signature(self.thrown("navigator.connection is undefined"))
+
+        self.assertNotEqual(first, second)
 
     def test_a_long_message_is_bounded(self) -> None:
         signature = MODULE.error_signature("x" * 500)


### PR DESCRIPTION
## Summary

When a probe throws an error, the test runner now signs it by the error's `name` and `message` fields alone, rather than by the entire serialized object. This ensures that a single missing API is grouped into one signature regardless of how the stack trace is truncated by the excerpt limit.

## Key Changes

- **New regex patterns** (`ERROR_SIGNATURE_NAME_RE`, `ERROR_SIGNATURE_MESSAGE_RE`) extract `name` and `message` fields from JSON-serialized error excerpts that may be cut mid-string.

- **New helper functions**:
  - `error_identity(value)` — extracts the `name` and `message` from an error object (whether it arrives as a dict or as a JSON string excerpt), returning `None` if the value is not an error.
  - `_truncated_json_string(text, pattern)` — safely reads a JSON string field from a potentially truncated excerpt.
  - `_normalize_incidental(text)` — extracted common normalization logic (URL, quoted value, and number replacement).

- **Updated `error_signature()`** to call `error_identity()` first. If the value is an error object, it signs only the `name` and `message` (joined with `": "`); otherwise it falls back to the previous behavior for plain messages.

- **Gap records now include `broilerSignature`** — a signature computed from the complete error object before excerpting, stored alongside the bounded `broilerValue` excerpt. When building gap issues, the recorded signature is used if available; older gap documents without it fall back to signing the excerpt.

- **Documentation updated** to explain why errors are signed by their identity fields rather than the serialized object: every field naming the fault is a quoted string, so normalizing the whole object would reduce it to `{<value>: <value>, …}` (identical for all errors), while the stack survives only as far as the excerpt limit and would split one missing API into multiple signatures per truncation point.

## Implementation Details

- Error identity extraction handles both complete error objects (dicts) and JSON-serialized excerpts, using regex patterns to recover the `name` and `message` even when the excerpt ends mid-escape sequence.
- The signature is built from the identity fields only, preserving the existing normalization rules (URLs, quoted fragments, numbers) to group related faults.
- Backward compatibility is maintained: gap documents written before `broilerSignature` was recorded still group correctly by falling back to signing the excerpt.

https://claude.ai/code/session_01LqDj5FA1aQ64MT3kFg4MHh