### PR TITLE
Resolve image-set(), fix SVG viewBox ratio, and handle rotated transforms

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/AffineLayerMapTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/AffineLayerMapTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Drawing;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// <see cref="AffineLayerMap"/> — the device-space map a rotated or skewed CSS transform becomes
+/// once its content has been drawn untransformed into an offscreen layer.
+/// </summary>
+/// <remarks>
+/// The property every case here checks is the same one: a content point drawn at its untransformed
+/// device position must be readable back at the device position CSS says the transform puts it, and
+/// <see cref="AffineLayerMap.InverseMap"/> must be the exact inverse of
+/// <see cref="AffineLayerMap.MapPoint"/> — a resample runs in the inverse direction, so an error
+/// there does not misplace the content, it fetches the wrong pixel for every destination.
+/// </remarks>
+public sealed class AffineLayerMapTests
+{
+    private const float Tol = 1e-3f;
+
+    private static AffineLayerMap Create(
+        float[] matrix, float originX = 0f, float originY = 0f,
+        float sx = 1f, float sy = 1f, float tx = 0f, float ty = 0f)
+    {
+        Assert.True(
+            AffineLayerMap.TryCreate(matrix, originX, originY, sx, sy, tx, ty, out var map),
+            "expected the matrix to need the layer path");
+        return map;
+    }
+
+    // rotate(90deg) is matrix(0, 1, -1, 0, 0, 0): the x axis goes to +y and the y axis to −x.
+    [Fact(Timeout = 600000)]
+    public void A_Quarter_Turn_About_The_Origin_Sends_X_To_Y()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f]);
+
+        map.MapPoint(10f, 0f, out float x, out float y);
+        Assert.Equal(0f, x, Tol);
+        Assert.Equal(10f, y, Tol);
+
+        map.MapPoint(0f, 10f, out x, out y);
+        Assert.Equal(-10f, x, Tol);
+        Assert.Equal(0f, y, Tol);
+    }
+
+    // The transform is applied about transform-origin, so that point is the one it does not move.
+    [Fact(Timeout = 600000)]
+    public void The_Transform_Origin_Is_The_Fixed_Point()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f], originX: 40f, originY: 70f);
+
+        map.MapPoint(40f, 70f, out float x, out float y);
+        Assert.Equal(40f, x, Tol);
+        Assert.Equal(70f, y, Tol);
+    }
+
+    // The worked case from css/css-transforms/transform-box/cssbox-content-box-001: a 200x200
+    // border box at (300, 100) rotated a quarter turn about (300, 100) lands at (100, 100)-(300,
+    // 300). The reference states the answer as "a square whose top-left corner is at 100,100".
+    [Fact(Timeout = 600000)]
+    public void A_Quarter_Turn_Moves_The_Box_Where_The_Reference_Says()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f], originX: 300f, originY: 100f);
+
+        var bounds = map.MapBounds(RectangleF.FromLTRB(300f, 100f, 500f, 300f));
+
+        Assert.Equal(100f, bounds.Left, Tol);
+        Assert.Equal(100f, bounds.Top, Tol);
+        Assert.Equal(300f, bounds.Right, Tol);
+        Assert.Equal(300f, bounds.Bottom, Tol);
+    }
+
+    // A 45-degree turn grows the axis-aligned box it needs by root two, which is the whole reason
+    // the caller iterates MapBounds rather than the source rectangle.
+    [Fact(Timeout = 600000)]
+    public void A_Diagonal_Turn_Grows_The_Destination_Box()
+    {
+        float k = MathF.Sqrt(2f) / 2f;
+        var map = Create([k, k, -k, k, 0f, 0f], originX: 50f, originY: 50f);
+
+        var bounds = map.MapBounds(RectangleF.FromLTRB(0f, 0f, 100f, 100f));
+
+        float grown = 100f * MathF.Sqrt(2f);
+        Assert.Equal(grown, bounds.Width, 1e-2f);
+        Assert.Equal(grown, bounds.Height, 1e-2f);
+        Assert.Equal(50f, bounds.Left + bounds.Width / 2f, 1e-2f);
+        Assert.Equal(50f, bounds.Top + bounds.Height / 2f, 1e-2f);
+    }
+
+    // The pre-image is what keeps a warp layer affordable: it is the part of the layer that can
+    // reach the region still visible, so a rasterizer inside the layer keeps a box to bound its
+    // loops with. Leaving it unbounded instead was measured at ten times the cost on the full suite.
+    [Fact(Timeout = 600000)]
+    public void The_Pre_Image_Of_A_Destination_Box_Round_Trips()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f], originX: 300f, originY: 100f);
+        var source = RectangleF.FromLTRB(300f, 100f, 500f, 300f);
+
+        var destination = map.MapBounds(source);
+        var preImage = map.InverseMapBounds(destination);
+
+        Assert.Equal(source.Left, preImage.Left, 1e-2f);
+        Assert.Equal(source.Top, preImage.Top, 1e-2f);
+        Assert.Equal(source.Right, preImage.Right, 1e-2f);
+        Assert.Equal(source.Bottom, preImage.Bottom, 1e-2f);
+    }
+
+    // It has to be a superset of what can land in the destination, or clipping to it would drop
+    // content that should have been drawn: a diagonal turn's pre-image grows the same way its image
+    // does, and every corner of the destination has to map back inside it.
+    [Fact(Timeout = 600000)]
+    public void The_Pre_Image_Contains_Everything_That_Can_Reach_The_Destination()
+    {
+        float k = MathF.Sqrt(2f) / 2f;
+        var map = Create([k, k, -k, k, 0f, 0f], originX: 50f, originY: 50f);
+        var destination = RectangleF.FromLTRB(0f, 0f, 100f, 100f);
+
+        var preImage = map.InverseMapBounds(destination);
+
+        foreach (var (dx, dy) in new[] { (0f, 0f), (100f, 0f), (100f, 100f), (0f, 100f), (50f, 50f) })
+        {
+            map.InverseMap(dx, dy, out float sx, out float sy);
+            Assert.True(
+                sx >= preImage.Left - 1e-3f && sx <= preImage.Right + 1e-3f
+                && sy >= preImage.Top - 1e-3f && sy <= preImage.Bottom + 1e-3f,
+                $"({sx}, {sy}) fell outside the pre-image {preImage}");
+        }
+    }
+
+    [Theory]
+    // rotation, skew, and a rotation composed with a scale — the three shapes that reach this path
+    [InlineData(0f, 1f, -1f, 0f, 0f, 0f)]
+    [InlineData(1f, 0f, 0.5f, 1f, 0f, 0f)]
+    [InlineData(1.5f, 2f, -2f, 1.5f, 13f, -7f)]
+    public void Inverse_Undoes_Forward(float a, float b, float c, float d, float e, float f)
+    {
+        var map = Create([a, b, c, d, e, f], originX: 25f, originY: 60f, sx: 2f, sy: 2f, tx: 11f, ty: 5f);
+
+        foreach (var (px, py) in new[] { (0f, 0f), (100f, 40f), (-30f, 250f) })
+        {
+            map.MapPoint(px, py, out float qx, out float qy);
+            map.InverseMap(qx, qy, out float rx, out float ry);
+            Assert.Equal(px, rx, 1e-2f);
+            Assert.Equal(py, ry, 1e-2f);
+        }
+    }
+
+    // The surface mapping is conjugated, not assumed away: content drawn into the layer is already
+    // in device space, so the transform has to be expressed there too. Under a 2x zoom a quarter
+    // turn about a canvas-local origin still fixes that origin's *device* position.
+    [Fact(Timeout = 600000)]
+    public void The_Surface_Scale_And_Translation_Are_Carried_Through()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f], originX: 30f, originY: 40f, sx: 2f, sy: 2f, tx: 7f, ty: 9f);
+
+        // Device position of the canvas-local origin: (30·2 + 7, 40·2 + 9) = (67, 89).
+        map.MapPoint(67f, 89f, out float x, out float y);
+        Assert.Equal(67f, x, Tol);
+        Assert.Equal(89f, y, Tol);
+
+        // A canvas-local point 10 to the right of the origin — device (87, 89) — turns to 10 below
+        // it in canvas-local terms, which under the 2x zoom is 20 device pixels: (67, 109).
+        map.MapPoint(87f, 89f, out x, out y);
+        Assert.Equal(67f, x, Tol);
+        Assert.Equal(109f, y, Tol);
+    }
+
+    // A non-uniform surface scale is where assuming a single zoom factor would go wrong: a quarter
+    // turn under sx != sy is not a quarter turn in device space, and the conjugation is what keeps
+    // the mapped box the right shape.
+    [Fact(Timeout = 600000)]
+    public void A_Non_Uniform_Surface_Scale_Is_Conjugated_Not_Averaged()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 0f, 0f], originX: 0f, originY: 0f, sx: 2f, sy: 4f);
+
+        // Canvas-local (10, 0) is device (20, 0); a quarter turn sends it to canvas-local (0, 10),
+        // which is device (0, 40).
+        map.MapPoint(20f, 0f, out float x, out float y);
+        Assert.Equal(0f, x, Tol);
+        Assert.Equal(40f, y, Tol);
+    }
+
+    [Theory]
+    // Translation and axis-aligned scale, mirrors included: the canvas draws these directly, and
+    // claiming them here would cost an offscreen surface and resample content it places exactly.
+    [InlineData(1f, 0f, 0f, 1f, 20f, 30f)]
+    [InlineData(2f, 0f, 0f, 3f, 0f, 0f)]
+    [InlineData(-1f, 0f, 0f, -1f, 0f, 0f)]
+    [InlineData(1f, 0f, 0f, 1f, 0f, 0f)]
+    public void An_Axis_Aligned_Matrix_Is_Declined(float a, float b, float c, float d, float e, float f)
+    {
+        float[] m = [a, b, c, d, e, f];
+        Assert.True(AffineLayerMap.IsAxisAligned(m));
+        Assert.False(AffineLayerMap.TryCreate(m, 0f, 0f, 1f, 1f, 0f, 0f, out _));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Singular_Matrix_Is_Declined()
+    {
+        // scale(0) composed with a rotation: every point collapses onto one, so there is no source
+        // point to fetch back for a destination pixel.
+        Assert.False(AffineLayerMap.TryCreate([0f, 1f, 0f, 0f, 0f, 0f], 0f, 0f, 1f, 1f, 0f, 0f, out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(new float[] { 1f, 0f, 0f })]
+    public void A_Malformed_Matrix_Is_Declined(float[] matrix)
+    {
+        Assert.True(AffineLayerMap.IsAxisAligned(matrix));
+        Assert.False(AffineLayerMap.TryCreate(matrix, 0f, 0f, 1f, 1f, 0f, 0f, out _));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Degenerate_Surface_Is_Declined()
+    {
+        Assert.False(AffineLayerMap.TryCreate([0f, 1f, -1f, 0f, 0f, 0f], 0f, 0f, 0f, 1f, 0f, 0f, out _));
+        Assert.False(AffineLayerMap.TryCreate([0f, 1f, -1f, 0f, 0f, 0f], 0f, 0f, 1f, float.NaN, 0f, 0f, out _));
+    }
+
+    // The matrix's own translation terms are lengths in canvas-local units, so they scale with the
+    // surface; its a/b/c/d terms are ratios and do not.
+    [Fact(Timeout = 600000)]
+    public void The_Matrix_Translation_Is_A_Length_And_Scales_With_The_Surface()
+    {
+        var map = Create([0f, 1f, -1f, 0f, 5f, 0f], originX: 0f, originY: 0f, sx: 3f, sy: 3f);
+
+        map.MapPoint(0f, 0f, out float x, out float y);
+        Assert.Equal(15f, x, Tol);
+        Assert.Equal(0f, y, Tol);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/CssImageSetTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/CssImageSetTests.cs
@@ -1,0 +1,165 @@
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Images 4 §5.4 <c>image-set()</c>: which of the offered images a 1x display takes, and the
+/// difference between a function that is invalid and one that validly selects nothing.
+/// </summary>
+/// <remarks>
+/// The selection is resolved into the property value before anything downstream reads it, because
+/// the two readers downstream each recognise only part of what the function can hold: the
+/// background loader looks for <c>url(</c>, the paint walker looks for <c>gradient(</c>. Every case
+/// here is one a WPT test in <c>css/css-images/image-set</c> states.
+/// </remarks>
+public sealed class CssImageSetTests
+{
+    private static string Resolve(string value)
+    {
+        Assert.True(CssImageSet.TryResolveLayers(value, out var resolved), $"expected {value} to parse");
+        return resolved;
+    }
+
+    [Theory]
+    // Every spelling of 1x resolves to the same image — 96dpi and 96/2.54 dpcm are one device pixel.
+    [InlineData("image-set(url(\"/images/green.png\") 1x)")]
+    [InlineData("image-set(url(\"/images/green.png\") 1dppx)")]
+    [InlineData("image-set(url(\"/images/green.png\") 96dpi)")]
+    [InlineData("image-set(url(\"/images/green.png\") 37.7952755906dpcm)")]
+    [InlineData("image-set(url(\"/images/green.png\") calc(0.5x * 2))")]
+    [InlineData("image-set(url(\"/images/green.png\") calc(2x / 2))")]
+    // An omitted resolution is 1x.
+    [InlineData("image-set(url(\"/images/green.png\"))")]
+    // type() naming something this engine decodes keeps the option.
+    [InlineData("image-set(url(\"/images/green.png\") 1x type('image/png'))")]
+    // The prefixed spelling is the same function.
+    [InlineData("-webkit-image-set(url(\"/images/green.png\") 1x)")]
+    public void A_Single_Usable_Option_Is_The_Answer(string value)
+    {
+        Assert.Equal("url(\"/images/green.png\")", Resolve(value));
+    }
+
+    // Ties go to the first option, which is the whole of image-set-first-match-rendering: it offers
+    // green then red, both at 1x.
+    [Fact(Timeout = 600000)]
+    public void The_First_Of_Two_Equal_Options_Wins()
+    {
+        Assert.Equal(
+            "url(\"/images/green.png\")",
+            Resolve("image-set(url(\"/images/green.png\") 1x, url(\"/images/red.png\") 1x)"));
+    }
+
+    // …and the order they are written in does not decide it: a 2x written first still loses to the
+    // 1x behind it on a 1x display (image-set-unordered-res-rendering).
+    [Fact(Timeout = 600000)]
+    public void The_Smallest_Resolution_That_Reaches_The_Device_Wins()
+    {
+        Assert.Equal(
+            "url(\"/images/green.png\")",
+            Resolve("image-set(url(\"/images/red.png\") 2x, url(\"/images/green.png\") 1x)"));
+    }
+
+    // When nothing on offer reaches the device, the largest is the least bad.
+    [Fact(Timeout = 600000)]
+    public void The_Largest_Below_The_Device_Wins_When_None_Reaches_It()
+    {
+        Assert.True(CssImageSet.TryResolve(
+            "image-set(url(\"a.png\") 0.25x, url(\"b.png\") 0.5x)", 1.0, out var image));
+        Assert.Equal("url(\"b.png\")", image);
+    }
+
+    [Theory]
+    // An option this device cannot take is skipped, and the next one answers instead.
+    [InlineData("image-set(url(\"/images/red.png\") 1x type('image/unsupported'), url(\"/images/green.png\") 1x)")]
+    [InlineData("image-set(url(\"/images/green.png\") 1x, url(\"\") 2x)")]
+    [InlineData("image-set(url(\"/images/red.png\") 0x, url(\"/images/green.png\") 1x)")]
+    public void An_Unusable_Option_Is_Skipped(string value)
+    {
+        Assert.Equal("url(\"/images/green.png\")", Resolve(value));
+    }
+
+    // A bare <string> is an image in this function, the same as wrapping it in url().
+    [Fact(Timeout = 600000)]
+    public void A_Bare_String_Is_An_Image()
+    {
+        Assert.Equal("url(\"/images/green.png\")", Resolve("image-set(\"/images/green.png\" 1x)"));
+    }
+
+    // A gradient is an image too, and unwrapping it is what lets the paint walker recognise the
+    // layer as one it draws rather than one it fetches.
+    [Fact(Timeout = 600000)]
+    public void A_Gradient_Option_Is_Unwrapped_Whole()
+    {
+        Assert.Equal(
+            "linear-gradient(green, lightgreen)",
+            Resolve("image-set(linear-gradient(green, lightgreen) 1x)"));
+    }
+
+    // Zero resolution parses but is not usable, so a function offering only that selects nothing —
+    // and `none` is what every reader of this value already understands that to mean. The test that
+    // states it (image-set-zero-resolution-rendering) puts a *red* url() in the declaration under
+    // it and expects a blank page, so "selects nothing" must not fall back to that declaration.
+    [Fact(Timeout = 600000)]
+    public void A_Function_With_No_Usable_Option_Selects_Nothing()
+    {
+        Assert.Equal("none", Resolve("image-set(url(\"/images/red.png\") 0x)"));
+    }
+
+    [Theory]
+    // A negative resolution is a parse error, not an unusable option: CSS Syntax 3 §9 drops the
+    // declaration whole, so the one cascaded under it applies. image-set-negative-resolution-
+    // rendering-2 puts a *green* url() there and expects green — the opposite of the zero case.
+    [InlineData("image-set(url(\"/images/red.png\") -1x)")]
+    [InlineData("image-set(url(\"/images/red.png\") -1x, url(\"/images/red.png\") 2x)")]
+    // Two images, or two resolutions, in one option is a parse error too.
+    [InlineData("image-set(url(\"a.png\") url(\"b.png\") 1x)")]
+    [InlineData("image-set(url(\"a.png\") 1x 2x)")]
+    [InlineData("image-set(1x)")]
+    public void An_Invalid_Function_Is_Reported_As_A_Parse_Error(string value)
+    {
+        Assert.False(CssImageSet.TryResolveLayers(value, out _));
+    }
+
+    [Theory]
+    // Anything without an image-set() in it comes back byte-identical, which is what keeps this off
+    // the path of every other background in the corpus.
+    [InlineData("none")]
+    [InlineData("url(\"/images/green.png\")")]
+    [InlineData("linear-gradient(red, blue), url(a.png)")]
+    [InlineData("")]
+    public void A_Value_Without_The_Function_Is_Untouched(string value)
+    {
+        Assert.Equal(value, Resolve(value));
+    }
+
+    // Only the image-set layers of a multi-layer value are rewritten; the others keep their text.
+    [Fact(Timeout = 600000)]
+    public void Only_The_Image_Set_Layers_Of_A_List_Are_Rewritten()
+    {
+        Assert.Equal(
+            "url(\"a.png\"), url(\"/images/green.png\"), linear-gradient(red, blue)",
+            Resolve("url(\"a.png\"), image-set(url(\"/images/green.png\") 1x, url(\"b.png\") 2x), linear-gradient(red, blue)"));
+    }
+
+    // A comma inside a nested function is not a layer separator, and neither is one inside a string.
+    [Fact(Timeout = 600000)]
+    public void Nested_Commas_Do_Not_Split_Layers()
+    {
+        Assert.Equal(
+            "linear-gradient(green, lightgreen)",
+            Resolve("image-set(linear-gradient(green, lightgreen) 1x, url(\"b.png\") 2x)"));
+        Assert.Equal("url(\"a,b.png\")", Resolve("image-set(url(\"a,b.png\") 1x)"));
+    }
+
+    [Theory]
+    // A token that is not a resolution at all makes the option's second image — a parse error —
+    // rather than being silently ignored.
+    [InlineData("image-set(url(\"a.png\") 1)")]
+    [InlineData("image-set(url(\"a.png\") calc(1x * 2x))")]
+    [InlineData("image-set(url(\"a.png\") calc(1x + 1))")]
+    public void A_Token_That_Is_Not_A_Resolution_Is_Not_Treated_As_One(string value)
+    {
+        Assert.False(CssImageSet.TryResolveLayers(value, out _));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/DisplayContentsBoxesTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/DisplayContentsBoxesTests.cs
@@ -140,6 +140,45 @@ public sealed class DisplayContentsBoxesTests
         Assert.Equal([child], root.Boxes);
     }
 
+    // …and it is still the root element when the pass is handed the *document* box, which is what
+    // the renderer hands it: HtmlParser.ParseDocument creates an anonymous block and appends <html>
+    // to it, so blockifying only the box we were given left the real root element to be spliced out
+    // like any other wrapper. What goes with it is the canvas: the canvas background is the root
+    // element's (CSS Backgrounds §2.11.2), so `:root { display: contents; background: … }` painted
+    // nothing at all — the shape of css/css-display/display-contents-root-background, which asks
+    // for a green page and got a white one.
+    [Fact(Timeout = 600000)]
+    public void The_Root_Element_Is_Blockified_Under_The_Anonymous_Document_Box()
+    {
+        var document = Box(null, "div", CssConstants.Block);
+        var html = Box(document, "html", Contents);
+        var body = Box(html, "body", CssConstants.Block);
+
+        DisplayContentsBoxes.Generate(document);
+
+        Assert.Equal([html], document.Boxes);
+        Assert.Equal(CssConstants.Block, html.Display);
+        Assert.Equal([body], html.Boxes);
+    }
+
+    // The rule is the document's, not the outermost box's: a sub-document's root element — an
+    // <iframe>'s, projected under a sub-viewport box — is entitled to the same blockification.
+    [Fact(Timeout = 600000)]
+    public void A_Sub_Documents_Root_Element_Is_Blockified_Too()
+    {
+        var document = Box(null, "div", CssConstants.Block);
+        var html = Box(document, "html", CssConstants.Block);
+        var subViewport = Box(html, "div", CssConstants.Block);
+        var subHtml = Box(subViewport, "html", Contents);
+        var subBody = Box(subHtml, "body", CssConstants.Block);
+
+        DisplayContentsBoxes.Generate(document);
+
+        Assert.Equal([subHtml], subViewport.Boxes);
+        Assert.Equal(CssConstants.Block, subHtml.Display);
+        Assert.Equal([subBody], subHtml.Boxes);
+    }
+
     [Fact(Timeout = 600000)]
     public void Running_The_Pass_Twice_Changes_Nothing()
     {

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgTransformTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgTransformTests.cs
@@ -105,4 +105,61 @@ public sealed class SvgTransformTests
         AssertMaps(page, 100, 50, 100, 50);
         AssertMaps(page, 110, 50, 100, 60);
     }
+
+    // TryParse separates the two things the transform alone cannot: a list that resolved to the
+    // identity because it *is* the identity, and one that resolved to it because nothing in it
+    // parsed. A caller deciding whether a CSS declaration beats a `transform` presentation
+    // attribute has to tell those apart — CSS Transforms 1 §3 drops an invalid declaration whole,
+    // so the attribute stands, while a valid identity still wins. The bridge's projection of a
+    // cascaded `transform` onto SVG markup is that caller, and the nine
+    // css-transforms/svg-{document,external,inline}-styles-005/006/013 tests are the assertion:
+    // each declares `transform: scale(invalid)` over a real `transform="rotate(90)"`.
+    [Theory]
+    [InlineData("rotate(90deg)")]
+    [InlineData("rotate(0deg)")]
+    [InlineData("scale(1)")]
+    [InlineData("translate(0)")]
+    [InlineData("matrix(1, 0, 0, 1, 0, 0)")]
+    public void TryParse_Accepts_A_List_Whose_Functions_Parse(string value)
+    {
+        Assert.True(SvgTransform.TryParse(value, out _));
+    }
+
+    [Theory]
+    [InlineData("scale(invalid)")]
+    [InlineData("rotate()")]
+    [InlineData("none")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("nonsense(3)")]
+    [InlineData("matrix(1, 0, 0)")]
+    public void TryParse_Rejects_A_List_With_No_Function_In_It(string value)
+    {
+        Assert.False(SvgTransform.TryParse(value, out var transform));
+        Assert.True(transform.IsIdentity);
+    }
+
+    // A valid list that resolves to the identity is accepted, and that is the whole point of
+    // reporting acceptance separately from the value.
+    [Fact(Timeout = 600000)]
+    public void A_Valid_Identity_Is_Accepted_And_Is_Still_The_Identity()
+    {
+        Assert.True(SvgTransform.TryParse("rotate(0deg)", out var transform));
+        Assert.True(transform.IsIdentity);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Parse_Still_Answers_The_Identity_For_Everything_TryParse_Rejects()
+    {
+        Assert.True(SvgTransform.Parse("scale(invalid)").IsIdentity);
+        Assert.True(SvgTransform.Parse(null).IsIdentity);
+        Assert.Equal(SvgTransform.Parse("translate(10 20)"), Translated());
+
+        static SvgTransform Translated()
+        {
+            SvgTransform.TryParse("translate(10 20)", out var t);
+            return t;
+        }
+    }
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -718,7 +718,18 @@ internal static partial class CssUtils
                 cssBox.BackgroundColor = value;
                 break;
             case "background-image":
-                cssBox.BackgroundImage = value;
+                // CSS Images 4 §5.4: `image-set()` is resolved to the one image it selects before
+                // anything downstream reads the value. The background loader looks for `url(` and
+                // the paint walker looks for `gradient(` to tell a fetched layer from a drawn one,
+                // so an unresolved `image-set(...)` was neither — it loaded nothing and drew
+                // nothing, whichever kind of image it held. Unwrapping it here leaves both of them
+                // reading a value they already understand.
+                //
+                // An invalid function (a negative resolution) leaves the property alone rather than
+                // overwriting it, which is what a dropped declaration does: the value already set
+                // is the one that was cascaded under it.
+                if (IR.CssImageSet.TryResolveLayers(value, out var resolvedImage))
+                    cssBox.BackgroundImage = resolvedImage;
                 break;
             case "background-position":
                 cssBox.BackgroundPosition = value;

--- a/Broiler.Layout/Broiler.Layout/Engine/DisplayContentsBoxes.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/DisplayContentsBoxes.cs
@@ -58,6 +58,25 @@ internal static class DisplayContentsBoxes
         Flatten(root);
     }
 
+    /// <summary>
+    /// Whether this box is a document's root element, which CSS Display 3 §2.3 blockifies — so
+    /// <c>contents</c> on it is <c>block</c> and it keeps its box.
+    /// </summary>
+    /// <remarks>
+    /// The box <see cref="Generate"/> is handed is the anonymous <em>document</em> box the parse
+    /// creates, not the root element: <c>&lt;html&gt;</c> is a child of it. Blockifying only the box
+    /// we were given therefore left the actual root element to be spliced out like any other
+    /// wrapper — and with it went the canvas, because the canvas background is the root element's
+    /// (CSS Backgrounds §2.11.2). The test that names this reads
+    /// <c>:root { display: contents; background-image: url(…) }</c> and asks for a green page;
+    /// Broiler painted the page's text on white
+    /// (<c>css/css-display/display-contents-root-background</c>). Recognised by tag rather than by
+    /// position so a sub-document's root element — an <c>&lt;iframe&gt;</c>'s, projected under a
+    /// sub-viewport box — is covered by the same rule, which is the rule its own document is
+    /// entitled to.
+    /// </remarks>
+    private static bool IsBlockifiedRootElement(CssBox box) => CssBoxHelper.IsRootElement(box);
+
     private static void Flatten(CssBox box)
     {
         // Depth first: a chain of nested `contents` boxes collapses from the inside out, so by the
@@ -70,6 +89,12 @@ internal static class DisplayContentsBoxes
         {
             if (child.Display != Contents)
                 continue;
+
+            if (IsBlockifiedRootElement(child))
+            {
+                child.Display = CssConstants.Block;
+                continue;
+            }
 
             // CSS Display 3 §3.1: on an element whose rendering is not purely CSS-based —
             // a replaced element or a form control — `contents` computes to `none` instead.

--- a/Broiler.Layout/Broiler.Layout/IR/AffineLayerMap.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/AffineLayerMap.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Drawing;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// The device-space affine map a rotated or skewed CSS <c>transform</c> becomes when its content
+/// has been drawn, untransformed, into an offscreen layer: given a destination pixel it says which
+/// point of that layer lands there (<see cref="InverseMap"/>), and given the layer's occupied
+/// region it says where that region ends up (<see cref="MapBounds"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A raster canvas that maps a point per axis — <c>p → p·scale + translation</c>, which is what
+/// Broiler's does — can express translation and axis-aligned scale, mirrors included, but nothing
+/// with a <c>b</c> or <c>c</c> term. Those used to fall through to a compat backend that on a
+/// headless host is an inert stub, so a rotated element and its whole subtree were not drawn
+/// <em>at all</em>: <c>transform: rotate(45deg)</c> on a green square painted a blank page. The
+/// graceful degradations beside it (opacity, filter, blend) had already been moved off that
+/// fall-through; the transform one is this.
+/// </para>
+/// <para>
+/// **Warping the finished layer, rather than teaching every primitive an affine matrix.** Content
+/// is drawn into a full-surface offscreen with the ordinary axis-aligned mapping, so every
+/// primitive — fills, text, images, clips — keeps the arithmetic it already has, and one resample
+/// puts the result where the transform says. Inverse mapping (destination → source) is what makes
+/// it hole-free: a forward scatter leaves gaps wherever the transform magnifies.
+/// </para>
+/// <para>
+/// The map lives here rather than beside the canvas because it is arithmetic with no pixels in it,
+/// and because the canvas is in a submodule: the caller there is a loop over
+/// <see cref="MapBounds"/> calling <see cref="InverseMap"/>, and everything that can be got wrong
+/// is on this side, under test.
+/// </para>
+/// </remarks>
+public readonly struct AffineLayerMap
+{
+    // The device-space forward map, q = B·d + w, and the inverse of B.
+    private readonly float _b00, _b01, _b10, _b11;
+    private readonly float _wx, _wy;
+    private readonly float _i00, _i01, _i10, _i11;
+
+    private AffineLayerMap(
+        float b00, float b01, float b10, float b11,
+        float wx, float wy,
+        float i00, float i01, float i10, float i11)
+    {
+        _b00 = b00; _b01 = b01; _b10 = b10; _b11 = b11;
+        _wx = wx; _wy = wy;
+        _i00 = i00; _i01 = i01; _i10 = i10; _i11 = i11;
+    }
+
+    /// <summary>
+    /// The <c>b</c>/<c>c</c> magnitude below which a matrix is treated as axis-aligned, matching the
+    /// canvas's own test so exactly one of the two paths claims a given matrix.
+    /// </summary>
+    public const float AxisAlignedEpsilon = 1e-4f;
+
+    /// <summary>
+    /// Whether <paramref name="matrix"/> is expressible as translation plus per-axis scale — the
+    /// case a per-axis canvas handles directly, and which must therefore <em>not</em> take the
+    /// layer path: warping a layer costs an offscreen surface and a resample, and would also
+    /// resample content the direct path places exactly.
+    /// </summary>
+    public static bool IsAxisAligned(float[] matrix) =>
+        matrix is null
+        || matrix.Length < 6
+        || (MathF.Abs(matrix[1]) <= AxisAlignedEpsilon && MathF.Abs(matrix[2]) <= AxisAlignedEpsilon);
+
+    /// <summary>
+    /// Builds the map for a CSS <c>matrix(a, b, c, d, e, f)</c> applied about
+    /// (<paramref name="originX"/>, <paramref name="originY"/>) in canvas-local coordinates, on a
+    /// canvas whose own mapping is <c>p → p·scale + translation</c>. Returns <see langword="false"/>
+    /// for an axis-aligned matrix (the caller's fast path owns it) and for a singular one, which
+    /// collapses the element to a line or a point and has nothing to sample back through.
+    /// </summary>
+    public static bool TryCreate(
+        float[] matrix,
+        float originX,
+        float originY,
+        float surfaceScaleX,
+        float surfaceScaleY,
+        float surfaceTranslateX,
+        float surfaceTranslateY,
+        out AffineLayerMap map)
+    {
+        map = default;
+
+        if (IsAxisAligned(matrix))
+            return false;
+        if (surfaceScaleX == 0f || surfaceScaleY == 0f
+            || !float.IsFinite(surfaceScaleX) || !float.IsFinite(surfaceScaleY)
+            || !float.IsFinite(surfaceTranslateX) || !float.IsFinite(surfaceTranslateY)
+            || !float.IsFinite(originX) || !float.IsFinite(originY))
+            return false;
+
+        float a = matrix[0], b = matrix[1], c = matrix[2], d = matrix[3], e = matrix[4], f = matrix[5];
+        for (int i = 0; i < 6; i++)
+        {
+            if (!float.IsFinite(matrix[i]))
+                return false;
+        }
+
+        // CSS matrix(a,b,c,d,e,f) is x' = a·x + c·y + e, y' = b·x + d·y + f — so the linear part is
+        // A = [[a, c], [b, d]], read row-wise.
+        //
+        // Content sits in the layer at its *device* position D(p) = S·p + t, and must end up at
+        // D(T(p)) where T(p) = A·(p − O) + O + E. Eliminating p gives a device-to-device map
+        //     W(d) = B·d + w,   B = S·A·S⁻¹,   w = t − B·t + S·(O − A·O + E),
+        // which is what this stores. Conjugating by S rather than assuming a uniform surface scale
+        // keeps it exact when the two axes differ.
+        float sx = surfaceScaleX, sy = surfaceScaleY;
+        float b00 = a, b01 = c * sx / sy, b10 = b * sy / sx, b11 = d;
+
+        float det = b00 * b11 - b01 * b10;
+        if (MathF.Abs(det) < 1e-9f || !float.IsFinite(det))
+            return false;
+
+        // S·(O − A·O + E), per axis.
+        float ax = a * originX + c * originY;
+        float ay = b * originX + d * originY;
+        float sOx = sx * (originX - ax + e);
+        float sOy = sy * (originY - ay + f);
+
+        float tx = surfaceTranslateX, ty = surfaceTranslateY;
+        float wx = tx - (b00 * tx + b01 * ty) + sOx;
+        float wy = ty - (b10 * tx + b11 * ty) + sOy;
+
+        float inv = 1f / det;
+        map = new AffineLayerMap(
+            b00, b01, b10, b11,
+            wx, wy,
+            b11 * inv, -b01 * inv, -b10 * inv, b00 * inv);
+        return true;
+    }
+
+    /// <summary>
+    /// Where a device-space rectangle of layer content lands: the axis-aligned bounding box of its
+    /// four mapped corners. A rotation makes that box larger than the rectangle, which is the point
+    /// — the caller iterates it to find every destination pixel the content can reach.
+    /// </summary>
+    public RectangleF MapBounds(RectangleF source)
+    {
+        MapPoint(source.Left, source.Top, out float x0, out float y0);
+        MapPoint(source.Right, source.Top, out float x1, out float y1);
+        MapPoint(source.Right, source.Bottom, out float x2, out float y2);
+        MapPoint(source.Left, source.Bottom, out float x3, out float y3);
+
+        float minX = MathF.Min(MathF.Min(x0, x1), MathF.Min(x2, x3));
+        float maxX = MathF.Max(MathF.Max(x0, x1), MathF.Max(x2, x3));
+        float minY = MathF.Min(MathF.Min(y0, y1), MathF.Min(y2, y3));
+        float maxY = MathF.Max(MathF.Max(y0, y1), MathF.Max(y2, y3));
+
+        return RectangleF.FromLTRB(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
+    /// The other direction: which part of the layer can reach a destination rectangle. This is what
+    /// keeps a warp layer affordable — the content drawn into it can be bounded to the pre-image of
+    /// whatever is still visible, so a rasterizer inside the layer keeps a box to clip and cull
+    /// against instead of walking the whole surface for every fill.
+    /// </summary>
+    public RectangleF InverseMapBounds(RectangleF destination)
+    {
+        InverseMap(destination.Left, destination.Top, out float x0, out float y0);
+        InverseMap(destination.Right, destination.Top, out float x1, out float y1);
+        InverseMap(destination.Right, destination.Bottom, out float x2, out float y2);
+        InverseMap(destination.Left, destination.Bottom, out float x3, out float y3);
+
+        float minX = MathF.Min(MathF.Min(x0, x1), MathF.Min(x2, x3));
+        float maxX = MathF.Max(MathF.Max(x0, x1), MathF.Max(x2, x3));
+        float minY = MathF.Min(MathF.Min(y0, y1), MathF.Min(y2, y3));
+        float maxY = MathF.Max(MathF.Max(y0, y1), MathF.Max(y2, y3));
+
+        return RectangleF.FromLTRB(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>Forward: where the layer's device point (<paramref name="x"/>, <paramref name="y"/>)
+    /// is drawn.</summary>
+    public void MapPoint(float x, float y, out float destX, out float destY)
+    {
+        destX = _b00 * x + _b01 * y + _wx;
+        destY = _b10 * x + _b11 * y + _wy;
+    }
+
+    /// <summary>Inverse: which point of the layer is drawn at the destination point
+    /// (<paramref name="destX"/>, <paramref name="destY"/>). This is the direction the resample runs
+    /// in, so that every destination pixel gets a value and none is skipped.</summary>
+    public void InverseMap(float destX, float destY, out float x, out float y)
+    {
+        float dx = destX - _wx, dy = destY - _wy;
+        x = _i00 * dx + _i01 * dy;
+        y = _i10 * dx + _i11 * dy;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/CssImageSet.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/CssImageSet.cs
@@ -1,0 +1,434 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS Images 4 §5.4 <c>image-set()</c>: picks the one option a device should load out of a set
+/// offered at several resolutions and types, and hands back the plain <c>&lt;image&gt;</c> it names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolving it here rather than at the point of loading is what makes it work for every kind of
+/// image the function can hold. An <c>image-set()</c> layer reached the background loader, which
+/// looks for <c>url(</c> and found a function it did not know, so the layer loaded nothing; and it
+/// reached the paint walker, which looks for <c>gradient(</c> to decide whether a layer is drawn
+/// rather than fetched — so <c>image-set(linear-gradient(…) 1x)</c> was neither. Unwrapping the
+/// value before either of them looks at it leaves both reading exactly what they already
+/// understand.
+/// </para>
+/// <para>
+/// <b>Invalid and "selects nothing" are different answers</b>, and two WPT tests are built to tell
+/// them apart. A negative resolution is a parse error, so the whole declaration is dropped and the
+/// previous one applies (<c>image-set-negative-resolution-rendering-2</c> puts a green
+/// <c>url()</c> behind it and expects green). A zero resolution parses, but no option survives it,
+/// so the declaration applies and paints nothing — <c>image-set-zero-resolution-rendering</c> puts
+/// a <em>red</em> <c>url()</c> behind it and expects a blank page.
+/// </para>
+/// </remarks>
+internal static class CssImageSet
+{
+    /// <summary>1x, in the units each <c>&lt;resolution&gt;</c> unit measures.</summary>
+    private const double DotsPerInchAt1x = 96.0;
+    private const double DotsPerCentimetreAt1x = 96.0 / 2.54;
+
+    /// <summary>
+    /// The image types this engine can decode, which is what <c>type()</c> is asked about. An
+    /// option naming anything else is skipped — that is the point of the modifier, and
+    /// <c>image-set-type-skip-unsupported-rendering</c> offers a red one first to check it happens.
+    /// </summary>
+    private static readonly HashSet<string> SupportedTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/png", "image/jpeg", "image/jpg", "image/gif", "image/bmp", "image/x-icon",
+        "image/vnd.microsoft.icon", "image/webp", "image/svg+xml", "image/apng",
+    };
+
+    /// <summary>Whether <paramref name="value"/> is an <c>image-set()</c> function — the prefixed
+    /// spelling included, which is still what a good deal of the web ships.</summary>
+    internal static bool IsImageSet(string? value) =>
+        TryGetArguments(value, out _);
+
+    /// <summary>
+    /// The device resolution the renderer draws at. Page zoom is baked into used values before
+    /// paint rather than carried as a device ratio, so this is 1 — and it is named rather than
+    /// written as a literal because it is the input the selection is *about*.
+    /// </summary>
+    internal const double RendererDevicePixelRatio = 1.0;
+
+    /// <summary>
+    /// Resolves every <c>image-set()</c> layer of a comma-separated image property, leaving every
+    /// other layer byte-identical. Returns <see langword="false"/> when any layer is a parse error,
+    /// which invalidates the declaration as a whole (CSS Syntax 3 §9: a declaration is dropped
+    /// whole or not at all) — the caller then leaves the property at the value cascaded under it.
+    /// </summary>
+    internal static bool TryResolveLayers(string? value, out string resolved)
+    {
+        resolved = value ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(value) || value.IndexOf("image-set(", StringComparison.OrdinalIgnoreCase) < 0)
+            return true;
+
+        var layers = SplitTopLevel(value, ',');
+        var rewritten = new List<string>(layers.Count);
+        bool changed = false;
+
+        foreach (var layer in layers)
+        {
+            if (!IsImageSet(layer))
+            {
+                rewritten.Add(layer);
+                continue;
+            }
+
+            if (!TryResolve(layer, RendererDevicePixelRatio, out var image))
+                return false;
+
+            // A function that selects nothing is a valid image that paints nothing, which is what
+            // `none` already means to every reader of this value.
+            rewritten.Add(image ?? "none");
+            changed = true;
+        }
+
+        if (changed)
+            resolved = string.Join(", ", rewritten);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves an <c>image-set()</c> layer to the <c>&lt;image&gt;</c> it selects for a display of
+    /// <paramref name="devicePixelRatio"/>. Returns <see langword="false"/> when the function is a
+    /// parse error and the declaration carrying it must be dropped whole; <see langword="true"/>
+    /// with <paramref name="image"/> <see langword="null"/> when it parses but no option survives.
+    /// </summary>
+    internal static bool TryResolve(string? value, double devicePixelRatio, out string? image)
+    {
+        image = null;
+        if (!TryGetArguments(value, out var arguments))
+            return false;
+
+        string? best = null;
+        double bestResolution = 0;
+
+        foreach (var option in SplitTopLevel(arguments, ','))
+        {
+            if (!TryParseOption(option, out var candidate, out double resolution, out bool usable))
+                return false;   // a parse error anywhere invalidates the whole function
+
+            if (!usable)
+                continue;
+
+            // CSS Images 4 leaves the choice to the UA; every engine takes the smallest resolution
+            // that is at least the device's, and the largest on offer when none is. Ties go to the
+            // first, which `image-set-first-match-rendering` states by offering two at 1x.
+            if (best is null || Better(resolution, bestResolution, devicePixelRatio))
+            {
+                best = candidate;
+                bestResolution = resolution;
+            }
+        }
+
+        image = best;
+        return true;
+    }
+
+    /// <summary>Whether <paramref name="candidate"/> is a better match for
+    /// <paramref name="devicePixelRatio"/> than <paramref name="incumbent"/>.</summary>
+    private static bool Better(double candidate, double incumbent, double devicePixelRatio)
+    {
+        bool candidateReaches = candidate >= devicePixelRatio;
+        bool incumbentReaches = incumbent >= devicePixelRatio;
+
+        if (candidateReaches != incumbentReaches)
+            return candidateReaches;
+
+        // Both above the device's resolution: the smaller wins, being the least oversampled. Both
+        // below it: the larger wins, being the least blurred. Equal: the incumbent came first.
+        return candidateReaches ? candidate < incumbent : candidate > incumbent;
+    }
+
+    /// <summary>
+    /// Parses one option — an <c>&lt;image&gt;</c> with an optional <c>&lt;resolution&gt;</c> and an
+    /// optional <c>type()</c>, in either order. <paramref name="usable"/> is <see langword="false"/>
+    /// for an option that parses but this device cannot take: an unsupported type, an empty URL, or
+    /// a zero resolution. A <see langword="false"/> return is a parse error.
+    /// </summary>
+    private static bool TryParseOption(string option, out string? image, out double resolution, out bool usable)
+    {
+        image = null;
+        resolution = 1.0;   // an omitted resolution is 1x — `image-set-no-res-rendering`
+        usable = false;
+
+        bool sawResolution = false;
+        bool sawType = false;
+        bool typeSupported = true;
+
+        foreach (var token in SplitTopLevel(option, ' '))
+        {
+            if (token.Length == 0)
+                continue;
+
+            if (StartsWithFunction(token, "type", out var typeArgument))
+            {
+                if (sawType)
+                    return false;
+                sawType = true;
+                typeSupported = SupportedTypes.Contains(Unquote(typeArgument).Trim());
+                continue;
+            }
+
+            if (TryParseResolution(token, out double parsed))
+            {
+                if (sawResolution)
+                    return false;
+                sawResolution = true;
+                if (parsed < 0)
+                    return false;   // negative: a parse error, not an unusable option
+                resolution = parsed;
+                continue;
+            }
+
+            if (image is not null)
+                return false;       // two images in one option
+
+            // `<string>` is an image in this function, the same as wrapping it in url() —
+            // `image-set-no-url-rendering` writes it that way.
+            image = token.Length > 1 && (token[0] == '"' || token[0] == '\'')
+                ? "url(" + token + ")"
+                : token;
+        }
+
+        if (image is null)
+            return false;
+
+        usable = typeSupported && resolution > 0 && !IsEmptyUrl(image);
+        return true;
+    }
+
+    /// <summary>An option whose URL is empty names no image, so it is skipped rather than
+    /// selected — <c>image-set-empty-url-rendering</c> offers one at 2x behind a green 1x.</summary>
+    private static bool IsEmptyUrl(string image) =>
+        StartsWithFunction(image, "url", out var argument) && Unquote(argument).Trim().Length == 0;
+
+    /// <summary>
+    /// A <c>&lt;resolution&gt;</c> in multiples of 1x, or <see langword="false"/> when the token is
+    /// not one. <c>calc()</c> is evaluated only far enough to cover a resolution expression, which
+    /// is a product or quotient of one resolution and plain numbers — <c>calc(0.5x * 2)</c>.
+    /// </summary>
+    private static bool TryParseResolution(string token, out double resolution)
+    {
+        resolution = 0;
+
+        if (StartsWithFunction(token, "calc", out var expression))
+            return TryEvaluateResolutionProduct(expression, out resolution);
+
+        return TryParseResolutionLiteral(token, out resolution);
+    }
+
+    private static bool TryParseResolutionLiteral(string token, out double resolution)
+    {
+        resolution = 0;
+        var (number, unit) = SplitNumberAndUnit(token);
+        if (number is null || unit.Length == 0)
+            return false;
+
+        if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
+            return false;
+
+        switch (unit.ToLowerInvariant())
+        {
+            case "x":
+            case "dppx":
+                resolution = value;
+                return true;
+            case "dpi":
+                resolution = value / DotsPerInchAt1x;
+                return true;
+            case "dpcm":
+                resolution = value / DotsPerCentimetreAt1x;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Evaluates <c>calc()</c> over a single resolution and plain numbers, left to right with no
+    /// precedence — which is all a resolution expression can be, because multiplying two
+    /// resolutions is not one. Anything else is declined and the token is then not a resolution.
+    /// </summary>
+    private static bool TryEvaluateResolutionProduct(string expression, out double resolution)
+    {
+        resolution = 0;
+        var tokens = SplitTopLevel(expression, ' ');
+        if (tokens.Count == 0)
+            return false;
+
+        double? accumulator = null;
+        bool sawResolutionTerm = false;
+        string pendingOperator = "*";
+
+        foreach (var token in tokens)
+        {
+            if (token is "*" or "/")
+            {
+                pendingOperator = token;
+                continue;
+            }
+
+            if (token is "+" or "-")
+                return false;   // adding a resolution to a number is not a resolution
+
+            double term;
+            if (TryParseResolutionLiteral(token, out double asResolution))
+            {
+                if (sawResolutionTerm)
+                    return false;
+                sawResolutionTerm = true;
+                term = asResolution;
+            }
+            else if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out term))
+            {
+                return false;
+            }
+
+            if (accumulator is null)
+                accumulator = term;
+            else if (pendingOperator == "*")
+                accumulator *= term;
+            else if (term == 0)
+                return false;
+            else
+                accumulator /= term;
+        }
+
+        if (accumulator is null || !sawResolutionTerm)
+            return false;
+
+        resolution = accumulator.Value;
+        return true;
+    }
+
+    private static (string? Number, string Unit) SplitNumberAndUnit(string token)
+    {
+        int i = 0;
+        if (i < token.Length && (token[i] == '+' || token[i] == '-'))
+            i++;
+        int digitsStart = i;
+        while (i < token.Length && (char.IsAsciiDigit(token[i]) || token[i] == '.'))
+            i++;
+        if (i == digitsStart)
+            return (null, string.Empty);
+
+        // An exponent is part of the number, not the unit: `1e2dppx` is a hundred.
+        if (i < token.Length && (token[i] == 'e' || token[i] == 'E'))
+        {
+            int save = i;
+            i++;
+            if (i < token.Length && (token[i] == '+' || token[i] == '-'))
+                i++;
+            int expStart = i;
+            while (i < token.Length && char.IsAsciiDigit(token[i]))
+                i++;
+            if (i == expStart)
+                i = save;
+        }
+
+        return (token[..i], token[i..]);
+    }
+
+    /// <summary>The arguments of an <c>image-set()</c> function, or <see langword="false"/> when
+    /// <paramref name="value"/> is not one.</summary>
+    private static bool TryGetArguments(string? value, out string arguments)
+    {
+        arguments = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var trimmed = value.Trim();
+        return StartsWithFunction(trimmed, "image-set", out arguments)
+            || StartsWithFunction(trimmed, "-webkit-image-set", out arguments);
+    }
+
+    /// <summary>Whether <paramref name="value"/> is the named function, and its argument text.</summary>
+    private static bool StartsWithFunction(string value, string name, out string arguments)
+    {
+        arguments = string.Empty;
+        if (value.Length < name.Length + 2
+            || !value.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+            || value[name.Length] != '('
+            || value[^1] != ')')
+            return false;
+
+        arguments = value[(name.Length + 1)..^1];
+        return true;
+    }
+
+    private static string Unquote(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length >= 2 && ((trimmed[0] == '"' && trimmed[^1] == '"') || (trimmed[0] == '\'' && trimmed[^1] == '\''))
+            ? trimmed[1..^1]
+            : trimmed;
+    }
+
+    /// <summary>
+    /// Splits on <paramref name="separator"/> at nesting depth zero, so a nested function — a
+    /// gradient, a <c>url()</c> holding a comma, a <c>calc()</c> — stays in one piece. A space
+    /// separator collapses runs of whitespace.
+    /// </summary>
+    private static List<string> SplitTopLevel(string value, char separator)
+    {
+        var parts = new List<string>();
+        int depth = 0, start = 0;
+        bool inString = false;
+        char quote = '\0';
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+
+            if (inString)
+            {
+                if (c == quote)
+                    inString = false;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                case '\'':
+                    inString = true;
+                    quote = c;
+                    break;
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    if (depth > 0)
+                        depth--;
+                    break;
+                default:
+                    if (depth == 0 && Separates(c, separator))
+                    {
+                        Add(value[start..i]);
+                        start = i + 1;
+                    }
+                    break;
+            }
+        }
+
+        Add(value[start..]);
+        return parts;
+
+        static bool Separates(char c, char separator) =>
+            separator == ' ' ? char.IsWhiteSpace(c) : c == separator;
+
+        void Add(string part)
+        {
+            part = part.Trim();
+            if (part.Length > 0 || separator != ' ')
+                parts.Add(part);
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgTransform.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgTransform.cs
@@ -23,8 +23,23 @@ internal readonly partial record struct SvgTransform(float A, float B, float C, 
     /// <summary>Parses a transform list; an absent or unparseable list is the identity.</summary>
     public static SvgTransform Parse(string? transformList)
     {
+        TryParse(transformList, out var transform);
+        return transform;
+    }
+
+    /// <summary>
+    /// Parses a transform list, reporting separately whether <em>any</em> function in it was
+    /// recognised. The transform alone cannot say: an unparseable list and a list that genuinely
+    /// resolves to the identity — <c>rotate(0deg)</c>, <c>scale(1)</c> — both come out as
+    /// <see cref="Identity"/>, and a caller deciding whether a declaration beats a presentation
+    /// attribute has to tell those apart. CSS Transforms 1 §3 drops an invalid declaration whole,
+    /// so the attribute stands; a valid one that happens to be the identity still wins.
+    /// </summary>
+    public static bool TryParse(string? transformList, out SvgTransform transform)
+    {
+        transform = Identity;
         if (string.IsNullOrWhiteSpace(transformList))
-            return Identity;
+            return false;
 
         var result = Identity;
         bool any = false;
@@ -61,7 +76,9 @@ internal readonly partial record struct SvgTransform(float A, float B, float C, 
             any = true;
         }
 
-        return any ? result : Identity;
+        if (any)
+            transform = result;
+        return any;
     }
 
     /// <summary><c>rotate(angle, cx, cy)</c>: a rotation about an arbitrary centre.</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,17 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- A `<link rel="stylesheet" href="data:text/css,…">` now contributes its rules to
+  the cascade and the CSSOM, and fires `load` rather than `error`. The sheet is in
+  the URL, so there is nothing to fetch — but the href went to the resource loader
+  like any other, and that loader dispatches `file` and `http(s)` only, so the
+  sheet came back empty. The renderer's own loader has always decoded `data:`
+  URIs, which is what hid it: such a sheet *painted*, while `getComputedStyle`
+  and the link's load event both reported it as not loaded.
+  A page that builds the link from script and waits on `link.onload` before doing
+  its next step therefore waited forever. `@import url(data:text/css,…)` was
+  already decoded in process; both call sites now go through that one seam.
+
 - The desktop browser paints a page's load window while it runs, instead of only
   its final state. Settling the load window on the load worker took the page's
   callbacks out of the message pump, which is what stopped www.google.com hanging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,24 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- An SVG used as an image keeps the intrinsic aspect ratio its `viewBox` gives it
+  even when it declares `preserveAspectRatio="none"`, and reports an absolute
+  `width` or `height` it states even when the other one is missing. SVG 2 §8.2
+  derives the intrinsic sizing properties from `width`/`height`/`viewBox` alone —
+  `preserveAspectRatio` governs how the content is fitted once the viewport size
+  is known, which is a later question than what size the image asks to be. Reading
+  `none` as "no intrinsic ratio" made every such image size to the whole
+  background positioning area, so a `background-size: contain` that should paint a
+  16×256 strip stretched across the full 768×256 box instead. Measured over the
+  full WPT reftest suite: 18 776 → 18 844 passing, +68 / −0.
+
+- `display: contents` on the root element no longer takes the page's canvas with
+  it. The root element is blockified (CSS Display 3 §2.3) and the rule was
+  implemented, but it was applied to the anonymous document box the parse creates
+  rather than to the `<html>` box beneath it — so the real root element was
+  spliced out like any other wrapper, and the canvas background, which is the root
+  element's, went with it.
+
 - A `<link rel="stylesheet" href="data:text/css,…">` now contributes its rules to
   the cascade and the CSSOM, and fires `load` rather than `error`. The sheet is in
   the URL, so there is nothing to fetch — but the href went to the resource loader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,16 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `image-set()` picks an image instead of painting nothing. It was recognised as
+  an image value and never resolved, so the layer reached two readers that each
+  understand only part of what the function can hold — the background loader
+  looks for `url(`, the paint walker looks for `gradient(` — and whichever kind
+  of image it named, nothing was drawn. The selection is now resolved into the
+  value before either of them sees it: resolution units (`x`/`dppx`, `dpi`,
+  `dpcm`, `calc()`), an omitted resolution as 1x, `type()` filtering, and the
+  smallest resolution that reaches the display, largest when none does, first on
+  a tie. The selected resolution does not yet scale the image's intrinsic size.
+
 - A CSS `transform` rule applies to an SVG element. The renderer reads an
   element's transform off the markup and sees no stylesheet, so the cascaded
   value is projected onto the SVG presentation attribute — `transform-box` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,15 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- A CSS `transform` rule applies to an SVG element. The renderer reads an
+  element's transform off the markup and sees no stylesheet, so the cascaded
+  value is projected onto the SVG presentation attribute — `transform-box` and
+  `transform-origin` were, and `transform` itself was not, so
+  `rect { transform: rotate(90deg) }` did nothing at all. A declaration that
+  parses no transform function is skipped rather than written, which is what
+  makes an invalid one fall back to the `transform` attribute instead of
+  destroying it (CSS Transforms 1 §3).
+
 - A rotated or skewed element is painted. `transform: rotate(45deg)` on a green
   square produced a **blank page** — and took its whole subtree with it, so a page
   that rotates a wrapper lost everything inside it. The raster canvas maps a point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,18 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- A rotated or skewed element is painted. `transform: rotate(45deg)` on a green
+  square produced a **blank page** — and took its whole subtree with it, so a page
+  that rotates a wrapper lost everything inside it. The raster canvas maps a point
+  per axis, so translation and axis-aligned scale fold into its own state and a
+  rotation does not; those fell through to a compat backend that on a headless host
+  is an inert stub, and the fall-through also stops every draw the group encloses
+  from reaching the canvas at all. Such a transform now opens a layer the contents
+  draw into untransformed, resampled through the matrix on the way out — so every
+  primitive keeps the arithmetic it already has. Ancestor clips are applied to the
+  transformed result rather than to the content on its way in, which is where
+  CSS Transforms 1 §3 puts them.
+
 - An SVG used as an image keeps the intrinsic aspect ratio its `viewBox` gives it
   even when it declares `preserveAspectRatio="none"`, and reports an absolute
   `width` or `height` it states even when the other one is missing. SVG 2 §8.2

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -255,6 +255,18 @@ argument for reading it as a ranking of blast radius rather than a work queue.
 Issue #1716's actual defect was found by ignoring that list and asking why a
 63-test family was failing uniformly — see the mismatch-comparison section above.
 
+**The streak ended at
+[issue #1788](https://github.com/Broiler-Platform/Broiler/issues/1788), and how it
+ended is the usable part.** Its top thirty opens with the same three unwinnables —
+`root-box-003`, `forced-colors-mode-49`, the 60×60 bitmap reference — and its #2,
+`css-backgrounds/background-image-shared-stylesheet`, was a real defect that
+[now passes at 100%](wpt-rendering-gaps-fixed.md#a-datatextcss-link-contributed-nothing-to-the-cascade).
+It was findable because it was the one entry on the list that already carried a
+diagnosis: the gaps file said what the 5.7% was made of down to the 300×150 pixels.
+So the rule the streak taught still holds — **do not start at the top of the list** —
+but the refinement is that the entries worth starting from are the ones a previous
+triage has already reduced, wherever they sit in the ranking.
+
 - **The runner cannot represent what the test builds.** The rarest answer and
   the hardest to see, because the render is neither wrong nor honest — it is of
   a *different document*. Two distinct versions of this, and the fix for the

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -267,6 +267,30 @@ So the rule the streak taught still holds — **do not start at the top of the l
 but the refinement is that the entries worth starting from are the ones a previous
 triage has already reduced, wherever they sit in the ranking.
 
+**The better entry point is the run's own manifest, not its issue.**
+`tests/wpt-baseline/failed-reftests.json` records every failure, so grouping it by
+directory ranks *families* rather than individual severities — and a family that
+fails uniformly is one bug however mild each instance looks. Two rows of that
+grouping paid for themselves on #1788. `css/css-backgrounds/background-size` (65
+failures, three rows below `grid-lanes`) turned out to be a single wrong reading of
+`preserveAspectRatio`, worth
+[+68 / −0](wpt-rendering-gaps-fixed.md#an-svgs-viewbox-stopped-giving-it-an-intrinsic-ratio-when-preserveaspectratio-none)
+over the whole suite; `css/css-display` had just 9, of which the top-thirty entry
+`display-contents-root-background` was
+[the root element never being blockified](wpt-rendering-gaps-fixed.md#display-contents-on-the-root-element-took-the-canvas-with-it).
+Neither is visible as a *cluster* from the severity ranking, which by design shows
+one line per test.
+
+```sh
+python3 - <<'PY'
+import json, collections
+d = json.load(open('tests/wpt-baseline/failed-reftests.json'))
+paths = [x['relativeTestPath'] for x in d['results']]
+for k, v in collections.Counter('/'.join(p.split('/')[:3]) for p in paths).most_common(25):
+    print(f"{v:5d}  {k}")
+PY
+```
+
 - **The runner cannot represent what the test builds.** The rarest answer and
   the hardest to see, because the render is neither wrong nor honest — it is of
   a *different document*. Two distinct versions of this, and the fix for the

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -292,6 +292,19 @@ PY
 ```
 
 
+
+## A single-run diff carries about one test of noise
+
+`css/compositing/background-blending/background-blend-mode-plus-lighter` renders at **93.6%** every
+time it is run on its own, and came back **100.0%** in one full sweep out of four. Nothing about the
+test is timing-dependent; what varies is what ran before it in the same worker. So a before/after
+diff taken from one run of each carries roughly a test of noise in both directions, and a change
+whose whole claim is ±1 needs the suspect test re-run on its own before the number is believed —
+which costs seconds, against the twenty minutes a second sweep costs.
+
+The rule that follows: **a single test that moves against the direction of a change is noise until
+re-run in isolation**, and one that moves *with* it is not evidence on its own either.
+
 ## The 98–99% band is not a work queue either, and it is a trap that looks like one
 
 Ranking the reftest failures by match percentage puts **3 207 of 7 373 — 44% — in a single

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -291,6 +291,27 @@ for k, v in collections.Counter('/'.join(p.split('/')[:3]) for p in paths).most_
 PY
 ```
 
+
+## The 98–99% band is not a work queue either, and it is a trap that looks like one
+
+Ranking the reftest failures by match percentage puts **3 207 of 7 373 — 44% — in a single
+98–99% bucket**, just under the gate, with another 1 193 in 97–98%. That reads like one
+systematic near-miss with one cause behind it, and it is not: it is a property of the
+*canvas*, not of the engine. A reftest's subject is usually a small box on a 1024×768
+viewport, and a 100×100 square is 1.27% of it — so a test whose square is **completely
+wrong** still scores 98.7%.
+
+Sampled across the ten directories that band is thickest in, the failures had nothing in
+common: `CSS2/selectors/default-attribute-selector-003` is a 100×100 square painted where
+no square belongs, `css-text/shaping/shaping-005` is Arabic characters that do not join.
+Two unrelated bugs, one number.
+
+**Rank by what a directory's pass rate says instead.** A directory failing 97% of its tests
+is one feature nobody implemented; a directory failing 20% is twenty unrelated bugs, and no
+amount of sorting by percentage separates them. That is what found the rotation defect:
+`css-transforms/transform-box` at 33 of 34 failing, reduced to a plain `<div>`, showed a
+blank page with the property deleted.
+
 - **The runner cannot represent what the test builds.** The rarest answer and
   the hardest to see, because the render is neither wrong nor honest — it is of
   a *different document*. Two distinct versions of this, and the fix for the

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -1211,6 +1211,29 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   on its own: `css/css-page`, `css/CSS2/margin-padding-clear`, `css/css-position` and
   `css/css-anchor-position` together go **968 → 972 passing, +4 / −0**.
 
+### `display: contents` on the root element took the canvas with it
+
+- **Test:** `css/css-display/display-contents-root-background` (reftest suite,
+  [#1788](https://github.com/Broiler-Platform/Broiler/issues/1788).6), 0.0% →
+  **100.0%, passing.** Owner: main repo, `Broiler.Layout/Engine/DisplayContentsBoxes.cs`.
+- **The rule was implemented; it was applied to the wrong box.** CSS Display 3 §2.3 blockifies
+  the root element, so `contents` on it is `block`, and `DisplayContentsBoxes.Generate` did
+  exactly that — to the box it was handed. The renderer hands it the anonymous *document* box
+  (`HtmlParser.ParseDocument` creates a block and appends `<html>` to it), so the real root
+  element was still a child like any other and was spliced out. What went with it was the
+  canvas: the canvas background is the root element's (CSS Backgrounds §2.11.2), so
+  `:root { display: contents; background-image: url(…) }` painted a white page where the test
+  asks for a green one.
+- **The blast radius is two files in the whole corpus**, which is why this sat unreported: a
+  scan of the checkout finds `display: contents` on `:root`/`html` in
+  `display-contents-root-background` and in `display-contents-computed-style`, and the second
+  is a testharness test with no reference. Nothing else in the reftest suite can move.
+- **Verified:** the reftest end to end, plus two unit tests over the box tree — the document-box
+  shape the renderer actually produces, and a sub-document's root element, which is entitled to
+  the same rule. Both fail on the parent commit. The pass's existing root test was passing
+  because it handed `Generate` the `<html>` box directly, which is the one shape the renderer
+  never produces.
+
 ### A grid with only out-of-flow children resolved no grid areas
 
 **[Issue #1667](https://github.com/Broiler-Platform/Broiler/issues/1667).12.**

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -1211,6 +1211,45 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   on its own: `css/css-page`, `css/CSS2/margin-padding-clear`, `css/css-position` and
   `css/css-anchor-position` together go **968 → 972 passing, +4 / −0**.
 
+### An SVG's `viewBox` stopped giving it an intrinsic ratio when `preserveAspectRatio: none`
+
+- **Tests:** the whole `css/css-backgrounds/background-size` directory, **146 → 214 of 217**.
+  Owner: `Broiler.HTML` (`Source/Broiler.HTML.Image.Compat/Adapters/StubImageAdapter.cs`) —
+  **submodule**, so it ships as the patch named
+  "image: an SVG's viewBox gives an intrinsic ratio whatever preserveAspectRatio says"
+  (push denied, 403), listed in `scripts/apply-pending-wpt-patches.sh`.
+- **The wrong question was being asked.** `RasterizeSvg` read `preserveAspectRatio="none"`
+  as removing the image's intrinsic aspect ratio, reasoning that an image willing to scale
+  non-uniformly does not insist on a shape. SVG 2 §8.2 derives the intrinsic sizing
+  properties from `width`/`height`/`viewBox` alone; `preserveAspectRatio` governs how the
+  content is fitted *once the viewport size is known*, which is a later question than what
+  size the image asks to be. Reading it the other way made such an image report no ratio at
+  all, so CSS sized it to the whole background positioning area.
+- **The directory was failing by construction, which is why it was worth looking at.** Every
+  SVG in `background-size/vector` carries `preserveAspectRatio="none"`, so all 60 of its
+  failures were one bug — a ratio-only image stretched to 768×256 where the test asks for
+  16×256. The same flag also hid dimensions the SVG states outright: with `width="8px"` and a
+  `viewBox`, `background-size: auto` sized to 24×384 in a 128×384 box instead of the 8×128 the
+  stated width and the ratio ask for. It survives under a name that says what it now decides
+  (`renderOversizedAndCrop`) — an SVG that gives one dimension and stretches to the other has
+  no viewport of its own to draw into, so it is rendered oversized and cropped to its content.
+- **Measured over the full 26 366-test reftest suite**, baseline and change on the same build
+  against the same checkout: **18 776 → 18 844 passing, +68 / −0**, average match 98.42% →
+  98.46%. All 68 wins are in `css/css-backgrounds/background-size`; nothing anywhere else in
+  the suite moved in either direction. The blast radius is small by construction — only 43
+  standalone SVGs in the whole corpus carry `preserveAspectRatio="none"` — but the sweep was
+  run rather than argued.
+- **Three stragglers remain in the directory**, and none is this bug:
+  `background-size-cover-svg` (74.5%) uses a `viewBox`-only SVG with *default*
+  `preserveAspectRatio`, so its ratio was never suppressed — it rasterises at the 300×150
+  default object size and is then scaled to 4923×400, which is a rasterisation-resolution
+  question; and `background-size-025`/`-031` are raster-image tests unrelated to SVG sizing.
+- **How it was found is the transferable part.** It is not on
+  [#1788](https://github.com/Broiler-Platform/Broiler/issues/1788)'s top-thirty list at all.
+  It came from reading `tests/wpt-baseline/failed-reftests.json` — the run's own failure
+  manifest — and grouping by directory, which puts a 65-test single-feature cluster three rows
+  below `grid-lanes` and well above anything the severity ranking surfaces.
+
 ### `display: contents` on the root element took the canvas with it
 
 - **Test:** `css/css-display/display-contents-root-background` (reftest suite,

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -2890,6 +2890,42 @@ the test that exposed it.
   [below the threshold](wpt-rendering-gaps-open.md#bold-and-italic-never-reach-the-face) on
   bold text.
 
+### A `data:text/css` `<link>` contributed nothing to the cascade
+
+- **Test:** `css-backgrounds/background-image-shared-stylesheet` (reftest suite,
+  [#1788](https://github.com/Broiler-Platform/Broiler/issues/1788).2), 0.0% →
+  **100.0%, passing.** Owner: main repo — `src/Broiler.HtmlBridge.Dom` and
+  `src/Broiler.Wpt`. No submodule patch.
+- **The bug.** A `<link rel="stylesheet" href="data:text/css,…">` carries its own sheet;
+  there is nothing to fetch. The bridge handed the href to the resource loader like any
+  other URL, and that loader dispatches `file` and `http(s)` only — so the sheet came back
+  empty, contributed no rules to the cascade or the CSSOM, and the link dispatched `error`
+  where the spec says `load`. `@import url(data:text/css,…)` was already decoded in
+  process; the `<link>` spelling of the same thing was not, so both call sites now go
+  through that one seam (`FetchStyleSheetText`).
+- **Why it survived so long: the renderer disagreed with the DOM.** `Broiler.HTML`'s own
+  stylesheet loader has always decoded `data:` URIs, so a data: sheet written in the markup
+  *painted* — while `getComputedStyle`, the CSSOM and the link's load event all said it had
+  not loaded. Only a page that reads one of those three notices, which is why the symptom
+  was a script waiting forever on `link.onload` rather than an unstyled render.
+- **The second half was the runner, and it is the more transferable one.** A run gives each
+  document a `file:///…` page URL, so the WPT idiom
+  `new URL("/images/green.png", location.href).href` — how a test hands a corpus URL to
+  another document — produces `file:///images/green.png`: the filesystem root, not the
+  checkout. `TryResolveWptRootRelativePath` already reads a corpus path back out of a served
+  WPT origin (`http://web-platform.test:8000/…`); it now does the same for a `file:` URL
+  that names nothing on disk. Strictly additive — a `file:` URL that resolves on its own is
+  returned untouched, and the corpus still has to hold what is left.
+- **Verified:** five focused tests in `DataUriStylesheetLinkTests` (script-injected sheet
+  reaches computed style; it fires `load`, not `error`; the markup and base64 spellings; and
+  the shared-sheet case the WPT test is named for) — all five fail on the parent commit —
+  plus two for the runner remap, and the reftest itself run end to end against a checkout
+  holding the test, its reference, `/images/green.png` and `/css/reference/blank.html`.
+- **Do not read the first half as the whole fix.** Landing only the data: decode moves the
+  test from 0.0% to 0.0%: the iframe is correctly removed (that is `link.onload` firing at
+  last) and the page is then blank white against a lime reference, because the image the
+  sheet names still does not load. The two together are what pass it.
+
 ### `transform: scale()` with percentages
 
 - **Test:** `css/css-transforms/transform-scale-percent-001`, 0.5% → **99.99%**.

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -2988,6 +2988,38 @@ the test that exposed it.
   last) and the page is then blank white against a lime reference, because the image the
   sheet names still does not load. The two together are what pass it.
 
+### A CSS `transform` rule never reached an SVG element
+
+- **Owner:** main repo — `src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs` and
+  `Broiler.Layout/IR/SvgTransform.cs`. **No submodule patch.**
+- **The bug.** `SvgRenderer` reads an element's transform off the serialized markup, and sees no
+  stylesheet of its own, so the bridge projects the cascaded value onto the SVG presentation
+  attribute on the way out. `transform-box` and `transform-origin` were projected; **`transform`
+  itself was not** — so `#target { transform: rotate(90deg) }` reached nothing and the element
+  rendered untransformed. The other two can only move a transform that arrived by attribute, so
+  projecting them without it was half a mechanism.
+- **The guard is the interesting half, and the tests are explicit about it.** A cascaded value that
+  parses no transform function must be *skipped*, not written. Two different things depend on that:
+  this bridge's cascade does not model SVG presentation attributes as declarations, so an element
+  carrying `transform="translate(50)"` and no rule computes `none` — writing that back erases the
+  attribute the renderer was about to read; and CSS Transforms 1 §3 drops an *invalid* declaration
+  whole, so `transform: scale(invalid)` over a real `transform="rotate(90)"` must leave the
+  attribute standing. The nine `css-transforms/svg-{document,external,inline}-styles-005/006/013`
+  tests assert exactly the second, and an unguarded first cut failed all nine — which is how the
+  rule was found.
+- **`SvgTransform.TryParse` is what makes that decidable.** The transform alone cannot say why it
+  is the identity: `scale(invalid)` and `rotate(0deg)` both come out as `Identity`, and the caller
+  needs the invalid one to lose to the attribute while the valid one wins. `TryParse` reports
+  whether any function was recognised; `Parse` is now a call to it.
+- **Measured over the full 26 366-test reftest suite: +13 / −0**, and **+10 / −0** across the four
+  families it touches (`transform-box`, `document-styles`, `external-styles`, `inline-styles`:
+  29 → 39 of 75).
+- **What it exposes rather than fixes.** `transform-origin` is honoured on `<rect>` and nowhere
+  else — `SvgStructure` composes every other element's transform straight from the attribute with
+  no origin conjugation — so a `<path>` that now receives its CSS transform turns about the
+  viewport origin. That, and `transform-box`'s reference-box choice, are
+  [the open entry](wpt-rendering-gaps-open.md#transform-box-is-not-read-at-all).
+
 ### A rotated element and its whole subtree were not painted at all
 
 - **Owner:** `Broiler.Layout` (`IR/AffineLayerMap.cs`, main repo) and `Broiler.HTML`

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -2988,6 +2988,40 @@ the test that exposed it.
   last) and the page is then blank white against a lime reference, because the image the
   sheet names still does not load. The two together are what pass it.
 
+### `image-set()` selected nothing, whatever it held
+
+- **Owner:** main repo — `Broiler.Layout/IR/CssImageSet.cs` and the `background-image` assignment
+  in `Engine/CssUtils.cs`. **No submodule patch.**
+- **The bug.** `image-set()` was recognised as an image value and never resolved, so the layer
+  reached two readers that each understand only part of what the function can hold: the background
+  loader looks for `url(` and found a function it did not know, so it fetched nothing; the paint
+  walker looks for `gradient(` to tell a drawn layer from a fetched one, so
+  `image-set(linear-gradient(…) 1x)` was neither. Whichever kind of image the function named, the
+  layer painted nothing.
+- **What landed.** The selection is resolved into the property value before either of them looks at
+  it, which is what makes it work for every kind of image at once — both readers then see a value
+  they already understand. `CssImageSet` implements CSS Images 4 §5.4: the resolution units
+  (`x`/`dppx`, `dpi` at 96, `dpcm` at 96/2.54, and `calc()` far enough to cover a resolution
+  expression), an omitted resolution as 1x, `type()` filtering against what this engine decodes, a
+  bare `<string>` as an image, and the choice itself — the smallest resolution that reaches the
+  device, the largest when none does, first on a tie.
+- **Invalid and "selects nothing" are different answers, and two tests are built to tell them
+  apart.** A negative resolution is a parse error, so the declaration is dropped whole and the one
+  under it applies; a zero resolution parses but leaves no usable option, so the declaration applies
+  and paints nothing. `image-set-zero-resolution-rendering` puts a **red** `url()` in the
+  declaration below and expects a blank page — so "selects nothing" must not fall back to it —
+  while `image-set-negative-resolution-rendering-2` puts a **green** one there and expects green.
+- **`css/css-images/image-set` goes 10 → 32 of 37**, and the full 26 366-test reftest suite
+  **+22 / −0**.
+- **What is left, and why it is not here.** Three tests
+  (`image-set-resolution-001`/`-002`/`-003`) assert the *other* half of the resolution: the selected
+  option's resolution divides the image's intrinsic size, so `url(green.png) 0.5x` on a 100×50 image
+  is drawn 200×100. That needs the resolution carried alongside the chosen image into the sizing
+  path, and it reaches `content` and `list-style-image` as well as `background-image`. The two
+  negative-resolution tests need the declaration dropped at parse time, which is `Broiler.CSS`'s
+  validator — a submodule, and two tests is not worth a third pending patch. Both are
+  [filed](wpt-rendering-gaps-open.md#image-sets-resolution-does-not-size-the-image).
+
 ### A CSS `transform` rule never reached an SVG element
 
 - **Owner:** main repo — `src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs` and

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -2988,6 +2988,79 @@ the test that exposed it.
   last) and the page is then blank white against a lime reference, because the image the
   sheet names still does not load. The two together are what pass it.
 
+### A rotated element and its whole subtree were not painted at all
+
+- **Owner:** `Broiler.Layout` (`IR/AffineLayerMap.cs`, main repo) and `Broiler.HTML`
+  (`Broiler.HTML.Image/BCanvas.cs`, `Adapters/GraphicsAdapter.cs`, **submodule — the
+  call ships as a patch**).
+- **The bug.** `transform: rotate(45deg)` on a green square painted a **blank page**.
+  Broiler's raster canvas maps a point per axis — `p → p·scale + translation` — so
+  translation and axis-aligned scale (mirrors included, and therefore `rotate(180deg)`)
+  fold straight into its own state, and anything carrying a `b` or `c` term does not.
+  Those fell through to a compat backend that on a headless host is an inert stub, and
+  the fall-through also switches `CanUseRaster` off for **every draw the group encloses**
+  — so the element and its entire subtree landed nowhere. The three neighbouring layer
+  kinds had already been moved off that same fall-through by degrading gracefully
+  (opacity draws at full opacity, a filter draws unfiltered, a blend draws unblended);
+  the transform one had not, and for it the fall-through was not an inaccuracy but a
+  disappearance.
+- **It was never a `transform-box` bug, which is how it was found.**
+  `css/css-transforms/transform-box` was failing 33 of 34 — the highest failure rate of
+  any directory in the corpus outside the deliberate ones — and reducing its first test
+  to a plain `<div>` showed the same blank output with the property deleted. The
+  directory is uniform because *every* test in it rotates.
+- **What landed: the finished layer is warped, rather than every primitive taught a
+  matrix.** The contents draw into a full-surface offscreen with the mapping unchanged —
+  fills, text, images, clips all keep the arithmetic they already have — and one resample
+  puts the result where the transform says. `Broiler.Layout.IR.AffineLayerMap` is the
+  arithmetic: it conjugates the CSS matrix by the surface mapping (`B = S·A·S⁻¹`, exact
+  when the axes differ rather than assuming one zoom factor), and answers where a layer
+  point lands and, for the resample, which layer point lands on a destination pixel.
+  Inverse mapping is what makes it hole-free — scattering the source forward leaves gaps
+  wherever the transform magnifies.
+  - **Nearest sample, not bilinear.** A quarter turn maps pixel centres onto pixel
+    centres, so nearest is exact for the axis-swapping rotations most of the corpus uses,
+    and it cannot fringe a hard edge the way interpolating against transparent black
+    does. A diagonal rotation gets hard edges instead of antialiased ones; both sides of
+    a reftest are rendered here, so they get the same ones.
+  - **The clips in force are suspended while the layer fills and applied at the
+    composite.** An ancestor's `overflow` or `clip-path` bounds where the element *ends
+    up* (CSS Transforms 1 §3), and the tile clip of a parallel replay bounds which slice
+    of the surface the canvas may write. Leaving either in force while the layer filled
+    would clip in pre-transform space — wrong for the first, and for the second a seam,
+    because content just outside a tile that rotates into it would be clipped away before
+    it could.
+- **Measured over the full 26 366-test reftest suite: 18 776 → 18 771 passing, +22 / −27**,
+  average match unchanged at 98.42%, run time unchanged (22:04 → 21:5x). **The score
+  going down is the honest result**, and the shape of it is the one
+  [this suite is built to produce](wpt-reftests.md#the-bug-is-as-likely-to-be-in-the-reference-and-that-inverts-the-scoreboard):
+  25 of the 27 losses rotate on *both* sides, so both used to render blank and match at
+  100%, and the other two were checked by rendering them — their references transform
+  too, through spellings a grep for `rotate` misses. 13 of the 22 wins transform on only
+  one side and could not have passed before at all. **The upside is in the golden suite,
+  which this one structurally cannot show**: 192 of its 6 914 failures declare a rotation
+  or skew, and a blank render can only lose against a Chromium reference that shows the
+  rotated content.
+- **A first cut cost a factor of ten and is worth not repeating.** Suspending the clips
+  by emptying the stack is correct and unaffordable: `_clipBounds` is what bounds a
+  rasterizer's loops, so with nothing in it every fill inside a warp layer walked the
+  whole surface. Replacing them with the *pre-image of what is still visible* — the part
+  of the layer that can land inside the suspended clip — keeps both properties, because
+  content outside it cannot reach the surface however it is transformed.
+- **Verified:** 20 `AffineLayerMapTests` in the main repo pin the arithmetic — the fixed
+  point is `transform-origin`, a quarter turn sends the x axis to y, the worked
+  `cssbox-content-box-001` box lands where its reference states, a diagonal turn grows
+  the destination box by root two, the inverse undoes the forward for rotation, skew and
+  a rotation composed with a scale, a non-uniform surface scale is conjugated rather than
+  averaged, and every axis-aligned, singular or malformed matrix is declined so exactly
+  one of the two paths claims a given matrix.
+- **What this exposes rather than fixes.** `transform-box` itself is still unimplemented:
+  `cssbox-content-box-001` now renders the right shape in the wrong place, offset by
+  exactly the 50px left border, because the reference box is always the border box
+  (`PaintWalker.Stacking` passes `bounds` to both the matrix and
+  `CssTransformOrigin.Resolve`). That is the next thing in this directory, and it is a
+  smaller job than this was.
+
 ### `transform: scale()` with percentages
 
 - **Test:** `css/css-transforms/transform-scale-percent-001`, 0.5% → **99.99%**.

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -1328,22 +1328,32 @@ Worth separating from the rest, because the test itself may be at fault:
 
 ## Dynamic stylesheets
 
-### A script-injected `data:text/css` stylesheet never applies
+### A script-injected `data:text/css` stylesheet never applies — **fixed**
 
-- **Test:** `css-backgrounds/background-image-shared-stylesheet`, CI 5.7% →
-  **5.7%** against its own reference. Reproduces exactly.
-- **It does not need the WPT server, and was filed for three runs as though it
-  did.** The `?pipe=trickle(d2)` query is simply stripped and `/images/green.png` is
-  served from the checkout like any other root-relative resource. The earlier note
-  that "the pair matched at 99.8% locally while CI reports 0.0%" was
-  [the resolver bug](wpt-rendering-gaps-fixed.md#a-root-relative-resolver-returned-a-working-directory-relative-path):
-  neither side loaded the image, so the two agreed on nothing.
-- **What the 5.7% is, precisely.** The reference is 100% lime. Broiler paints 94%
-  white with a green block of exactly 300×150 — **the default `<iframe>` size**. So
-  the iframe is never removed and the parent's script-injected `data:text/css`
-  stylesheet never applies, while the *iframe's own* copy of that stylesheet does.
-- **Exit gate:** a `data:text/css` stylesheet injected from script applies to the
-  injecting document, with a focused test covering the shared-sheet case.
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#a-datatextcss-link-contributed-nothing-to-the-cascade).
+`background-image-shared-stylesheet` now **passes at 100.0%**, and it took a second
+fix beside the data: one — the runner could not read a corpus path back out of the
+`file:///…` URL a script builds from `location.href`.
+
+### `document.styleSheets` lists no `<link>` sheet at all
+
+- **Owner:** main repo, `src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs`.
+  No test on any current list is known to turn on it; it was found while fixing the entry
+  above and is recorded rather than fixed, because widening what that collection returns
+  changes what every script iterating it sees.
+- **What it is.** `GetStyleSheets` filters the document's elements to tag `style`, so an
+  external sheet is absent from `document.styleSheets` however well it loaded — measured
+  on a page whose linked sheet demonstrably applies (`getComputedStyle` reads the linked
+  colour, `document.styleSheets.length` reads `0`). CSSOM §2.2 makes the collection every
+  sheet associated with the document, `<link rel=stylesheet>` included.
+- **The fix is already written, one layer over.** A sub-document's `styleSheets` goes
+  through `DomBridge.BuildStyleSheetsCollection`, which collects `<style>` *and*
+  `IsExternalStylesheet` links, skips a disabled `<link>`, and caches per element for
+  identity. The main-document binding predates it and never adopted it, so the two
+  disagree about what a document's stylesheets are.
+- **Exit gate:** both bindings return the same collection for the same tree, with a test
+  covering a linked sheet, a `<link disabled>`, and object identity across two reads.
 
 ---
 
@@ -1518,7 +1528,7 @@ can follow the same shape the
 [`sub` pipe already did](wpt-rendering-gaps-fixed.md#the-runner-never-performed-wpts-sub-substitution)
 — a runner-side transform, not a server. No test currently on any list is blocked on
 it: `background-image-shared-stylesheet`, the one that was, turned out
-[not to need it](#a-script-injected-datatextcss-stylesheet-never-applies).
+[not to need it](#a-script-injected-datatextcss-stylesheet-never-applies--fixed) and now passes.
 
 ### Paged media is partial
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -1253,10 +1253,23 @@ express those, and does not claim to.
   `content-box`/`border-box`/`border-box`.
 - **Measured:** `cssbox-content-box-001` now renders the correct shape in the wrong place,
   offset by exactly the 50px left border its `content-box` reference box would have removed.
-  The SVG half is partly there already — `SvgRenderer.TransformOrigin` reads
-  `transform-box` for the box-relative values — so this is the CSS-layout half.
+- **The directory is now 11 of 34**, up from 5, after
+  [the CSS `transform` projection](wpt-rendering-gaps-fixed.md#a-css-transform-rule-never-reached-an-svg-element)
+  — the `svgbox-*` tests were failing because their transform never arrived at all, not because
+  of the reference box. What is left splits in two.
+- **The CSS-layout half** (`cssbox-content-box-001`/`-002`, `cssbox-fill-box`,
+  `content-box-mutation-001`, `value-changed`) is the reference-box choice above.
+- **The SVG half is a bigger and more general gap than `transform-box`:** `transform-origin` is
+  honoured on `<rect>` and nowhere else. `SvgStructure` composes every element's transform
+  straight from the attribute (`SvgTransform.Parse(attributes["transform"])`) with no origin
+  conjugation, and only the `<rect>` path calls `OwnTransformAbout`. So a `<path>` with a
+  `transform-origin` turns about the viewport origin — `svgbox-initial` and `svgbox-view-box`
+  are that, not a `transform-box` failure. Fixing it properly needs each element's fill box,
+  stroke box and nearest viewport rect available where the transform is composed, which
+  `SvgStructure` builds during a markup scan without geometry.
 - **Exit gate:** the eight `cssbox-*` tests match, and the `*-mutation-*` ones follow, with
-  a `Broiler.Layout` test over the five keywords against a box with a border and padding.
+  a `Broiler.Layout` test over the five keywords against a box with a border and padding;
+  separately, `transform-origin` applies to every SVG shape rather than to `<rect>` alone.
 
 ### Transform interpolation has no matrix fallback
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -1310,6 +1310,37 @@ express those, and does not claim to.
 
 ---
 
+### `image-set()`'s resolution does not size the image
+
+- **Tests:** `css-images/image-set/image-set-resolution-001`, `-002`, `-003` — the three the
+  [selection fix](wpt-rendering-gaps-fixed.md#image-set-selected-nothing-whatever-it-held) left
+  behind, out of that directory's 37.
+- **Owner:** main repo. `Broiler.Layout/IR/CssImageSet.cs` already computes the number; nothing
+  carries it past the selection.
+- **What it is.** CSS Images 4 §5.4: the chosen option's resolution divides the image's intrinsic
+  size, so `image-set(url(green.png) 0.5x)` on a 100×50 file is a 200×100 image. The resolver picks
+  the right option and then throws the resolution away, so the image draws at its file size. The
+  three tests differ only in which property carries it — `content`, `background-image`,
+  `list-style-image` — which is the second half of the work: the resolution has to reach the image
+  sizing path for each, and today only `background-image` is even resolved.
+- **Exit gate:** the three tests match, with a `Broiler.Layout` test over an intrinsic size scaled
+  by a non-1x selection.
+
+### An invalid `image-set()` does not drop its declaration
+
+- **Tests:** `css-images/image-set/image-set-negative-resolution-rendering` and `-2`.
+- **Owner:** `Broiler.CSS` (`CssDeclarationValidator`). **Submodule** — a fix ships as a patch.
+- **What it is.** A negative resolution is a parse error, so CSS Syntax 3 §9 drops the declaration
+  whole and the one cascaded under it applies; `-2` puts a green `url()` there and expects green.
+  The renderer sees only the winning value, so refusing it there leaves the property at its
+  *initial* value rather than at the previous declaration — the fallback has to happen in the
+  cascade. `CssImageSet.TryResolveLayers` already reports the parse error separately from a
+  function that validly selects nothing, so the validator has something to call.
+- **Deliberately not fixed yet:** two tests against a third pending submodule patch is the wrong
+  trade while the first two are still waiting to be applied.
+
+---
+
 ## Masking
 
 ### SVG `<clipPath>` referenced by `url()`

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -1213,31 +1213,50 @@ Worth separating from the rest, because the test itself may be at fault:
 
 ## Transforms
 
-### Nothing with a rotation or a skew in it paints at all
+### Nothing with a rotation or a skew in it paints at all — **fixed**
 
-- **Tests:** `css-transforms/animation/transform-interpolation-005`
-  ([#1670](https://github.com/Broiler-Platform/Broiler/issues/1670).23) and every test whose
-  transform is not axis-aligned.
-- **Owner:** `Broiler.HTML` (`Source/Broiler.HTML.Image/BCanvas.cs`,
-  `Adapters/GraphicsAdapter.cs`). **Submodule** — a fix ships as a patch.
-- **Root cause.** `BCanvas.TrySaveTransform` returns false when the affine's `b` or `c` is
-  non-zero, i.e. for any rotation or skew — including every `matrix()` with non-zero b/c.
-  `GraphicsAdapter` then routes the layer to `_canvasCompat`, whose only implementation in
-  the tree is `StubCanvasCompat`, **every method of which is a no-op**, and
-  `CanUseRaster` sends every enclosed draw there too. So the content does not paint
-  mis-rotated; it does not paint.
-- **What it needs:** `BCanvas` keeps `_translation`, `_scaleX`, `_scaleY` and maps points
-  per axis. That has to become a real 2×3 matrix, composed in
-  `TrySaveTransform`/`Translate`/`Scale` and applied at the ~12 mapping call sites; a
-  rect-shaped primitive under a rotation has to go out as the polygon primitive the backend
-  already draws, and `PushClip` has to become the polygon clip that already exists.
-- **`perspective-split-by-zero-w`
-  ([#1670](https://github.com/Broiler-Platform/Broiler/issues/1670).22) is a tier beyond
-  that** and belongs with
-  [the 3D entry below](#a-perspective-transformed-box-is-not-rasterised-in-3d): there is no
-  `w` to split against because there is no 3D pipeline at all —
-  `ParseCssTransformMatrix` reduces the whole list to a 2D affine and silently drops
-  `rotateX`, `rotateY`, off-Z `rotate3d` and genuinely-3D `matrix3d`.
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#a-rotated-element-and-its-whole-subtree-were-not-painted-at-all).
+**Not by the route this entry proposed**, which is worth recording. It asked for
+`BCanvas`'s per-axis mapping to become a real 2×3 matrix, composed in
+`TrySaveTransform`/`Translate`/`Scale` and applied at a dozen call sites, with rect
+primitives going out as polygons under a rotation and `PushClip` becoming a polygon clip.
+What landed instead leaves every primitive exactly as it was: the contents draw into an
+offscreen with the mapping unchanged, and the *finished layer* is resampled through the
+matrix (`Broiler.Layout.IR.AffineLayerMap` in the main repo, the call as a submodule
+patch). Same result for one tenth of the surface area, and the arithmetic ends up on the
+side of the boundary this session can test.
+
+**What is still open here is the 3D half**, which that entry already separated out:
+`perspective-split-by-zero-w` belongs with
+[the 3D entry below](#a-perspective-transformed-box-is-not-rasterised-in-3d), because
+`ParseCssTransformMatrix` reduces the whole list to a 2D affine and silently drops
+`rotateX`, `rotateY`, off-Z `rotate3d` and genuinely-3D `matrix3d`. A 2D warp cannot
+express those, and does not claim to.
+
+### `transform-box` is not read at all
+
+- **Tests:** `css-transforms/transform-box` — 33 of 34 failing, the highest failure rate of
+  any directory in the corpus outside the deliberate ones. The whole directory rotates, so
+  it read as a rotation bug and
+  [was one](wpt-rendering-gaps-fixed.md#a-rotated-element-and-its-whole-subtree-were-not-painted-at-all);
+  what is left underneath is the property itself.
+- **Owner:** `Broiler.HTML` (`Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs`)
+  for the call, with the box choice belonging in `Broiler.Layout` beside
+  `CssTransformOrigin` — the same split the rotation fix used. Needs
+  `ComputedStyle.TransformBox` plumbed through first, which is main repo.
+- **What it is.** The reference box for a CSS transform is always the border box:
+  `PaintWalker.Stacking` passes `bounds` to both `ParseCssTransformMatrix` (which resolves
+  percentage translations against it) and `CssTransformOrigin.Resolve`. CSS Transforms 1 §6
+  makes that a choice of five — `content-box`, `border-box`, `fill-box`, `stroke-box`,
+  `view-box` — and on a non-SVG element `fill-box`/`stroke-box`/`view-box` behave as
+  `content-box`/`border-box`/`border-box`.
+- **Measured:** `cssbox-content-box-001` now renders the correct shape in the wrong place,
+  offset by exactly the 50px left border its `content-box` reference box would have removed.
+  The SVG half is partly there already — `SvgRenderer.TransformOrigin` reads
+  `transform-box` for the box-relative values — so this is the CSS-layout half.
+- **Exit gate:** the eight `cssbox-*` tests match, and the `*-mutation-*` ones follow, with
+  a `Broiler.Layout` test over the five keywords against a box with a border and padding.
 
 ### Transform interpolation has no matrix fallback
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -246,7 +246,7 @@ reference-disagreement list rather than from its severity ranking.
 
 | Test | Status | CI (#1624) | `rel=match` | First reported |
 | --- | --- | --- | --- | --- |
-| `css-backgrounds/background-image-shared-stylesheet` | **not fixed** | fails | 5.7% | #1491.4 |
+| `css-backgrounds/background-image-shared-stylesheet` | **fixed** | fails | 100.0% | #1491.4 |
 | `css-flexbox/percentage-heights-003` | **not fixed** | fails | n/a | #1624.27 |
 | `css-grid/abspos/grid-sizing-positioned-items-001` | **not fixed** | fails | n/a | #1624.13 |
 | `css-grid/grid-lanes/…/column-subgrid-orthogonal-writing-mode-004` | **not fixed** | fails | 94.8% | #1624.3 |

--- a/patches/0001-html-svg-viewbox-intrinsic-ratio.patch
+++ b/patches/0001-html-svg-viewbox-intrinsic-ratio.patch
@@ -1,0 +1,124 @@
+From 61a970685816a998ddfa9ffcc227213548439789 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 23 Aug 2026 00:19:14 +0000
+Subject: [PATCH] image: an SVG's viewBox gives an intrinsic ratio whatever
+ preserveAspectRatio says
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+RasterizeSvg read preserveAspectRatio="none" as removing the image's intrinsic
+aspect ratio, on the grounds that non-uniform scaling means the image does not
+insist on a shape. That is the wrong question: SVG 2 §8.2 derives the intrinsic
+sizing properties from width/height/viewBox alone, and preserveAspectRatio
+governs how the content is fitted once the viewport size is known — a later
+question than what size the image asks to be.
+
+The consequence was that such an image reported no ratio at all, so CSS sized it
+to the whole background positioning area. Every SVG in the
+css-backgrounds/background-size/vector family carries preserveAspectRatio="none",
+so the entire family painted a stretched image where the ratio was the thing
+under test.
+
+The same flag also hid intrinsic dimensions the SVG states outright: with
+width="8px" and a viewBox, `background-size: auto` sized to 24x384 in a 128x384
+box instead of the 8x128 the stated width and the ratio ask for. It is a
+rasterization choice — an SVG that gives one dimension and stretches to the other
+has no viewport of its own to draw into, so it is rendered oversized and cropped
+to its content — and it now only decides that, under a name that says so.
+
+Measured over the full 26 366-test WPT reftest suite: 18 776 -> 18 844 passing,
++68 / -0, average match 98.42% -> 98.46%. Every one of the 68 is in
+css-backgrounds/background-size, which goes 146 -> 214 of 217.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VzR2khcAg4qgityTfzRTVi
+---
+ .../Adapters/StubImageAdapter.cs              | 47 +++++++++++--------
+ 1 file changed, 27 insertions(+), 20 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image.Compat/Adapters/StubImageAdapter.cs b/Source/Broiler.HTML.Image.Compat/Adapters/StubImageAdapter.cs
+index 9ec8ad8..58ee04e 100644
+--- a/Source/Broiler.HTML.Image.Compat/Adapters/StubImageAdapter.cs
++++ b/Source/Broiler.HTML.Image.Compat/Adapters/StubImageAdapter.cs
+@@ -414,11 +414,11 @@ internal sealed class StubImageAdapter : RAdapter
+         bool parsedIntrinsicWidth = svgWidth > 0;
+         bool parsedIntrinsicHeight = svgHeight > 0;
+         int width, height;
+-        // Chrome's SVG sizing for <img> elements: only when BOTH explicit
+-        // width and height attributes are present does the SVG have true
+-        // intrinsic dimensions and an intrinsic aspect ratio.  When either
+-        // dimension is missing Chrome falls back to the 300×150 default
+-        // object size, regardless of viewBox or partial attributes.
++        // The size to rasterize at, which is a different question from what the image reports
++        // as its intrinsic size: with both width and height present the SVG is rasterized at
++        // them, and otherwise at the 300×150 default object size, which is a canvas to draw
++        // on rather than a claim about the image. What it reports is decided at the bottom of
++        // this method, from width/height/viewBox per SVG 2 §8.2.
+         bool hasBothDimensions = parsedIntrinsicWidth && parsedIntrinsicHeight;
+         if (hasBothDimensions)
+         {
+@@ -431,7 +431,12 @@ internal sealed class StubImageAdapter : RAdapter
+             height = 150;
+         }
+ 
+-        bool suppressPartialIntrinsicDimensions =
++        // A rasterization choice only: an SVG that gives one dimension and stretches to the
++        // other has no viewport of its own to draw into, so it is rendered oversized and
++        // cropped to its content instead. It used to double as the reported-intrinsics gate,
++        // which hid a width the SVG states outright — `width="8px"` with a viewBox sized to
++        // 24×384 in a 128×384 box rather than the 8×128 the ratio asks for.
++        bool renderOversizedAndCrop =
+             preserveAspectRatioNone && vbRatio > 0 && !hasBothDimensions;
+ 
+         int rasterScale = GetSvgRasterizationScale(width, height, hasBothDimensions, vbRatio);
+@@ -444,7 +449,7 @@ internal sealed class StubImageAdapter : RAdapter
+             bitmap = new BBitmap(rasterWidth, rasterHeight);
+             bitmap.Erase(BColor.Transparent);
+         }
+-        else if (suppressPartialIntrinsicDimensions)
++        else if (renderOversizedAndCrop)
+         {
+             const int fallbackRenderScale = 4;
+             int renderWidth = rasterWidth * fallbackRenderScale;
+@@ -494,22 +499,24 @@ internal sealed class StubImageAdapter : RAdapter
+         if (!hasDegenerateViewBox && TryParseSolidViewportFill(svgContent, out var solidFill))
+             bitmap.Erase(solidFill);
+ 
+-        // Only SVGs with both explicit width and height have intrinsic
+-        // dimensions.  A viewBox exposes an intrinsic ratio only when the
+-        // root element preserves aspect ratio; preserveAspectRatio="none"
+-        // allows non-uniform scaling and therefore does not contribute an
+-        // intrinsic ratio for CSS background-size calculations.
+-        bool hasIntrinsicRatio = hasBothDimensions || (vbRatio > 0 && !preserveAspectRatioNone);
+-        double intrinsicRatio = hasBothDimensions
+-            ? svgWidth / svgHeight
+-            : (preserveAspectRatioNone ? 0 : vbRatio);
++        // Only SVGs with both explicit width and height have intrinsic dimensions. A viewBox
++        // gives an intrinsic ratio whatever preserveAspectRatio says (SVG 2 §8.2 decides the
++        // intrinsic sizing properties from width/height/viewBox alone): preserveAspectRatio
++        // governs how the content is fitted once the viewport size is known, which is a later
++        // question than what size the image asks to be. Reading `none` as "no intrinsic ratio"
++        // made every such image size to the whole background positioning area, so the entire
++        // css-backgrounds/background-size/vector family — 60 reftests whose SVGs all carry
++        // preserveAspectRatio="none" — painted a stretched image where the ratio was the thing
++        // under test.
++        bool hasIntrinsicRatio = hasBothDimensions || vbRatio > 0;
++        double intrinsicRatio = hasBothDimensions ? svgWidth / svgHeight : vbRatio;
+         return new ImageAdapter(bitmap,
+             hasIntrinsicRatio: hasIntrinsicRatio,
+-            hasIntrinsicWidth: parsedIntrinsicWidth && !suppressPartialIntrinsicDimensions,
+-            hasIntrinsicHeight: parsedIntrinsicHeight && !suppressPartialIntrinsicDimensions,
++            hasIntrinsicWidth: parsedIntrinsicWidth,
++            hasIntrinsicHeight: parsedIntrinsicHeight,
+             intrinsicAspectRatio: intrinsicRatio > 0 ? intrinsicRatio : null,
+-            intrinsicWidth: parsedIntrinsicWidth && !suppressPartialIntrinsicDimensions ? svgWidth : 0,
+-            intrinsicHeight: parsedIntrinsicHeight && !suppressPartialIntrinsicDimensions ? svgHeight : 0);
++            intrinsicWidth: parsedIntrinsicWidth ? svgWidth : 0,
++            intrinsicHeight: parsedIntrinsicHeight ? svgHeight : 0);
+     }
+ 
+     private static int GetSvgRasterizationScale(int width, int height, bool hasBothDimensions, double viewBoxRatio)
+-- 
+2.43.0
+

--- a/patches/0002-html-affine-transform-layer.patch
+++ b/patches/0002-html-affine-transform-layer.patch
@@ -1,0 +1,310 @@
+From 82a367689c6e690203c8a883f7fd05a49830e758 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 23 Aug 2026 07:29:45 +0000
+Subject: [PATCH] image: resample a rotated layer instead of dropping it
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+BCanvas maps a point per axis — p → p·scale + translation — so translation and
+axis-aligned scale fold into its own state and anything carrying a b or c term
+does not. GraphicsAdapter routed those to the compat backend, which on a
+headless host is an inert stub, and that route also switches CanUseRaster off
+for every draw the group encloses: `transform: rotate(45deg)` on a green square
+painted a blank page, and took its whole subtree with it. Opacity, filter and
+blend had already been moved off the same fall-through by degrading; a transform
+has somewhere better to go, because a finished layer can be resampled through a
+matrix the primitives cannot express.
+
+TrySaveWarpLayer opens a full-surface offscreen the contents draw into with the
+mapping unchanged, so every primitive keeps the arithmetic it already has, and
+RestoreWarpLayer resamples it through Broiler.Layout.IR.AffineLayerMap. Nearest
+sample, not bilinear: a quarter turn maps pixel centres onto pixel centres, so
+it is exact for the axis-swapping rotations most content uses, and it cannot
+fringe a hard edge the way interpolating against transparent black does.
+
+The clips in force are suspended while the layer fills and applied at the
+composite, because they bound the transformed result rather than the content on
+its way in: an ancestor's overflow or clip-path bounds where the element ends up,
+and the tile clip of a parallel replay bounds which slice of the surface the
+canvas may write — leaving that one in force would clip away content just outside
+a tile that rotates into it, a seam. What replaces them is the pre-image of what
+is still visible, which is what keeps the layer affordable: leaving the stack
+empty instead cost a factor of ten on the whole suite, because _clipBounds is
+what bounds a rasterizer's loops.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../Adapters/GraphicsAdapter.cs               |  57 +++++--
+ Source/Broiler.HTML.Image/BCanvas.cs          | 146 +++++++++++++++++-
+ 2 files changed, 191 insertions(+), 12 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+index 7fce3f7..373af7e 100644
+--- a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
++++ b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+@@ -24,6 +24,14 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+     private readonly Action? _onDispose;
+     private readonly List<Action<object>> _deferredCanvasOperations = [];
+     private readonly Stack<bool> _rasterLayerStack = new();
++
++    /// <summary>
++    /// One entry per open <see cref="SaveTransformLayer"/>: whether the raster canvas took it as a
++    /// <em>warp layer</em> (an offscreen resampled through the matrix) rather than by folding the
++    /// matrix into its own per-axis mapping. The two are closed differently, and the shared
++    /// <see cref="_rasterLayerStack"/> only records whether the raster canvas took it at all.
++    /// </summary>
++    private readonly Stack<bool> _transformWarpStack = new();
+     private readonly ITextShaper _textShaper;
+     private readonly ICanvasCompat _canvasCompat;
+     private object? _canvas;
+@@ -474,20 +482,43 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+             _rasterCanvas!.RestoreBlendLayer();
+     }
+ 
++    /// <summary>
++    /// Opens the group for a CSS <c>transform</c>. Translation and axis-aligned scale fold into the
++    /// raster canvas's own per-axis mapping; a rotation or skew becomes a warp layer there — an
++    /// offscreen the contents draw into untransformed, resampled through the matrix when the group
++    /// closes. Only a canvas-less or already-compat context falls through.
++    /// </summary>
++    /// <remarks>
++    /// The fall-through is what <see cref="SaveOpacityLayer"/> describes: it switches
++    /// <see cref="CanUseRaster"/> off for every draw the group encloses, and against the stub
++    /// compat backend this image renderer ships with, every one of those draws lands nowhere. For a
++    /// transform that was not an inaccuracy but a disappearance — <c>transform: rotate(45deg)</c> on
++    /// a green square painted a blank page, and with it went the whole subtree. Opacity, filter and
++    /// blend were moved off that fall-through by degrading; a transform has somewhere better to go,
++    /// because a finished layer can be resampled through a matrix the primitives cannot express.
++    /// </remarks>
+     public override void SaveTransformLayer(float[] matrix, float originX, float originY)
+     {
+-        // Prefer the raster canvas for translate/uniform-scale transforms — the common
+-        // translate()/scale() cases. Routing those to the compat backend (as the fall-through does)
+-        // makes CanUseRaster false for every enclosed draw; with a stub compat backend the
+-        // transformed content then vanishes entirely. Rotation/skew/non-uniform scale are not
+-        // expressible on the raster canvas and still fall back.
+-        bool useRaster = _rasterCanvas is not null
+-            && _activeCompatLayerDepth == 0
+-            && _rasterCanvas.TrySaveTransform(matrix, originX, originY);
+-        _rasterLayerStack.Push(useRaster);
+-        if (useRaster)
++        bool canUseCanvas = _rasterCanvas is not null && _activeCompatLayerDepth == 0;
++
++        // Cheapest first: a matrix the canvas's point mapping expresses needs no offscreen at all,
++        // and placing content directly is exact where a resample would not be.
++        if (canUseCanvas && _rasterCanvas!.TrySaveTransform(matrix, originX, originY))
++        {
++            _rasterLayerStack.Push(true);
++            _transformWarpStack.Push(false);
+             return;
++        }
++
++        if (canUseCanvas && _rasterCanvas!.TrySaveWarpLayer(matrix, originX, originY))
++        {
++            _rasterLayerStack.Push(true);
++            _transformWarpStack.Push(true);
++            return;
++        }
+ 
++        _rasterLayerStack.Push(false);
++        _transformWarpStack.Push(false);
+         _activeCompatLayerDepth++;
+         ApplyCanvasOperation(canvas => _canvasCompat.SaveTransformLayer(canvas, matrix, originX, originY));
+     }
+@@ -495,9 +526,13 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+     public override void RestoreTransformLayer()
+     {
+         bool usedRaster = _rasterLayerStack.Count > 0 && _rasterLayerStack.Pop();
++        bool usedWarp = _transformWarpStack.Count > 0 && _transformWarpStack.Pop();
+         if (usedRaster)
+         {
+-            _rasterCanvas!.Restore();
++            if (usedWarp)
++                _rasterCanvas!.RestoreWarpLayer();
++            else
++                _rasterCanvas!.Restore();
+             return;
+         }
+ 
+diff --git a/Source/Broiler.HTML.Image/BCanvas.cs b/Source/Broiler.HTML.Image/BCanvas.cs
+index 8131c02..684b4cb 100644
+--- a/Source/Broiler.HTML.Image/BCanvas.cs
++++ b/Source/Broiler.HTML.Image/BCanvas.cs
+@@ -1022,6 +1022,71 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         CompositeLayer(layer);
+     }
+ 
++    /// <summary>
++    /// Opens a layer for a CSS <c>transform</c> this canvas's per-axis mapping cannot express — a
++    /// rotation or a skew. The contents are drawn into it with the mapping unchanged, so every
++    /// primitive keeps the arithmetic it already has, and <see cref="RestoreWarpLayer"/> resamples
++    /// the finished layer through the matrix. Returns <see langword="false"/> — having pushed
++    /// nothing — for a matrix <see cref="TrySaveTransform"/> should have taken, and for a singular
++    /// one, which has no source point to fetch back for a destination pixel.
++    /// </summary>
++    public bool TrySaveWarpLayer(float[] matrix, float originX, float originY)
++    {
++        if (!Broiler.Layout.IR.AffineLayerMap.TryCreate(
++                matrix, originX, originY, _scaleX, _scaleY, _translation.X, _translation.Y, out var warp))
++            return false;
++
++        // The clips in force belong to the *transformed* result, not to the content on its way
++        // into the layer: an ancestor's overflow or clip-path bounds where the element ends up
++        // (CSS Transforms 1 §3), and the tile clip of a parallel replay bounds which slice of the
++        // surface this canvas may write. Leaving either in force while the layer fills would clip
++        // in pre-transform space — wrong for the first, and for the second a seam: content just
++        // outside a tile that rotates into it would be clipped away before it could. So they are
++        // set aside, and applied at the composite instead, where the content is where CSS puts it.
++        //
++        // What replaces them is the *pre-image* of what is still visible: the part of the layer
++        // that can land inside the suspended clip, and no more. Content outside it cannot reach
++        // the surface however it is transformed, so clipping it away changes no pixel — and
++        // leaving the stack empty instead is what a first cut did, which cost a factor of ten on
++        // the whole suite: `_clipBounds` is what bounds a rasterizer's loops, and with nothing in
++        // it every fill inside a warp layer walks the entire surface.
++        var visible = CurrentClipBounds ?? SurfaceBounds;
++        var reachable = RectangleF.Intersect(warp.InverseMapBounds(visible), SurfaceBounds);
++
++        var suspendedClips = new List<ClipOperation>(_clipOperations);
++        var suspendedBounds = new List<RectangleF>(_clipBounds);
++        _clipOperations.Clear();
++        _clipBounds.Clear();
++        AddClip(ClipOperation.Include(reachable));
++
++        _layerStack.Push(new LayerState(
++            new BBitmap(_rootBitmap.Width, _rootBitmap.Height), 1f, "normal", reachable, null, warp,
++            suspendedClips, suspendedBounds));
++        return true;
++    }
++
++    /// <summary>Closes the layer <see cref="TrySaveWarpLayer"/> opened, resampling it onto the
++    /// surface through the transform.</summary>
++    public void RestoreWarpLayer()
++    {
++        if (_layerStack.Count == 0)
++            return;
++
++        var layer = _layerStack.Pop();
++
++        // Back in force before the composite, which is the point: IsVisible there is the one
++        // place the suspended clips apply, and it applies them to the transformed result.
++        if (layer.SuspendedClipOperations is { } clips && layer.SuspendedClipBounds is { } bounds)
++        {
++            _clipOperations.Clear();
++            _clipOperations.AddRange(clips);
++            _clipBounds.Clear();
++            _clipBounds.AddRange(bounds);
++        }
++
++        CompositeLayer(layer);
++    }
++
+     public void Dispose()
+     {
+         while (_layerStack.Count > 0)
+@@ -1207,6 +1272,12 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     /// </remarks>
+     private void CompositeLayer(LayerState layer)
+     {
++        if (layer.Warp is { } warp)
++        {
++            CompositeWarpedLayer(layer, warp);
++            return;
++        }
++
+         var destination = CurrentTarget;
+         int minX = 0, minY = 0, maxX = destination.Width - 1, maxY = destination.Height - 1;
+         if (layer.ContentBounds is { } bounds)
+@@ -1238,6 +1309,76 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         layer.Bitmap.Dispose();
+     }
+ 
++    /// <summary>
++    /// Composites a warp layer: for every destination pixel the transform can reach, fetch the
++    /// layer pixel that lands there and blend it. Inverse mapping is what makes it hole-free —
++    /// scattering the source forward leaves gaps wherever the transform magnifies.
++    /// </summary>
++    /// <remarks>
++    /// <para>
++    /// <b>Nearest sample, not bilinear.</b> A quarter turn maps pixel centres onto pixel centres,
++    /// so nearest is exact for the axis-swapping rotations that most of the corpus uses, and it
++    /// cannot fringe a hard edge the way interpolating against transparent black does. A diagonal
++    /// rotation gets hard edges instead of antialiased ones; both sides of a reftest are rendered
++    /// here, so they get the same ones.
++    /// </para>
++    /// <para>
++    /// <b>The clip is applied twice, and the second time is the one CSS asks for.</b> Content was
++    /// already clipped on its way into the layer, in pre-transform space, which is not where an
++    /// ancestor's <c>overflow</c> clip belongs; <see cref="IsVisible"/> here applies it in
++    /// post-transform space, which is. The intersection of the two is conservative: content
++    /// rotated <em>into</em> an ancestor's clip from outside it is not recovered. With no ancestor
++    /// clip — the ordinary case — both are the whole surface and neither costs anything.
++    /// </para>
++    /// </remarks>
++    private void CompositeWarpedLayer(LayerState layer, Broiler.Layout.IR.AffineLayerMap warp)
++    {
++        var destination = CurrentTarget;
++        var source = layer.Bitmap;
++        var sourceBounds = layer.ContentBounds
++            ?? new RectangleF(0f, 0f, source.Width, source.Height);
++        sourceBounds = RectangleF.Intersect(
++            sourceBounds, new RectangleF(0f, 0f, source.Width, source.Height));
++        if (sourceBounds.Width <= 0f || sourceBounds.Height <= 0f)
++        {
++            source.Dispose();
++            return;
++        }
++
++        var destBounds = warp.MapBounds(sourceBounds);
++        int minX = Math.Max(0, (int)Math.Floor(destBounds.Left));
++        int minY = Math.Max(0, (int)Math.Floor(destBounds.Top));
++        int maxX = Math.Min(destination.Width - 1, (int)Math.Ceiling(destBounds.Right));
++        int maxY = Math.Min(destination.Height - 1, (int)Math.Ceiling(destBounds.Bottom));
++
++        for (int y = minY; y <= maxY; y++)
++        {
++            for (int x = minX; x <= maxX; x++)
++            {
++                warp.InverseMap(x + 0.5f, y + 0.5f, out float sx, out float sy);
++                int ix = (int)Math.Floor(sx);
++                int iy = (int)Math.Floor(sy);
++                if (ix < 0 || iy < 0 || ix >= source.Width || iy >= source.Height)
++                    continue;
++
++                var sample = source.GetPixel(ix, iy);
++                if (sample.A == 0)
++                    continue;
++                if (!IsVisible(x, y))
++                    continue;
++
++                if (layer.Filter is { } filter)
++                    sample = ApplyColorFilter(sample, filter);
++                if (layer.Opacity < 1f)
++                    sample = ApplyOpacity(sample, layer.Opacity);
++
++                BlendPixel(destination, x, y, sample, layer.BlendMode);
++            }
++        }
++
++        source.Dispose();
++    }
++
+     private static BColor ApplyOpacity(BColor color, float opacity)
+     {
+         opacity = Math.Clamp(opacity, 0f, 1f);
+@@ -1631,7 +1772,10 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         float Opacity,
+         string BlendMode,
+         RectangleF? ContentBounds,
+-        string? Filter = null);
++        string? Filter = null,
++        Broiler.Layout.IR.AffineLayerMap? Warp = null,
++        List<ClipOperation>? SuspendedClipOperations = null,
++        List<RectangleF>? SuspendedClipBounds = null);
+ 
+     private readonly record struct ClipOperation(
+         RectangleF Rect,
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,57 @@
+# Pending submodule patches
+
+A fix often belongs in a submodule rather than in this repository. When the push
+to that submodule's remote is authorized, the fix lands there and the pointer is
+bumped, and nothing appears here. When the push is denied — the submodule remote
+is outside the session's GitHub scope, so the git proxy answers **403** — the
+commit is captured here instead, as a `git format-patch` file, for a maintainer
+to apply upstream.
+
+**This directory is a backlog, not an archive.** A patch file is deleted once its
+fix is upstream and the submodule pointer is bumped, and the numbering restarts
+from `0001` against whatever is left. The same number therefore names different
+changes at different times, so never identify a patch by number in prose that
+outlives it — name the **commit subject** instead, and check whether a fix is
+live with:
+
+```sh
+git -C <Submodule> log --oneline --grep '<commit subject>'
+git -C <Submodule> merge-base --is-ancestor <sha> HEAD
+```
+
+`scripts/apply-pending-wpt-patches.sh` applies the listed patches to the
+checked-out submodule working trees before a WPT run, so a fix that is not in the
+pinned pointer is still exercised on CI. It is idempotent: once a maintainer
+lands one upstream and bumps the pointer, the patch's reverse-apply check starts
+succeeding and it is skipped rather than re-applied.
+
+## Index
+
+| Patch | Submodule | What it is |
+| --- | --- | --- |
+| `0001-html-svg-viewbox-intrinsic-ratio.patch` | `Broiler.HTML` | An SVG image's `viewBox` gives it an intrinsic aspect ratio whatever `preserveAspectRatio` says (SVG 2 §8.2), and an absolute `width`/`height` it states is reported even when the other one is missing. Listed in the apply script. |
+
+### `0001-html-svg-viewbox-intrinsic-ratio.patch`
+
+`StubImageAdapter.RasterizeSvg` read `preserveAspectRatio="none"` as removing the
+image's intrinsic aspect ratio. SVG 2 §8.2 derives the intrinsic sizing
+properties from `width`/`height`/`viewBox` alone; `preserveAspectRatio` governs
+how the content is fitted *once the viewport size is known*, which is a later
+question than what size the image asks to be. Reading it the other way made such
+an image report no ratio, so CSS sized it to the whole background positioning
+area.
+
+Measured over the full 26 366-test WPT reftest suite: **18 776 → 18 844 passing,
++68 / −0**, average match 98.42% → 98.46%. Every one of the 68 is in
+`css/css-backgrounds/background-size`, which goes **146 → 214 of 217** — the
+directory's SVGs all carry `preserveAspectRatio="none"`, so the whole family was
+failing by construction.
+
+**It is listed in `PENDING_PATCHES`**, and it has to be: it decides the concrete
+size of every SVG background image, which is a pixel difference on 68 tests that
+no unit test in this repository can reach — the sizing arithmetic lives in the
+submodule's `PaintWalker`, and what this patch changes is the intrinsic data fed
+into it.
+
+There is no main-repo half to pair it with, so nothing here compensates while it
+is pending; without the apply script the 68 tests stay red on CI.

--- a/patches/README.md
+++ b/patches/README.md
@@ -30,6 +30,7 @@ succeeding and it is skipped rather than re-applied.
 | Patch | Submodule | What it is |
 | --- | --- | --- |
 | `0001-html-svg-viewbox-intrinsic-ratio.patch` | `Broiler.HTML` | An SVG image's `viewBox` gives it an intrinsic aspect ratio whatever `preserveAspectRatio` says (SVG 2 §8.2), and an absolute `width`/`height` it states is reported even when the other one is missing. Listed in the apply script. |
+| `0002-html-affine-transform-layer.patch` | `Broiler.HTML` | A rotated or skewed element is resampled through its matrix instead of being dropped on the floor: `transform: rotate(45deg)` painted a blank page and took its whole subtree with it. Pairs with `Broiler.Layout.IR.AffineLayerMap` in the main repo. Listed in the apply script. |
 
 ### `0001-html-svg-viewbox-intrinsic-ratio.patch`
 
@@ -55,3 +56,45 @@ into it.
 
 There is no main-repo half to pair it with, so nothing here compensates while it
 is pending; without the apply script the 68 tests stay red on CI.
+
+### `0002-html-affine-transform-layer.patch`
+
+`BCanvas` maps a point per axis — `p → p·scale + translation` — so translation
+and axis-aligned scale (mirrors included, and therefore `rotate(180deg)`) fold
+into its own state, and anything carrying a `b` or `c` term does not.
+`GraphicsAdapter` routed those to the compat backend, which on a headless host is
+an inert stub, and that route also switches `CanUseRaster` off for **every draw
+the group encloses**. So `transform: rotate(45deg)` on a green square painted a
+**blank page**, and took its whole subtree with it. Opacity, filter and blend had
+already been moved off the same fall-through by degrading gracefully; a transform
+has somewhere better to go, because a finished layer can be resampled through a
+matrix the primitives cannot express.
+
+The patch is the call: an offscreen the contents draw into with the mapping
+unchanged, and a resample of it on the way out. The arithmetic is in the main
+repo — `Broiler.Layout.IR.AffineLayerMap`, with 20 tests — which is why this is
+310 lines and not a rewrite of every primitive.
+
+**The two halves must stay together, and neither does anything alone.** The map
+is inert with nothing calling it; the call does not compile without the map. The
+main-repo half is already in the pinned tree, so applying this patch is all that
+is outstanding.
+
+**Measured over the full 26 366-test WPT reftest suite: 18 776 → 18 771 passing,
++22 / −27**, average match 98.42% → 98.42%, and the run takes the same time
+(22:04 → 21:5x). The score going *down* is the honest result and is worth reading
+carefully:
+
+- **25 of the 27 losses have a rotation or skew on both sides**, so both rendered
+  blank and matched at 100%. That is the
+  [fake pass](../docs/wpt-reftests.md#the-bug-is-as-likely-to-be-in-the-reference-and-that-inverts-the-scoreboard)
+  this suite is built to produce, ending. The two that do not — `mix-blend-mode-rotated-clip`
+  and `3dtransform-and-filter-no-perspective-001` — were checked by rendering
+  them: the reference transforms too (through spellings a grep for `rotate`
+  misses), so both sides were blank there as well.
+- **13 of the 22 wins transform on only one side**, which could not have passed
+  before at all.
+- **The upside this suite structurally cannot show is in the golden one**, where
+  the reference is Chromium's render rather than Broiler's: **192 of the 6 914
+  golden-image failures declare a rotation or skew**, and a blank render can only
+  lose against a reference that shows the rotated content.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -367,7 +367,16 @@ set -euo pipefail
 # declares the same origin as its test, so the error cancels there and only stops cancelling
 # against a reference browser's screenshot. 272 tests in the corpus declare `transform-origin`.
 
+# The SVG intrinsic-ratio patch (Broiler.HTML, "image: an SVG's viewBox gives an
+# intrinsic ratio whatever preserveAspectRatio says") is listed because it decides
+# the concrete size of every SVG background image, and there is no main-repo half
+# to compensate while it is pending: the sizing arithmetic lives in the
+# submodule's PaintWalker and what this patch changes is the intrinsic data fed
+# into it, so nothing here can be unit-tested into standing in for it. Measured
+# over the full 26 366-test reftest suite it is +68 / -0 (18 776 -> 18 844
+# passing); without it those 68 css-backgrounds/background-size tests stay red.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0001-html-svg-viewbox-intrinsic-ratio.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -377,6 +377,7 @@ set -euo pipefail
 # passing); without it those 68 css-backgrounds/background-size tests stay red.
 PENDING_PATCHES=(
   "Broiler.HTML|patches/0001-html-svg-viewbox-intrinsic-ratio.patch"
+  "Broiler.HTML|patches/0002-html-affine-transform-layer.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/DataUriStylesheetLinkTests.cs
+++ b/src/Broiler.Cli.Tests/DataUriStylesheetLinkTests.cs
@@ -1,0 +1,140 @@
+using System.IO;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A <c>&lt;link rel="stylesheet" href="data:text/css,…"&gt;</c> carries its own sheet: there is
+/// nothing to fetch, and the payload is the stylesheet. The bridge handed the href to the resource
+/// loader like any other URL, and the loader dispatches only <c>file</c> and <c>http(s)</c> — so a
+/// data: sheet contributed nothing to the cascade and its link dispatched <c>error</c> instead of
+/// <c>load</c>.
+/// <para>
+/// The renderer's own stylesheet loader has always decoded data: URIs, which is what made this hard
+/// to see: a data: sheet written in the markup painted, while the CSSOM, <c>getComputedStyle</c>,
+/// and the link's load event all disagreed with the picture. A page that builds the link from
+/// script and waits on <c>link.onload</c> — <c>css-backgrounds/background-image-shared-stylesheet</c>
+/// is the WPT case, and the idiom is common enough on its own — never got the callback and stalled.
+/// </para>
+/// </summary>
+public sealed class DataUriStylesheetLinkTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "broiler-data-css-" + Guid.NewGuid().ToString("N"));
+
+    public DataUriStylesheetLinkTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { }
+    }
+
+    /// <summary>Runs <paramref name="bodyHtml"/> as a page in the temp directory and returns the
+    /// serialized result, so an <c>#out</c> element's text can be asserted on.</summary>
+    private string Run(string bodyHtml) =>
+        CaptureService.ExecuteScriptsWithDom(
+            "<!DOCTYPE html><html><head></head><body>" + bodyHtml + "</body></html>",
+            new Uri(Path.Combine(_dir, "page.html")).AbsoluteUri);
+
+    [Fact(Timeout = 600000)]
+    public void A_Script_Injected_Data_Sheet_Applies_To_The_Injecting_Document()
+    {
+        var result = Run("""
+<div id="probe">styled</div>
+<div id="out">not run</div>
+<script>
+window.onload = function() {
+  var link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'data:text/css,' + encodeURI('#probe { color: rgb(0, 128, 0); }');
+  document.head.appendChild(link);
+  document.getElementById('out').textContent =
+    getComputedStyle(document.getElementById('probe')).color;
+};
+</script>
+""");
+
+        Assert.Contains(">rgb(0, 128, 0)<", result);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Script_Injected_Data_Sheet_Fires_Load_Not_Error()
+    {
+        // The half the shared-stylesheet test turns on: it removes its iframe and starts its image
+        // load from link.onload, so an `error` here leaves the page waiting forever.
+        var result = Run("""
+<div id="out">no event</div>
+<script>
+window.onload = function() {
+  var link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'data:text/css,' + encodeURI('#out { color: rgb(0, 128, 0); }');
+  link.addEventListener('load', function(e) { document.getElementById('out').textContent = 'load ' + (e.currentTarget === link); });
+  link.addEventListener('error', function() { document.getElementById('out').textContent = 'error'; });
+  document.head.appendChild(link);
+};
+</script>
+""");
+
+        Assert.Contains(">load true<", result);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Data_Sheet_In_The_Markup_Reaches_Computed_Style()
+    {
+        // Not script-specific: the same sheet spelled in the markup painted (the renderer decodes
+        // data: URIs) while computed style read the unstyled value, so the two disagreed.
+        var result = Run("""
+<link rel="stylesheet" href="data:text/css,%23probe%20%7B%20color%3A%20rgb(0%2C%20128%2C%200)%3B%20%7D">
+<div id="probe">styled</div>
+<div id="out">not run</div>
+<script>
+document.getElementById('out').textContent = getComputedStyle(document.getElementById('probe')).color;
+</script>
+""");
+
+        Assert.Contains(">rgb(0, 128, 0)<", result);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Base64_Data_Sheet_Applies_Too()
+    {
+        // "#probe { color: rgb(0, 128, 0); }" base64-encoded — the other payload spelling RFC 2397
+        // allows, and the one a build tool emits.
+        var result = Run("""
+<link rel="stylesheet" href="data:text/css;base64,I3Byb2JlIHsgY29sb3I6IHJnYigwLCAxMjgsIDApOyB9">
+<div id="probe">styled</div>
+<div id="out">not run</div>
+<script>
+document.getElementById('out').textContent = getComputedStyle(document.getElementById('probe')).color;
+</script>
+""");
+
+        Assert.Contains(">rgb(0, 128, 0)<", result);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void The_Shared_Sheet_Case_Applies_To_Both_Documents()
+    {
+        // The shape the WPT test is named for: one data: URL used as a stylesheet by an iframe and,
+        // separately, by the page that built the iframe. The child's copy applying must not be the
+        // only one that does — that was the exact symptom, a green iframe on an unstyled page.
+        var result = Run("""
+<iframe id="frame"></iframe>
+<div id="probe">styled</div>
+<div id="out">not run</div>
+<script>
+window.onload = function() {
+  var sheet = 'data:text/css,' + encodeURI('#probe { color: rgb(0, 128, 0); }');
+  document.getElementById('frame').srcdoc = '<link rel="stylesheet" href="' + sheet + '"><div id="probe">child</div>';
+  var link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = sheet;
+  document.head.appendChild(link);
+  document.getElementById('out').textContent =
+    getComputedStyle(document.getElementById('probe')).color;
+};
+</script>
+""");
+
+        Assert.Contains(">rgb(0, 128, 0)<", result);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
@@ -32,6 +32,24 @@ public sealed partial class DomBridge
         // every one of them declares transform-box in a <style> block rather than as an attribute.
         // Neither inherits, so the cascaded value is this element's own and may overwrite the
         // attribute — the same reasoning `fill` and `stroke` are given above.
+        // `transform` itself is the third of them, and it was the one left out — so a
+        // `#target { transform: rotate(90deg) }` rule reached nothing and the element rendered
+        // untransformed, which is the whole of what the css-transforms/transform-box `svgbox-*`
+        // family measures: each declares its transform in a <style> block. `transform-box` and
+        // `transform-origin` were already projected, and on their own they can only move a
+        // transform that arrived by attribute.
+        //
+        // A value that parses no function at all is skipped rather than written, and that is not a
+        // detail — it is the rule CSS Transforms 1 §3 states. This bridge's cascade does not model
+        // SVG presentation attributes as declarations, so an element carrying
+        // `transform="translate(50)"` and no rule computes `none`, and writing that back would
+        // erase the attribute the renderer was going to read. The same guard is what makes an
+        // *invalid* declaration fall back to the attribute instead of destroying it:
+        // `transform: scale(invalid)` must leave `transform="rotate(90)"` standing, which is
+        // exactly what the nine svg-{document,external,inline}-styles-005/006/013 tests assert.
+        ApplySvgPresentationAttribute(
+            element, props, "transform", cascadeWins: true,
+            accept: static value => Layout.IR.SvgTransform.TryParse(value, out _));
         ApplySvgPresentationAttribute(element, props, "transform-box", cascadeWins: true);
         ApplySvgPresentationAttribute(element, props, "transform-origin", cascadeWins: true);
 
@@ -88,7 +106,7 @@ public sealed partial class DomBridge
     /// </param>
     private void ApplySvgPresentationAttribute(
         DomElement element, Dictionary<string, string> props, string propertyName,
-        bool preferInlineStyle = false, bool cascadeWins = false)
+        bool preferInlineStyle = false, bool cascadeWins = false, Func<string, bool>? accept = null)
     {
         if (!cascadeWins && HasAttr(element, propertyName))
             return;
@@ -102,6 +120,12 @@ public sealed partial class DomBridge
             value = fallbackProp;
 
         if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        // A value the caller will not accept carries no author intent this attribute should take,
+        // and writing it would overwrite one that does. See the `transform` call site for why that
+        // is not hypothetical.
+        if (accept is not null && !accept(value.Trim()))
             return;
 
         SetAttr(element, propertyName, value.Trim());

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -359,7 +359,12 @@ public sealed partial class DomBridge
             {
                 try
                 {
-                    var fetchedCss = FetchExternalStylesheet(href);
+                    // Through the data:-aware seam, not the loader directly: a
+                    // <link rel="stylesheet" href="data:text/css,…"> carries its own sheet and
+                    // never goes on the wire. The loader only dispatches file/http(s), so a data:
+                    // href fetched as an ordinary URL came back empty and the sheet — the whole
+                    // sheet, for a link a script builds at run time — silently did not apply.
+                    var fetchedCss = FetchStyleSheetText(href);
                     if (!string.IsNullOrEmpty(fetchedCss))
                     {
                         StyleSheetStateFor(styleEl).FetchedCss.Set(fetchedCss);
@@ -713,9 +718,11 @@ public sealed partial class DomBridge
         // The resource loader only takes absolute URLs, so the content attribute is resolved against
         // the page URL first — the same rebasing the renderer does for a linked sheet. Skipping it
         // made every relative href look like a failed fetch and dispatched `error` for a sheet that
-        // then applied perfectly well.
+        // then applied perfectly well. A data: href is already its own absolute URL and carries the
+        // sheet in it, so it is read through the same seam the cascade uses rather than rebased and
+        // handed to the loader, which knows no data: scheme and reported the sheet as failed.
         var loaded = IsExternalStyleAllowedByCsp(element, href) &&
-                     !string.IsNullOrEmpty(FetchExternalStylesheet(ResolveAgainstPageUrl(href)));
+                     !string.IsNullOrEmpty(FetchStyleSheetText(ResolveStyleSheetLinkUrl(href)));
 
         try
         {
@@ -739,6 +746,17 @@ public sealed partial class DomBridge
         Uri.TryCreate(baseUri, url, out var resolved)
             ? resolved.AbsoluteUri
             : url;
+
+    /// <summary>
+    /// The URL a <c>&lt;link rel="stylesheet"&gt;</c>'s sheet is read from: a <c>data:</c> href
+    /// verbatim, anything else resolved against the page URL. The verbatim case matters — round
+    /// tripping a data: URL through <see cref="Uri"/> normalizes the percent-escapes its payload is
+    /// made of, and the payload is the stylesheet.
+    /// </summary>
+    private string ResolveStyleSheetLinkUrl(string href) =>
+        href.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+            ? href
+            : ResolveAgainstPageUrl(href);
 
     /// <summary>Fires the stylesheet <c>load</c> event for <paramref name="element"/> and every
     /// <c>&lt;link rel="stylesheet"&gt;</c> beneath it — the subtree counterpart used when a whole
@@ -781,6 +799,11 @@ public sealed partial class DomBridge
                 continue;
 
             if (!TryGetAttribute(styleEl, "href", out var href) || string.IsNullOrEmpty(href))
+                continue;
+
+            // A data: sheet is decoded in-process by the consuming path and never reaches the
+            // loader, so prefetching one buys nothing and would leave an unconsumed entry behind.
+            if (href.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
                 continue;
 
             // Already fetched for this document — the consuming path reads the cached text and

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleImports.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleImports.cs
@@ -280,16 +280,22 @@ public sealed partial class DomBridge
         return UrlResolver.Resolve(href, string.IsNullOrEmpty(baseUrl) ? _pageUrl : baseUrl)?.AbsoluteUri;
     }
 
-    /// <summary>Fetches the CSS text for an already-absolute stylesheet URL — decoding a
-    /// <c>data:</c> URI in-process, or loading <c>file</c>/<c>http(s)</c> via the loader.</summary>
-    private string? FetchStyleSheetText(string absoluteUrl)
+    /// <summary>
+    /// Fetches the CSS text for a stylesheet URL — decoding a <c>data:</c> URI in-process, or
+    /// loading <c>file</c>/<c>http(s)</c> via the loader. The seam every stylesheet read goes
+    /// through, <c>@import</c> and <c>&lt;link rel="stylesheet"&gt;</c> alike, so a <c>data:</c>
+    /// sheet is decoded wherever it is named rather than only where someone remembered to.
+    /// Anything but a <c>data:</c> URI is passed to the loader as given, which for a
+    /// <c>&lt;link&gt;</c> href means the caller resolves it first if it needs to be absolute.
+    /// </summary>
+    private string? FetchStyleSheetText(string url)
     {
-        if (absoluteUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
         {
-            var (_, body) = DecodeDataUriParts(absoluteUrl);
+            var (_, body) = DecodeDataUriParts(url);
             return body;
         }
-        return FetchExternalStylesheet(absoluteUrl);
+        return FetchExternalStylesheet(url);
     }
 
     /// <summary>

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -11816,4 +11816,41 @@ div {{ width: 256px; height: 768px; }}
         Assert.Null(WptTestRunner.TryResolveWptRootRelativePath("/", _tempDir));
         Assert.Null(WptTestRunner.TryResolveWptRootRelativePath("/nope/missing.png?x", _tempDir));
     }
+
+    [Fact(Timeout = 600000)]
+    public void TryResolveWptRootRelativePath_Reads_A_Corpus_Path_Back_Out_Of_A_File_Url()
+    {
+        // A run hands each document a file:///… page URL, so a script that absolutizes a
+        // root-relative corpus path — new URL("/images/green.png", location.href).href, the idiom
+        // WPT uses whenever a URL has to be passed to another document — produces
+        // file:///images/green.png: the filesystem root, not the checkout. Nothing served it and
+        // the /-prefix test did not recognise it, so the resource silently failed to load while the
+        // same path written literally in the markup loaded fine
+        // (css-backgrounds/background-image-shared-stylesheet, whose whole assertion is that the
+        // image the stylesheet names paints).
+        Directory.CreateDirectory(Path.Combine(_tempDir, "images"));
+        var onDisk = Path.Combine(_tempDir, "images", "green.png");
+        File.WriteAllText(onDisk, "not-really-a-png");
+
+        Assert.Equal(onDisk, WptTestRunner.TryResolveWptRootRelativePath("file:///images/green.png", _tempDir));
+        Assert.Equal(onDisk, WptTestRunner.TryResolveWptRootRelativePath("file:///images/green.png?pipe=trickle(d2)&0.5", _tempDir));
+        Assert.Equal(onDisk, WptTestRunner.TryResolveWptRootRelativePath("file:///images/green%2Epng", _tempDir));
+
+        // Still null when the corpus does not hold it — the remap only ever finds a real file.
+        Assert.Null(WptTestRunner.TryResolveWptRootRelativePath("file:///images/missing.png", _tempDir));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void TryResolveWptRootRelativePath_Leaves_A_File_Url_That_Resolves_On_Its_Own_Alone()
+    {
+        // The guard on the remap above: a file: URL naming a real file is already resolved, and
+        // reinterpreting its path as corpus-relative would point a test's own sibling resource at
+        // an unrelated file that happened to sit at the same path under the checkout. Returning
+        // null leaves it to the engine, which reads it directly.
+        Directory.CreateDirectory(Path.Combine(_tempDir, "images"));
+        var onDisk = Path.Combine(_tempDir, "images", "blue.png");
+        File.WriteAllText(onDisk, "not-really-a-png");
+
+        Assert.Null(WptTestRunner.TryResolveWptRootRelativePath(new Uri(onDisk).AbsoluteUri, _tempDir));
+    }
 }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2679,6 +2679,7 @@ internal sealed partial class WptTestRunner
         // once substituted. WPT serves every one of those hosts from this same checkout, so such a
         // URL is the root-relative one with an origin in front of it.
         src = WptSubstitution.TryStripServedOrigin(src) ?? src;
+        src = TryStripUnservedFileOrigin(src) ?? src;
 
         if (src == null || !src.StartsWith("/", StringComparison.Ordinal))
             return null;
@@ -2709,6 +2710,46 @@ internal sealed partial class WptTestRunner
         // regardless, because it resolves against the process's working directory, so
         // the failure is invisible: the render simply comes out with no image.
         return Path.GetFullPath(local);
+    }
+
+    /// <summary>
+    /// The root-relative form of a <c>file:</c> URL that names nothing on disk, or <see langword="null"/>
+    /// for anything else — including a <c>file:</c> URL that does name a real file, which is already
+    /// resolved and must be left exactly as it is.
+    /// </summary>
+    /// <remarks>
+    /// A run gives each document a <c>file:///…</c> page URL, so a script that absolutizes a
+    /// root-relative corpus path — <c>new URL("/images/green.png", location.href).href</c>, the
+    /// idiom WPT uses whenever a URL has to be handed to another document — produces
+    /// <c>file:///images/green.png</c>: the filesystem root, not the checkout. Nothing serves that,
+    /// and the caller's <c>/</c>-prefix test does not recognise it either, so the resource silently
+    /// did not load while the same path written literally in the markup loaded fine. Reading the
+    /// path back out of such a URL is the <c>file:</c> counterpart of stripping a served WPT origin,
+    /// and it is strictly additive: it only ever turns a resource that was not found into one the
+    /// corpus holds, because a <c>file:</c> URL that resolves on its own is returned untouched and
+    /// the caller still requires the corpus to actually hold what is left.
+    /// </remarks>
+    private static string? TryStripUnservedFileOrigin(string? url)
+    {
+        if (url == null || !url.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !uri.IsFile)
+            return null;
+
+        try
+        {
+            if (File.Exists(uri.LocalPath))
+                return null;
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return null;
+        }
+
+        // PathAndQuery, not AbsolutePath: the query is what the caller strips, and a WPT resource
+        // routinely carries one it is identified by (`?pipe=trickle(d2)`, a cache-buster).
+        return uri.PathAndQuery;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Seven fixes found by working [#1788](https://github.com/Broiler-Platform/Broiler/issues/1788) — the WPT reftest "biggest problems" list — and then by ranking directories by **pass rate** rather than by match percentage, which is what actually separated missing features from scattered bugs.

Two of them are **rotation and SVG transforms not painting at all**, which no score can excuse.

## Changes

### Rotated and skewed transforms painted nothing at all
`transform: rotate(45deg)` on a green square produced a **blank page**, and took its whole subtree with it. The raster canvas maps a point per axis (`p → p·scale + translation`), so translation and axis-aligned scale fold into its own state and anything with a `b`/`c` term does not; those fell through to a compat backend that on a headless host is an inert stub, and the fall-through also stops every draw the group encloses from reaching the canvas.

`Broiler.Layout.IR.AffineLayerMap` (main repo) is the arithmetic — it conjugates the CSS matrix by the surface mapping, and inverse-maps so the resample is hole-free. The submodule half opens an offscreen the contents draw into untransformed and resamples it on the way out, so **every primitive keeps the arithmetic it already has**. Ancestor clips are suspended while the layer fills and applied at the composite, which is where CSS Transforms 1 §3 puts them.

### A CSS `transform` rule never reached an SVG element
`transform-box` and `transform-origin` were projected onto the SVG presentation attribute; `transform` itself was not, so `rect { transform: rotate(90deg) }` did nothing. The guard is the interesting half: a value that parses no transform function is skipped rather than written, which is what makes an *invalid* declaration fall back to the `transform` attribute instead of destroying it. `SvgTransform.TryParse` makes that decidable — `scale(invalid)` and `rotate(0deg)` both compute to the identity and only one may lose to the attribute.

### `image-set()` selected nothing, whatever it held
It was recognised as an image value and never resolved, so it reached two readers that each understand only part of what it can hold — the background loader looks for `url(`, the paint walker looks for `gradient(`. `Broiler.Layout.IR.CssImageSet` resolves the selection into the value before either sees it: resolution units (`x`/`dppx`, `dpi`, `dpcm`, `calc()`), omitted resolution as 1x, `type()` filtering, and smallest-that-reaches-the-device / largest-when-none-does / first-on-a-tie.

### An SVG image's `viewBox` gives it an intrinsic ratio
`preserveAspectRatio="none"` was read as removing it. SVG 2 §8.2 derives the intrinsic sizing properties from `width`/`height`/`viewBox` alone; `preserveAspectRatio` governs how content is fitted *after* the viewport size is known. Every SVG in the `background-size/vector` family carries it, so the whole family sized to the positioning area.

### A `data:text/css` `<link>` contributed nothing to the cascade
The sheet is in the URL, but the href went to the resource loader, which dispatches `file` and `http(s)` only. The renderer's own loader has always decoded `data:`, so such a sheet *painted* while `getComputedStyle` and the link's load event said it had not loaded — the symptom was a script waiting forever on `link.onload`.

### `display: contents` on the root element dropped the canvas
The pass blockified the box it was handed, but the renderer hands it the *anonymous document box* — `<html>` is a child of that, so the real root element was spliced out and the canvas background went with it.

### The runner could not read a corpus path out of a `file:` URL
`new URL("/images/green.png", location.href).href` — the WPT idiom for handing a URL to another document — produces `file:///images/green.png`. `TryResolveWptRootRelativePath` now reads the path back out, strictly additively.

## Measurements

Each measured over the **full 26,366-test WPT reftest suite**, against the build immediately before it, with both pending patches applied:

| Change | Reftest suite |
| --- | --- |
| SVG `viewBox` intrinsic ratio | **+68 / −0** (`css-backgrounds/background-size` 146 → 214 of 217) |
| `image-set()` resolution | **+22 / −0** (`css-images/image-set` 10 → 32 of 37) |
| SVG `transform` projection | **+12 / −0** (four transform families 29 → 39 of 75) |
| Rotated-layer resample | **+22 / −27** — see below |
| `data:text/css` link | `background-image-shared-stylesheet` 0.0% → **100.0%** |
| `display: contents` root | `display-contents-root-background` 0.0% → **100.0%** |

**The rotation fix lowers the reftest score by 5, and that is the honest result.** This suite renders *both* sides with Broiler, so 25 of its 27 losses rotate on both sides — both used to render blank and match at 100%. The other two were checked by rendering them; their references transform too. 13 of the 22 wins transform on only one side and could not have passed before at all. The upside is in the golden suite, which this one structurally cannot show: **192 of its 6,914 failures declare a rotation or skew**, and a blank render can only lose against a Chromium reference that shows the rotated content.

Unit tests: `CssImageSetTests` **32** cases, `AffineLayerMapTests` **20**, plus additions to `SvgTransformTests`, `DisplayContentsBoxesTests`, `WptTestRunnerTests` and a new `DataUriStylesheetLinkTests` (5, all failing on the parent commit). `Broiler.Layout.Tests` 1309/1309. `Broiler.Cli.Tests` and `Broiler.Wpt.Tests` unchanged at their documented baselines (49 and 54 failing).

## Submodule patches

Two fixes are in `Broiler.HTML`; the push was denied (403), so they ship as patches and are listed in `PENDING_PATCHES`. Both WPT shard actions run `scripts/apply-pending-wpt-patches.sh`, so CI exercises them.

- `patches/0001-html-svg-viewbox-intrinsic-ratio.patch`
- `patches/0002-html-affine-transform-layer.patch` — pairs with `AffineLayerMap`; **neither half does anything alone.**

## Known limits, filed rather than hidden

- **`transform-box` is still unread**, and underneath it `transform-origin` is honoured on `<rect>` and nowhere else — that needs each element's fill box, stroke box and viewport rect where the transform is composed.
- **`image-set()`'s resolution does not size the image** (3 tests), and an invalid one does not drop its declaration (2 tests, needs `Broiler.CSS`'s validator).
- **`document.styleSheets` omits every `<link>` sheet** on the main document, where a sub-document's already lists them.
- **The reftest runner is not run-to-run deterministic**: `background-blend-mode-plus-lighter` is 93.6% every time in isolation and returned 100.0% in one sweep of four. A single-run diff carries about a test of noise each way — which is why the transform-projection figure above is +12 and not the +13 a single sweep showed.

https://claude.ai/code/session_01VzR2khcAg4qgityTfzRTVi