### PR TITLE
Fix viewport resolution, scroll geometry, and four rendering bugs

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/SvgImageRasterTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgImageRasterTests.cs
@@ -487,4 +487,79 @@ public sealed class SvgImageRasterTests
         Assert.Throws<ArgumentNullException>(
             () => SvgImageRaster.Render(svg, Bounds, new RecordingBackend(), null!));
     }
+
+    /// <summary>
+    /// CSS Backgrounds §2.11.2: the root element's background is the canvas's, and for an SVG used
+    /// as an image that canvas is the destination box. It is painted first, behind the document.
+    /// </summary>
+    /// <remarks>
+    /// Nothing painted it, so a file drawing tinted shapes over a dark ground rendered them on
+    /// white. Asserted on the display list rather than on pixels because that is where the ordering
+    /// lives — a background emitted after the shapes would cover them.
+    /// </remarks>
+    [Theory(Timeout = 600000)]
+    [InlineData("background: black")]
+    [InlineData("background-color: black")]
+    [InlineData("background: url(none.png) black")]
+    public void A_Root_Background_Paints_The_Canvas_Behind_The_Document(string declaration)
+    {
+        var svg = $"<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' " +
+                  $"viewBox='0 0 100 100' style='{declaration}'>" +
+                  "<rect fill='blue' x='10' y='10' width='20' height='20' /></svg>";
+
+        var items = SvgImageRaster.BuildDisplayList(svg, Bounds).Items;
+
+        var first = Assert.IsType<DrawSvgRectItem>(items[0]);
+        Assert.Equal(0, first.Fill.R);
+        Assert.Equal(0, first.Fill.G);
+        Assert.Equal(0, first.Fill.B);
+        Assert.Equal(255, first.Fill.A);
+
+        // It covers the whole destination box, not the shape's bounds.
+        Assert.Equal(Bounds.Width, first.Width);
+        Assert.Equal(Bounds.Height, first.Height);
+
+        // And the document is still drawn, over it.
+        Assert.Contains(items.Skip(1), i => i is DrawSvgRectItem { Fill.B: 255 });
+    }
+
+    /// <summary>
+    /// A root that declares no background, or a fully transparent one, adds nothing — an SVG image
+    /// is transparent where it paints nothing, and stamping an opaque rect would hide whatever the
+    /// image is composited over.
+    /// </summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("")]
+    [InlineData("style='background: transparent'")]
+    [InlineData("style='background: none'")]
+    [InlineData("style='fill: black'")]
+    public void No_Root_Background_Paints_No_Canvas(string attribute)
+    {
+        var svg = $"<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' " +
+                  $"viewBox='0 0 100 100' {attribute}>" +
+                  "<rect fill='blue' x='10' y='10' width='20' height='20' /></svg>";
+
+        var items = SvgImageRaster.BuildDisplayList(svg, Bounds).Items;
+
+        var first = Assert.IsType<DrawSvgRectItem>(items[0]);
+        Assert.Equal(20, first.Width);
+    }
+
+    /// <summary>
+    /// The inline path must <em>not</em> paint it: an inline <c>&lt;svg&gt;</c> is an ordinary
+    /// element whose CSS box already paints its background, and doing it again would double a
+    /// translucent colour over itself.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void The_Inline_Renderer_Leaves_The_Root_Background_To_The_Css_Box()
+    {
+        var svg = "<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' " +
+                  "viewBox='0 0 100 100' style='background: black'>" +
+                  "<rect fill='blue' x='10' y='10' width='20' height='20' /></svg>";
+
+        var inline = SvgRenderer.RenderSvgContent(svg, Bounds);
+
+        var first = Assert.IsType<DrawSvgRectItem>(inline[0]);
+        Assert.Equal(20, first.Width);
+    }
 }

--- a/Broiler.Layout/Broiler.Layout/BoxGeometry.cs
+++ b/Broiler.Layout/Broiler.Layout/BoxGeometry.cs
@@ -19,4 +19,57 @@ namespace Broiler.Layout;
 public readonly record struct BoxGeometry(
     RectangleF BorderBox,
     RectangleF PaddingBox,
-    RectangleF ContentBox);
+    RectangleF ContentBox)
+{
+    /// <summary>
+    /// The three box-model levels of an <em>inline</em> box, whose border box has been rebuilt from
+    /// the union of its per-line rectangles because a <c>display: inline</c> box lays out as one
+    /// rectangle per line rather than as a single box.
+    /// </summary>
+    /// <param name="borderBox">The union of the box's per-line rectangles.</param>
+    /// <param name="box">The box the rectangles belong to, read for its used border and padding.</param>
+    /// <remarks>
+    /// <para>
+    /// For a <b>non-replaced</b> inline the three levels genuinely coincide here: this engine's line
+    /// geometry carries no box-model padding or border for one, so there is nothing to deflate out
+    /// and all three are the union.
+    /// </para>
+    /// <para>
+    /// For a <b>replaced</b> inline they do not, and treating them as if they did is what made
+    /// <c>clientWidth</c>/<c>clientHeight</c> wrong on every inline image with a border or padding.
+    /// <c>CssLineBox.UpdateRectangle</c> adds an image's border and padding to its line rectangle
+    /// explicitly, and <c>MeasureImageSize</c> adds them in the block axis, so the union really is
+    /// the border box and the other two levels have to be deflated out of it.
+    /// <c>&lt;img style="width:50px;height:30px;border:3px solid"&gt;</c> reported
+    /// <c>getBoundingClientRect</c> 56×36 — right — and <c>clientWidth</c>/<c>clientHeight</c> 56×36
+    /// too, where the client box excludes the border and must be 50×30. The same declarations on a
+    /// <c>&lt;div&gt;</c> or an <c>inline-block</c> already reported 50×30, so the two paths
+    /// disagreed with each other as well as with the spec.
+    /// </para>
+    /// </remarks>
+    internal static BoxGeometry ForInlineBox(RectangleF borderBox, Engine.CssBox box)
+    {
+        if (box is null || !box.IsImage)
+            return new BoxGeometry(borderBox, borderBox, borderBox);
+
+        var paddingBox = Deflate(borderBox,
+            box.ActualBorderLeftWidth, box.ActualBorderTopWidth,
+            box.ActualBorderRightWidth, box.ActualBorderBottomWidth);
+
+        var contentBox = Deflate(paddingBox,
+            box.ActualPaddingLeft, box.ActualPaddingTop,
+            box.ActualPaddingRight, box.ActualPaddingBottom);
+
+        return new BoxGeometry(borderBox, paddingBox, contentBox);
+    }
+
+    /// <summary>Shrinks a rectangle by the given edges, never past zero extent.</summary>
+    private static RectangleF Deflate(RectangleF r, double left, double top, double right, double bottom)
+    {
+        float x = r.X + (float)left;
+        float y = r.Y + (float)top;
+        float width = Math.Max(0f, r.Width - (float)(left + right));
+        float height = Math.Max(0f, r.Height - (float)(top + bottom));
+        return new RectangleF(x, y, width, height);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -117,6 +117,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         return direction is not ("column" or "column-reverse");
     }
 
+    /// <summary>A flex container whose main axis is the block axis, so its cross axis is inline.</summary>
+    internal bool IsColumnFlexContainer() => IsFlexContainer() && !IsRowFlexContainer();
+
     internal void PerformFlexRowLayout(ILayoutEnvironment g)
     {
         using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Flex);

--- a/Broiler.Layout/Broiler.Layout/Engine/FlexGridItemBlockification.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/FlexGridItemBlockification.cs
@@ -117,6 +117,104 @@ internal static class FlexGridItemBlockification
         && IsInFlowItem(box);
 
     /// <summary>
+    /// Whether a replaced box that is about to be wrapped in an anonymous block — because it is a
+    /// <em>column</em> flex item, which <see cref="IsRowFlexItem"/> deliberately does not exempt —
+    /// must be made to fill that wrapper, because the item it becomes will be stretched across the
+    /// flex line (CSS Flexbox §9.4 step 11).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The wrapper is an implementation artifact: to the spec the replaced element <em>is</em> the
+    /// flex item, and stretching it is what gives it its cross size. With the wrapper in between,
+    /// the stretch lands on the wrapper and the image inside keeps an <c>auto</c> width — which for
+    /// an inline replaced box with no intrinsic size means the 300×150 default object size. So
+    /// <c>&lt;div style="display:flex;flex-direction:column"&gt;&lt;img&gt;</c> holding an SVG sized
+    /// <c>100%</c> with a 2:1 <c>viewBox</c> painted a 300×150 rectangle where every browser paints
+    /// one the full width of the container, its height derived through the ratio
+    /// (<c>css-flexbox/aspect-ratio-intrinsic-size-007</c>).
+    /// </para>
+    /// <para>
+    /// The conditions are §9.4 step 11's own, asked before layout: the item resolves to
+    /// <c>stretch</c>, its cross size is <c>auto</c>, and neither cross-axis margin is <c>auto</c>.
+    /// A container that aligns its items any other way leaves the wrapper to shrink-wrap, and
+    /// filling it would then be circular. It is the same trade the auto-side-margin case in the
+    /// wrapping fix-up already makes, and it lives here beside <see cref="IsRowFlexItem"/> so the
+    /// two readings of "what is the item" cannot drift apart.
+    /// </para>
+    /// <para>
+    /// <b>Two further conditions are what make <c>width: 100%</c> an exact stand-in for the
+    /// stretch rather than an approximation of it, and both were found by measuring.</b> A
+    /// percentage width sizes the <em>content</em> box while a stretch sizes the <em>border</em>
+    /// box, so the two agree only when the replaced element has no inline-axis padding or border —
+    /// with <c>img { padding: 20px }</c> in a 240px container the shortcut overflows by exactly the
+    /// padding (<c>flex-aspect-ratio-intrinsic-padding-001</c>, whose assertion names the content
+    /// box outright). And the container's cross size has to come from outside rather than from its
+    /// own contents: an <c>inline-flex</c> column container shrink-wraps to its items, so an item
+    /// declared <c>100%</c> of it contributes nothing to the size it is a percentage of, and the
+    /// container collapses (<c>inline-flex-column-image-load</c>). Both of those pass today and
+    /// must keep passing.
+    /// </para>
+    /// <para>
+    /// Outside those conditions the stretch still belongs on the replaced element and is still not
+    /// applied — that is the general form of this gap, and it wants the cross size pushed onto the
+    /// box during flex layout rather than a declaration rewritten before it.
+    /// </para>
+    /// </remarks>
+    internal static bool IsStretchedColumnFlexItem(CssBox box)
+    {
+        if (box?.ParentBox is not { } parent)
+            return false;
+
+        // `inline-flex` is deliberately excluded: its cross size is shrink-to-fit, so a
+        // percentage against it is circular. Only a block-level `flex` container's cross size is
+        // settled without consulting the item.
+        if (parent.Display != "flex" || !parent.IsColumnFlexContainer() || !IsInFlowItem(box))
+            return false;
+
+        // `align-self: auto` defers to the container's `align-items`; `normal` behaves as
+        // `stretch` for a flex item, and it is what an unstyled container has.
+        var align = box.AlignSelf;
+        if (string.IsNullOrEmpty(align) || align is "auto")
+            align = parent.AlignItems;
+        if (!(string.IsNullOrEmpty(align) || align is "normal" or "stretch"))
+            return false;
+
+        if (!string.IsNullOrEmpty(box.Width) && box.Width != CssConstants.Auto)
+            return false;
+
+        if (box.MarginLeft == CssConstants.Auto || box.MarginRight == CssConstants.Auto)
+            return false;
+
+        return !HasInlineAxisSpacing(box);
+    }
+
+    /// <summary>
+    /// Whether the box has any inline-axis padding or border, which is what separates a
+    /// content-box percentage width from a border-box stretch.
+    /// </summary>
+    private static bool HasInlineAxisSpacing(CssBox box) =>
+        !IsZeroLength(box.PaddingLeft)
+        || !IsZeroLength(box.PaddingRight)
+        || DrawsBorder(box.BorderLeftStyle, box.BorderLeftWidth)
+        || DrawsBorder(box.BorderRightStyle, box.BorderRightWidth);
+
+    private static bool IsZeroLength(string? value)
+    {
+        var v = value?.Trim();
+        return string.IsNullOrEmpty(v) || v is "0" or "0px" or "0%" or "0em" or "0rem";
+    }
+
+    /// <summary>A border occupies space only when its style is neither <c>none</c> nor
+    /// <c>hidden</c>; the <c>medium</c> default width means nothing on its own.</summary>
+    private static bool DrawsBorder(string? style, string? width)
+    {
+        var s = style?.Trim();
+        if (string.IsNullOrEmpty(s) || s is CssConstants.None or "hidden")
+            return false;
+        return !IsZeroLength(width);
+    }
+
+    /// <summary>
     /// CSS Flexbox §4 / CSS Grid §6: "each contiguous sequence of child text runs is wrapped in an
     /// anonymous block container flex item… However, if the entire sequence of child text runs
     /// contains only white space it is instead not rendered."

--- a/Broiler.Layout/Broiler.Layout/IR/SvgImageRaster.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgImageRaster.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using Broiler.Graphics;
 
 namespace Broiler.Layout.IR;
 
@@ -76,7 +77,35 @@ public static class SvgImageRaster
         SvgTextEnvironment.Reset(null);
         try
         {
-            return new() { Items = SvgRenderer.RenderSvgContent(svgXml, bounds, effectiveZoom) };
+            var items = SvgRenderer.RenderSvgContent(svgXml, bounds, effectiveZoom);
+
+            // CSS Backgrounds §2.11.2: the root element's background paints the canvas, and for an
+            // SVG document used as an image that canvas is the destination box. Nothing painted it:
+            // `<svg style="background: black">` came back transparent, so a file that draws tinted
+            // shapes over a dark ground rendered them on white.
+            //
+            // It belongs here rather than in SvgRenderer because SvgRenderer serves both callers,
+            // and the *inline* one must not do this: an inline <svg> is an ordinary element whose
+            // CSS box already paints its background, so painting it again would double a
+            // translucent colour over itself. Only an image has no box to have done it.
+            // Emitted as the same rect primitive every other shape uses, so it replays through the
+            // backend arm that is already there rather than needing a new one.
+            if (SvgRenderer.TryGetRootBackgroundColor(svgXml, out var canvas))
+            {
+                items.Insert(0, new DrawSvgRectItem
+                {
+                    Bounds = bounds,
+                    X = bounds.X,
+                    Y = bounds.Y,
+                    Width = bounds.Width,
+                    Height = bounds.Height,
+                    Fill = canvas,
+                    Stroke = BColor.Empty,
+                    StrokeWidth = 0,
+                });
+            }
+
+            return new() { Items = items };
         }
         finally
         {

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -1218,6 +1218,61 @@ internal static partial class SvgRenderer
         return ParseColorValue(val, defaultColor);
     }
 
+    /// <summary>
+    /// The colour the root <c>&lt;svg&gt;</c> element declares as its background, if any.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// CSS Backgrounds §2.11.2 makes the root element's background the canvas's. For an SVG document
+    /// used <em>as an image</em> that canvas is the destination box, and nothing painted it — a file
+    /// opening <c>&lt;svg style="background: black"&gt;</c> came back transparent, so a document
+    /// drawing tinted shapes over a dark ground rendered them on white instead.
+    /// </para>
+    /// <para>
+    /// Only <see cref="SvgImageRaster"/> asks. An <em>inline</em> <c>&lt;svg&gt;</c> is an ordinary
+    /// element whose CSS box already paints its background, so painting it here as well would double
+    /// a translucent colour over itself; an image has no box to have done it.
+    /// </para>
+    /// <para>
+    /// <c>background</c> is a shorthand, so its colour is taken as the last component that parses as
+    /// one — which covers <c>background: green</c>, <c>background: #001</c> and
+    /// <c>background: url(x) navy</c> alike. <c>background-color</c> is preferred when both are
+    /// present, matching the cascade's own order for a longhand written after the shorthand.
+    /// </para>
+    /// </remarks>
+    internal static bool TryGetRootBackgroundColor(string svgXml, out BColor color)
+    {
+        color = BColor.Empty;
+        if (string.IsNullOrEmpty(svgXml))
+            return false;
+
+        var svgMatch = ParseRegex().Match(svgXml);
+        if (!svgMatch.Success)
+            return false;
+
+        var attrs = ParseAttributes(svgMatch.Groups[1].Value);
+
+        var longhand = GetPresentationValue(attrs, "background-color");
+        if (!string.IsNullOrWhiteSpace(longhand))
+        {
+            color = ParseColorValue(longhand.Trim(), BColor.Empty);
+            return !color.IsEmpty && color.A > 0;
+        }
+
+        var shorthand = GetPresentationValue(attrs, "background");
+        if (string.IsNullOrWhiteSpace(shorthand))
+            return false;
+
+        foreach (var token in shorthand.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parsed = ParseColorValue(token.Trim(), BColor.Empty);
+            if (!parsed.IsEmpty)
+                color = parsed;
+        }
+
+        return !color.IsEmpty && color.A > 0;
+    }
+
     /// <summary>Parses one already-resolved colour value; <c>none</c> and empty are "no paint".</summary>
     private static BColor ParseColorValue(string val, BColor defaultColor)
     {

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -281,6 +281,21 @@ over the whole suite; `css/css-display` had just 9, of which the top-thirty entr
 Neither is visible as a *cluster* from the severity ranking, which by design shows
 one line per test.
 
+**#1792 is the third run where that grouping beat the ranking, and the cleanest
+example of why.** Its top forty opens with the same three unwinnables, spends twenty
+of its forty lines on
+[`grid-lanes`](wpt-rendering-gaps-open.md#grid-lanes-is-an-unshipped-draft-feature)
+(a maintainer's call, not a defect) and nine more on the
+[`-print` corpus](wpt-rendering-gaps-open.md#a--print-document-renders-on-the-viewport-not-on-the-page-it-declares),
+so almost nothing on it is startable. The manifest's `failureFamilies` list, by
+contrast, *heads* with `html-ruby-extensions/html-ruby-{N}.html` at 35 — a family
+that appears nowhere in the top forty, because
+[ruby is unimplemented](wpt-rendering-gaps-open.md#ruby-annotations-are-not-laid-out-at-all)
+and every one of the 35 therefore fails at a **100% match** against a `rel=mismatch`
+reference. A severity ranking sorted by *lowest* match cannot show a family that
+fails at the highest possible number, which is the structural blind spot the grouping
+covers.
+
 ```sh
 python3 - <<'PY'
 import json, collections

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -763,6 +763,30 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## CSS engine
 
+### A declaration whose `image-set()` carried a negative resolution was not dropped
+
+- **Tests:** `css-images/image-set/image-set-negative-resolution-rendering` and `-2`, both
+  **98.7% → 100%, passing**.
+- **Owner:** `Broiler.CSS` (`CssStyleEngine.Values.cs`). **Submodule, and with no main-repo
+  half** — `patches/0005`.
+- **The rule.** CSS Images 4 §5.4 makes a `<resolution>` non-negative, so
+  `image-set(url(a) -1x, …)` is a parse error and CSS Syntax 3 §9 drops the **whole
+  declaration**, letting the one cascaded under it apply. `-2` puts a green `url()` behind it
+  and expects green.
+- **It has to be refused in the cascade, not at the renderer.** Only the winning value reaches
+  the renderer, so declining it there leaves the property at its *initial* value rather than at
+  the previous declaration — which is why the main-repo half already in `CssUtils` (leave the
+  property alone when `TryResolveLayers` reports a parse error) could not close these two.
+- **The open entry proposed a split that does not exist.** It read "`CssImageSet.TryResolveLayers`
+  already reports the parse error … so the validator has something to call". `CssImageSet` lives
+  in `Broiler.Layout`, which **references** `Broiler.CSS` and not the other way round, so the
+  validator cannot call it. The check is self-contained.
+- Scanning ignores anything inside `url()` or quotes, so a file genuinely named
+  `sprite-1x.png` does not invalidate the declaration that loads it. A **zero** resolution is
+  deliberately still accepted: it parses and selects nothing, a different outcome from being
+  dropped.
+- **Measured: `css/css-images/image-set` 26 → 28 of 31, +2 / −0**; `css/css-images` 271 → 273.
+
 ### Every CSS Color 4 colour function painted opaque black
 
 - **Tests:** `css-images/gradient/gradient-single-stop-none-interpolation`
@@ -999,6 +1023,59 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 ---
 
 ## Layout
+
+### A column flex item's stretch never reached the image inside it
+
+- **Test:** `css-flexbox/aspect-ratio-intrinsic-size-007`, **41.1% → 100%, passing**.
+- **Owner:** main repo (`Broiler.Layout/Engine/FlexGridItemBlockification.cs`) with a
+  `Broiler.HTML` call — `patches/0003`, the push to that remote being outside session scope.
+- **The previous diagnosis named the wrong mechanism.** It read "a column flex container
+  whose only child is inline-level takes the `ContainsInlinesOnly` branch … the cross-axis
+  stretch is then applied as a *post*-pass that re-lays the item out at a target width. That
+  is destructive for an inline replaced `<img>`." The stretch is not destructive; it simply
+  never reaches the image. A block-level image inside a flex container is wrapped in an
+  anonymous block (`CorrectImgBoxes`), and for a **column** container that wrapper becomes
+  the flex item — `IsRowFlexItem` exempts only *row* containers, deliberately, because block
+  flow cannot position a block-level replaced box on its own. So the stretch lands on the
+  wrapper and the image keeps an `auto` width, which for an inline replaced box with no
+  intrinsic size means the 300×150 default object size. To the spec the image **is** the item.
+- **What landed.** `IsStretchedColumnFlexItem`, beside the `IsRowFlexItem` the fix-up already
+  asks, so the two readings of "what is the item" cannot drift apart. It is asked *before* the
+  reparent, while the image is still the container's own child and still carries the width,
+  margins and alignment CSS Flexbox §9.4 step 11 turns on.
+- **Two conditions exist because the first attempt lost two tests**, and they are the reusable
+  part. A percentage width sizes the *content* box while a stretch sizes the *border* box, so
+  `width: 100%` is exact only with no inline-axis padding or border —
+  `flex-aspect-ratio-intrinsic-padding-001`, whose assertion names the content box outright,
+  overflowed by exactly its `padding: 20px`. And an `inline-flex` column container shrink-wraps
+  to its items, so an item declared `100%` of it contributes nothing to the size it is a
+  percentage of and the container collapses (`inline-flex-column-image-load`).
+- **Outside those conditions the stretch still belongs on the replaced element and is still not
+  applied.** That general form wants the cross size pushed onto the box during flex layout, not
+  a declaration rewritten before it.
+- **Measured over `css/css-flexbox`, 644 reftests: 436 → 438, +2 / −0**, with the failing-test
+  *lists* diffed rather than the totals compared — the first run's totals were identical while
+  hiding a +2/−2. `css/css-images`, `css/css-masking/clip-path` and `quirks` do not move.
+
+### An inline replaced element's three box-model rects were all the same rectangle
+
+- **Owner:** main repo (`Broiler.Layout/BoxGeometry.cs`) with a `Broiler.HTML` call —
+  `patches/0004`.
+- **The bug.** A `display: inline` box lays out as one rectangle per line rather than as a
+  single border box, so the geometry collector rebuilds its border box from the union of those
+  rectangles — and then set **all three** levels to that same rectangle, on the stated grounds
+  that inline boxes contribute no box-model padding or border to line geometry here. That holds
+  for a non-replaced inline and not for a replaced one: `CssLineBox.UpdateRectangle` adds an
+  image's border and padding to its line rectangle explicitly, so the union really *is* the
+  border box.
+- **Measured:** `<img style="width:50px;height:30px;border:3px solid;padding:4px">` reported
+  `getBoundingClientRect` 64×44 — right — and `clientWidth`/`clientHeight` **64×44 → 58×38**.
+  A `<div>` with the same declarations already reported 58×38, so the two paths disagreed with
+  each other as well as with the spec. A non-replaced `<span>` is untouched.
+- **It moves no WPT test, and the open entry was wrong about why it would** — see
+  [that entry](wpt-rendering-gaps-open.md#an-inline-elements-three-box-model-rects-are-all-the-same-rectangle--fixed)
+  for the six `contain-intrinsic-size-logical-003` assertions, which are an axis transposition
+  rather than a deflation. What this closes is the general API defect.
 
 ### Every CSS transform was applied about the box centre, whatever `transform-origin` said
 
@@ -2077,6 +2154,25 @@ the test that exposed it.
 ---
 
 ## Paint and the renderer
+
+### An SVG image's root background was never painted
+
+- **Owner:** main repo (`Broiler.Layout/IR/SvgImageRaster.cs` and `IR/SvgRenderer.cs`). No patch.
+- **The rule.** CSS Backgrounds §2.11.2 makes the root element's background the canvas's, and
+  for an SVG document used *as an image* that canvas is the destination box. Nothing painted it:
+  a file opening `<svg style="background: black">` came back transparent, so a document drawing
+  tinted shapes over a dark ground rendered them on white.
+- **Measured** on a 50%-alpha green rect over a black root: **(127,255,127) → (0,127,0)**, which
+  is what compositing that rect over black gives.
+- **Why it is in `SvgImageRaster` rather than `SvgRenderer`.** `SvgRenderer` serves both callers
+  and the *inline* one must not do this: an inline `<svg>` is an ordinary element whose CSS box
+  already paints its background, so painting it again would double a translucent colour over
+  itself. A test pins that the inline path still leaves it alone.
+- **No WPT test in the available subsets moves**, and that is expected — almost no WPT file
+  declares a root background. The one this came from does, and it is a *reference*
+  (`css-images/cross-fade-natural-size`, which both engines fail on the test side). So it is
+  pinned by unit tests instead: three cases that fail against the unmodified build, plus the
+  transparent/absent and inline cases, which must not change and do not.
 
 ### Six SVG shape elements were never drawn when an attribute held a slash
 

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -35,6 +35,35 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## The runner and the report
 
+### The bridge resolved every viewport question against 1024×768, whatever the run rendered at
+
+- **Owner:** main repo — `src/Broiler.HtmlBridge.Dom/DomBridge.cs` with the runner
+  (`src/Broiler.Wpt/WptTestRunner.cs`).
+- **The bug, and it is exactly as blunt as it sounds.** `DomBridge` held
+  `_viewportWidth`/`_viewportHeight` at 1024×768 and **nothing ever assigned them** — a grep
+  finds the two initialisers and no write anywhere in the tree. Everything the bridge resolves
+  against the viewport read those: `window.innerWidth`/`innerHeight`, `vw`/`vh` lengths,
+  media-query evaluation and the maximum scroll offset. A run at any other size therefore
+  produced a document whose script-visible geometry disagreed with its own pixels: a page built
+  to be "taller than the viewport" at 200×200 scrolled to somewhere that was not the bottom of
+  the canvas, and a test asserting on what is on screen then failed for a reason that had
+  nothing to do with what it was testing.
+- **Layout was never wrong**, and that split is what made it hard to see. The engine is handed
+  the real width and height, so a `vh` length in a *stylesheet* already resolved correctly. The
+  page looks right; the script reading its geometry is told something else.
+- **What landed.** `ViewportWidth`/`ViewportHeight` are settable on the bridge, defaulting to
+  the same 1024×768 so every existing host is unchanged, and the runner passes the size it is
+  about to render at into both bridges it builds.
+- **The old tests passed for the wrong reason.** `ScrollClampingTests` rendered only at
+  1024×768 — the bridge's own default — so it agreed by coincidence;
+  `docs` recorded that it and `ViewTransitionOldCaptureScrollTests` "pin their renders to the
+  default size to work around it". Two new cases render at **200×200**, where the two sizes
+  disagree: one on the scroll clamp, one on `window.innerWidth`/`innerHeight` directly. Both
+  were run against the unmodified build first and **fail there** (2 failed / 5 passed), and pass
+  with the fix (7 passed).
+- **No effect on the standard suite**, which renders at the default size: `quirks` holds at
+  21 of 25 before and after.
+
 ### The run reported correct renders as its worst failures
 
 - **Owner:** the WPT runner (`src/Broiler.Wpt`), the shard merger
@@ -2550,6 +2579,54 @@ the test that exposed it.
 ---
 
 ## DOM and the bridge
+
+### `document.styleSheets` listed no `<link>` sheet at all
+
+- **Owner:** main repo (`src/Broiler.HtmlBridge.Dom` — `Features/DocumentCollectionBinding.cs`
+  and `DomBridge/StyleSheets.cs`).
+- **The bug.** CSSOM §2.2 makes the collection every sheet associated with the document, a
+  `<link rel=stylesheet>` included. The main-document binding filtered the element list to
+  tag `style`, so an external sheet was absent however well it loaded — while the
+  *sub*-document collection (`DomBridge.BuildStyleSheetsCollection`) counted it. The same
+  tree answered two different things depending on which document was asked.
+- **What landed.** One predicate, `HasAssociatedStyleSheet`, reached from the binding through
+  `IDocumentCollectionHost`. Factoring it out rather than copying the condition across is the
+  point of the fix: the two readings drifting apart *was* the defect.
+- **Measured** on a served page carrying an enabled `<link>`, a `<style>` and a
+  `<link disabled>`: the collection goes **1 → 2**, in document order, with object identity
+  holding across two reads. `Broiler.Cli.Tests/DocumentCollectionBindingModuleTests` pins all
+  three, plus the `rel=icon` link and a bare `<a href>` staying out.
+- **Two adjacent gaps it makes visible**, both separate and neither introduced by it — see
+  [the open entry](wpt-rendering-gaps-open.md#a-linked-sheet-is-listed-and-carries-no-rules):
+  the listed link sheet reports **zero `cssRules`**, and `getComputedStyle` does not reflect
+  its declarations. The sheet does reach the cascade — the same page *renders* the linked
+  colour — so it is the CSSOM projection that stops short, not the loader.
+
+### `ViewTransition` was not an interface object, and a page probing it lost its whole script
+
+- **Test:** `css-view-transitions/view-transition-waituntil-animation-manipulation`.
+- **Owner:** main repo (`src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs`).
+- **The bug, and why it was worth more than the missing feature.** The object
+  `document.startViewTransition()` returns has always existed here; the *interface* did not.
+  The test opens with `failIfNot(ViewTransition.prototype.waitUntil, …)`, so evaluating the
+  **argument** threw `ReferenceError` before `failIfNot` was entered — the whole inline script
+  aborted, including the `onload` assignment at the bottom of it, and `startViewTransition`
+  was never called at all. The failure read as a compositing bug and was not one.
+- **What landed.** `ViewTransition` joins the illegal-constructor interfaces beside `Element`
+  and `CanvasRenderingContext2D`, with a `Symbol.hasInstance` recognising the object the bridge
+  builds. The probe reads `undefined`, the statements after it run, and
+  `t instanceof ViewTransition` answers true.
+- **`waitUntil` is deliberately not defined.** It is a proposal this engine does not implement,
+  and faking one would carry the test past its own guard into Web Animations calls that are not
+  there either (no `Animation` constructor, no `Element.prototype.animate`) — a worse answer
+  than an honest precondition failure.
+- **Measured over `css/css-view-transitions`, 305 reftests, before and after: 181 passed / 123
+  failed both ways — no test moves.** The one visible change is the subject test going
+  **1.3% → 0.0%** against its own reference, and that is the artifact ending rather than a
+  regression: `failIfNot` sets the body's `textContent` to *"Precondition Failed: …"*, so the
+  green square the crashed script used to leave on screen is correctly gone. Rendering the test
+  confirms it now paints that sentence. **The page says what is missing instead of accidentally
+  scoring for it**, which is the same shape as every other fake pass this document records.
 
 ### A root-relative frame `src` resolved against the wrong directory
 

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -64,6 +64,39 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 - **No effect on the standard suite**, which renders at the default size: `quirks` holds at
   21 of 25 before and after.
 
+### A nested scroll container's clipped content inflated its ancestor's scrollable overflow
+
+- **Owner:** main repo, `src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs` and
+  `LayoutMetrics.ScrollGeometry.cs`.
+- **The rule.** CSS Overflow 3 §3.1: a box's scrollable overflow region is the union of its own
+  content and its descendants' *scrollable overflow* — and a descendant that is itself a scroll
+  container has **already scrolled** its own overflow, so what it contributes upward is its
+  border box. Its clipped content is reachable by scrolling *it*, not the ancestor.
+  `TryGetSharedScrollExtent` unioned every rendered descendant's border box with no such stop,
+  so a 400×400 block inside a 120×100 `overflow: auto` box made the **document** report
+  `scrollHeight` **401** for a page whose content is 102px tall.
+- **It was invisible until the viewport was fixed**, and that is the useful part. While the
+  bridge held its viewport at
+  [1024×768](#the-bridge-resolved-every-viewport-question-against-1024768-whatever-the-run-rendered-at),
+  401 is under 768 — the maximum scroll came out 0 either way and nothing moved. Giving the
+  bridge the real size turned it into a 271px scroll range that does not exist, and
+  `scrollIntoView` on content inside one of those containers scrolled the whole document to
+  reach it. **Two bugs had been cancelling.**
+- **Measured** on that page at 280×130: `scrollHeight` **401 → 105.8**,
+  `documentElement.scrollTop` **1 → 0**, with both containers still landing on `(40, 300)` —
+  the reference's own values.
+- **One test changed for a real reason, and it is worth reading.**
+  `Wpt_CssViewport_ZoomScrollIntoViewAlignmentOptions` has a `zoom: 2` container that is 244px
+  tall in a 240px viewport, so that document genuinely *does* have 13.6px of scrollable overflow
+  and `scrollIntoView` correctly continues outward into it. Its container scrolls are exactly
+  the reference's `(180, 190)`; only the incidental viewport scroll differs, and the reference
+  does not model it. It now resets the document scroll the same way — and for the same stated
+  reason — as the sibling fixture directly above it, which has carried that reset all along.
+- **Whole-suite evidence:** `Broiler.Wpt.Tests` goes **56 failures → 54** against the pre-change
+  tree, with **no new failures**; the two remaining are the new `ScrollClampingTests` cases now
+  passing. Reftests are unmoved on every subset available in this checkout — `quirks` 21/25,
+  `css-view-transitions` 181/305, `css-masking/clip-path` 157/227, `html-ruby-extensions` 49/84.
+
 ### The run reported correct renders as its worst failures
 
 - **Owner:** the WPT runner (`src/Broiler.Wpt`), the shard merger

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -554,6 +554,48 @@ containment**.
   rows are 76px against 54px), with `position-area-scrolling-002` and the `lh`-unit
   tests staying green.
 
+### An inline-block does not sit on the line's baseline
+
+- **Owner:** `Broiler.Layout` (`Engine/CssLayoutEngine.cs` `ApplyVerticalAlignment`,
+  `Engine/CssLineBox.cs` `SetBaseLine`). Main repo.
+- **Reproduction, no WPT checkout needed** — an empty 80px inline-block beside text:
+  ```sh
+  printf '%s' '<style>body{font-size:40px;padding:20px}
+  .ib{display:inline-block;outline:2px solid #000;height:80px;width:40px}</style>
+  Hxy<span class="ib"></span>Hxy' > /tmp/ib.html
+  dotnet run --project src/Broiler.Wpt -- --render /tmp/ib.html
+  ```
+  The box's **top** lines up with the text top and it hangs ~60px below the baseline.
+  CSS 2.1 §10.8.1 gives an inline-block with no in-flow line boxes its baseline at the
+  **bottom margin edge**, so the box should stand *on* the text baseline and extend
+  upward; Chromium renders it that way.
+- **It is deliberate in the code, not an oversight to patch in one line.** Two places
+  agree on leaving it where the flow put it: `ApplyVerticalAlignment` excludes
+  `display: inline-block` from the boxes that contribute to the line's baseline
+  (the `box.Display != CssConstants.InlineBlock` guard), and `SetBaseLine` returns
+  early for a box whose `vertical-align` is absent or `baseline`. Only a *non-default*
+  `vertical-align` moves an inline-block at all.
+- **The line-height entry above is the same root.** The layout layer approximates the
+  baseline with a hardcoded `TypicalAscentRatio = 0.8` and has no real ascent/descent,
+  so there is no number to align an inline-block's last line box *to*. Closing this
+  and closing that one are the same piece of work.
+- **What it blocks, beyond its own tests.** It is the reason ruby cannot be desugared
+  to ordinary CSS boxes — see
+  [ruby annotations are not laid out at all](#ruby-annotations-are-not-laid-out-at-all).
+  It is also the shape of an icon-and-label row, a badge, and every
+  `vertical-align: middle` cell replacement, so it caps far more than the reftests
+  that name it.
+- **Do not "fix" it speculatively.** It moves the vertical position of *every*
+  inline-block in the corpus, and the compensating code written around the current
+  behaviour (the atomic-inline margin-box term in the line-box height calculation, the
+  `minTop < starty` line-box shift) has to move with it. The
+  [line-height entry](#an-inline-blocks-height-ignores-line-height) already records two
+  such attempts that measured well in isolation and lost over the suite. This one needs
+  a full before/after sweep, not a local metric.
+- **Exit gate:** an empty inline-block's bottom margin edge lands on the baseline and
+  one with in-flow content aligns on its last line box, with a before/after sweep over
+  the full reftest suite showing a net gain.
+
 ### Text does not flow around a float
 
 - **Owner:** `Broiler.Layout`. Long-standing; the
@@ -1443,6 +1485,66 @@ fix beside the data: one — the runner could not read a corpus path back out of
 ---
 
 ## Text and fonts
+
+### Ruby annotations are not laid out at all
+
+- **Tests:** the whole `html-ruby-extensions/` directory — **35 failures of its 84
+  reftests**, and the largest uniform failure family outside `grid-lanes` in the
+  [#1792 reftest run](https://github.com/Broiler-Platform/Broiler/issues/1792)
+  (`failureFamilies` heads its list with `html-ruby-extensions/html-ruby-{N}.html`, 35).
+  Twenty of that run's top forty are `grid-lanes`, which is
+  [a maintainer's call, not a defect](#grid-lanes-is-an-unshipped-draft-feature); this
+  family is the run's largest tractable one.
+- **Owner:** `Broiler.Layout` (no ruby layout model) and `Broiler.HTML`
+  (`Source/Broiler.HTML.Core/CssDefaults.cs` — the UA stylesheet has no ruby rules at
+  all). Submodule half is one block of default styles; the layout half is the feature.
+- **They are `rel=mismatch` tests, so they fail at a *100%* match, not a low one.**
+  Each test declares up to ten references that each spell out one *incorrect* way to
+  render it, and passes only by differing from every one. Broiler renders
+  `html-ruby-001` byte-identically to its `-a-ref`, whose comment reads *"incorrect
+  rendering: annotations displayed identical to base text, interleaved"*. So the
+  runner's "100.0% match" on these is the failure, not a near-miss.
+- **Root cause, and it is not the fonts.** The CJK text these tests use renders blank
+  in a bare container, which makes the failure images look like a font gap. It is not
+  — reproduce it in Latin:
+  ```sh
+  printf '%s' '<style>body{font-size:24px}</style>
+  <hr>context<ruby>BASE<rt>note</rt></ruby>after
+  <hr>context<span>BASE</span><span>note</span>after' > /tmp/ruby.html
+  dotnet run --project src/Broiler.Wpt -- --render /tmp/ruby.html
+  ```
+  Both lines render `contextBASEnoteafter`, identically. `<rt>` is an unknown inline
+  element, so its text is laid out in document order between the bases. `<rp>` is not
+  hidden either — `<ruby>BASE<rp>(</rp><rt>note</rt><rp>)</rp></ruby>` renders
+  `BASE(note)`, which is precisely the legacy fallback `<rp>` exists to give a UA that
+  has no ruby, and what Chromium suppresses.
+- **`display: ruby` already parses; nothing consumes it.** `Broiler.CSS`'s
+  `CssStyleEngine.Values.cs` accepts `ruby`, `ruby-base`, `ruby-text`,
+  `ruby-base-container` and `ruby-text-container` as valid `<display>` values with the
+  standing comment *"the layout engine does not model ruby specially yet"*, and
+  `CssBox.SizeContainment.cs` is the only file in the engine that names them.
+- **Desugaring it to existing boxes was tried and does not land.** The natural shape —
+  a box-tree fixup in the `AnonymousTableBoxes` / `DisplayContentsBoxes` pattern (both
+  in `Broiler.Layout/Engine`, called from `Broiler.HTML`'s `DomParser`) that rewrites
+  each ruby column as an `inline-block` holding an annotation block above a base
+  block — puts the
+  base **28px below** the surrounding text at 40px/em rather than on its baseline, and
+  no `vertical-align` constant fixes it, because
+  [an inline-block does not sit on the line's baseline](#an-inline-block-does-not-sit-on-the-lines-baseline)
+  in the first place. That entry is the blocker, and it is the bigger of the two.
+  A change to `SetBaseLine` to move an aligned inline-block's whole subtree was written
+  during this triage and **reverted**: the contents already move with the box, so it
+  dropped the content out of the box entirely. Do not re-try that one.
+- **Do not buy these 35 with a cosmetic rule.** `rt { vertical-align: super;
+  font-size: 50% }` plus `rp { display: none }` differs from all ten references and
+  would flip the whole family green while rendering nothing like ruby — the annotation
+  trails its base instead of centring over it. That is the
+  [fake pass](wpt-rendering-gaps-wont-fix.md) this suite is built to produce, and it
+  would move *away* from Chromium on the golden-image suite, which does render real
+  ruby. The UA rules are worth landing only together with the layout.
+- **Exit gate:** `html-ruby-001` renders its annotations above their correct bases and
+  differs from all ten of its references, with the `html-ruby-extensions` directory
+  going 49/84 → most of 84 and the golden-image suite not losing ruby tests.
 
 ### Bold and italic never reach the face
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -830,6 +830,14 @@ the two defects at the end of this entry.
   single-stop test render at all; declining the conversion instead was measured and is
   *worse* — it takes `gradient-none-interpolation` to 68.2% and loses the single-stop pass.
   Carry-forward has to be implemented, not worked around.
+- **Re-scoped on 2026-08-23: well specified, but a feature rather than a patch.** The three
+  rules are named precisely and none is a one-liner, and they land in two places rather than
+  one: the interpolation space is *parsed* in `PaintWalker.Gradients.cs` and carried on the
+  display item (`DisplayList.GradientInterpolationSpace`, main repo, already there), while the
+  ramp is *evaluated* in the image backend. Premultiplying before interpolating and taking a
+  hue arc both change the evaluator; carrying a `none` component forward changes the
+  normaliser that runs before it. Nothing here is main-repo-only, so it ships as a patch of
+  real size.
 - **Exit gate:** the three tests pass, and `gradient-single-stop-none-interpolation` and the
   four `gradient-powerless-hue-*` stay passing.
 
@@ -1376,6 +1384,16 @@ express those, and does not claim to.
   three tests differ only in which property carries it — `content`, `background-image`,
   `list-style-image` — which is the second half of the work: the resolution has to reach the image
   sizing path for each, and today only `background-image` is even resolved.
+- **Re-scoped on 2026-08-23: this is two halves times three properties, not a carry.** The
+  number is indeed already computed, but nothing downstream can use it where it is. The
+  intrinsic-size arithmetic for a background lives in `Broiler.HTML`'s
+  `PaintWalker.Parsing.cs`, so the resolution has to be carried onto the box or the fragment
+  in the main repo *and* divided into the intrinsic size in the submodule — and then the same
+  again for `content` and `list-style-image`, neither of which resolves `image-set()` at all
+  today. It is the shape `CLAUDE.md` recommends, but the submodule half is not a call.
+- **Its sibling is closed and does not help.**
+  [The negative-resolution drop](#an-invalid-image-set-does-not-drop-its-declaration--fixed)
+  landed, taking `css/css-images/image-set` to 28 of 31; these three are the whole remainder.
 - **Exit gate:** the three tests match, with a `Broiler.Layout` test over an intrinsic size scaled
   by a non-1x selection.
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -19,6 +19,18 @@ measured 2026-08-13; CI is the golden-image score from the
    [the false negative](#the-flag-can-be-a-false-negative) — and it can fail its
    own reference while passing CI, which is the newer and more interesting case:
    four tests below are green on CI and demonstrably wrong.
+3. **Re-measure the entry before you believe its diagnosis.** An entry is written at a
+   moment; the tree moves under it, and the *stalest part is usually the "what is left"
+   line*, because that is the part written from inference rather than from a run. Working
+   through the readiest-looking entries on 2026-08-23 turned up three in a row where the
+   remaining-work sentence was wrong:
+   [the quirks table colour](#a-table-inherits-color-where-it-must-not) is not the quirk
+   (which is implemented and unit-tested) but scripts running after the parse;
+   [the `clipPath`](#svg-clippath-referenced-by-url) is not `userSpaceOnUse` units (also
+   implemented) but a 512px offset; and
+   [`document.styleSheets`](#a-linked-sheet-is-listed-and-carries-no-rules) was reported as
+   a page "whose linked sheet demonstrably applies", which `getComputedStyle` does not
+   agree with. Each cost a few minutes to check and would have cost far more to act on.
 
 ## Contents
 
@@ -171,7 +183,7 @@ The largest remaining cluster, and it reduces to three causes.
   were written to verify are still untested here**; a future reader must not take these two
   passing as evidence that scrollbars in a snapshot work.
 
-### `ViewTransition` is not an interface object, and has no `waitUntil`
+### `ViewTransition` has no `waitUntil` — the interface object is **fixed**
 
 - **Test:** `css-view-transitions/view-transition-waituntil-animation-manipulation`
   ([#1670](https://github.com/Broiler-Platform/Broiler/issues/1670).4), 1.3% against its
@@ -193,8 +205,18 @@ The largest remaining cluster, and it reduces to three causes.
   `waitUntil` on its prototype is small. Making `waitUntil` *mean* something — the test then
   manipulates the pseudo-element animations through the Web Animations API — needs
   `document.getAnimations()` over the pseudo tree, which does not exist.
-- **Exit gate:** the interface object exists, and a focused test pins that a page probing
-  `ViewTransition.prototype` no longer aborts.
+- **The interface object landed** — see
+  [the fixed entry](wpt-rendering-gaps-fixed.md#viewtransition-was-not-an-interface-object-and-a-page-probing-it-lost-its-whole-script).
+  The probe now reads `undefined` instead of throwing, so the script runs and the page paints
+  *"Precondition Failed: ViewTransition.waitUntil is not available"*. That took the test
+  **1.3% → 0.0%** against its own reference, which is the crashed-script artifact ending, not a
+  regression: the green square it used to leave on screen was never something the engine earned.
+  `css/css-view-transitions` is 181 of 305 before and after.
+- **What is still open is the half with the feature in it.** `waitUntil` is deliberately not
+  defined: faking one carries the test past its own guard into Web Animations calls that are not
+  there either. Implementing it for real needs `document.getAnimations()` over the pseudo tree.
+- **Exit gate:** `waitUntil` defers the transition's completion and `document.getAnimations()`
+  returns the pseudo tree's animations, so the test manipulates them and reaches its screenshot.
 
 ### Two tests are green on CI and wrong
 
@@ -1391,10 +1413,20 @@ express those, and does not claim to.
   **82.6%** against its own reference.
 - The [path-clip work](wpt-rendering-gaps-fixed.md#clip-path-modelled-only-inset)
   landed `polygon()`, `circle()`, `ellipse()` and `url(#…)` resolution, and took this
-  test from 2.9% to 82.6% — but not over the line. `userSpaceOnUse` units on the
-  referenced `<clipPath>` are the remaining piece.
-- **Exit gate:** the test matches, with the two `clip-path-document-element` tests
-  staying passing.
+  test from 2.9% to 82.6% — but not over the line.
+- **"`userSpaceOnUse` units are the remaining piece" is stale, and re-measuring the family
+  is what shows it.** `userSpaceOnUse` is implemented and covered by
+  `Broiler.Cli.Tests/ClipPathShapeTests` for `-001`, `-003` and `-004`. Measured over
+  `css/css-masking/clip-path` on 2026-08-23: **157 of 227 pass, average 98.35%**, and the two
+  that name this entry fail with signatures that are not a units gap —
+  `userSpaceOnUse-003` at **50.0%** with *"content shifted right ~512px"*, and `-004` at
+  **83.3%** with *"extra content present in output, blank in reference"*. A shift of half the
+  1024px viewport and an over-large clip are two different bugs, and neither is "the units are
+  not read".
+- **So this is not the one-piece fix it was filed as.** Start from `-003`'s 512px offset,
+  which is the larger and the more legible of the two.
+- **Exit gate:** `-003` and `-004` match, with the two `clip-path-document-element` tests and
+  the 157 currently passing staying passing.
 
 ---
 
@@ -1441,24 +1473,26 @@ Closed: see
 fix beside the data: one — the runner could not read a corpus path back out of the
 `file:///…` URL a script builds from `location.href`.
 
-### `document.styleSheets` lists no `<link>` sheet at all
+### A linked sheet is listed, and carries no rules
 
-- **Owner:** main repo, `src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs`.
-  No test on any current list is known to turn on it; it was found while fixing the entry
-  above and is recorded rather than fixed, because widening what that collection returns
-  changes what every script iterating it sees.
-- **What it is.** `GetStyleSheets` filters the document's elements to tag `style`, so an
-  external sheet is absent from `document.styleSheets` however well it loaded — measured
-  on a page whose linked sheet demonstrably applies (`getComputedStyle` reads the linked
-  colour, `document.styleSheets.length` reads `0`). CSSOM §2.2 makes the collection every
-  sheet associated with the document, `<link rel=stylesheet>` included.
-- **The fix is already written, one layer over.** A sub-document's `styleSheets` goes
-  through `DomBridge.BuildStyleSheetsCollection`, which collects `<style>` *and*
-  `IsExternalStylesheet` links, skips a disabled `<link>`, and caches per element for
-  identity. The main-document binding predates it and never adopted it, so the two
-  disagree about what a document's stylesheets are.
-- **Exit gate:** both bindings return the same collection for the same tree, with a test
-  covering a linked sheet, a `<link disabled>`, and object identity across two reads.
+- **Owner:** main repo, `src/Broiler.HtmlBridge.Dom` (the `CSSStyleSheet` projection in
+  `DomBridge/StyleSheets.cs`, and the computed-style path).
+- **The collection itself is
+  [fixed](wpt-rendering-gaps-fixed.md#documentstylesheets-listed-no-link-sheet-at-all)** —
+  `document.styleSheets` now lists a `<link rel=stylesheet>` beside a `<style>`, in document
+  order, with a disabled `<link>` correctly out. What that made visible is two further gaps,
+  found by measuring the fixed behaviour rather than assumed:
+  1. **The listed link sheet reports zero `cssRules`.** `document.styleSheets[0].cssRules.length`
+     is `0` for a sheet that loaded and applied.
+  2. **`getComputedStyle` does not reflect a linked sheet's declarations.** On a served page
+     whose `linked.css` says `p { color: rgb(0,128,0) }`, `getComputedStyle(p).color` reads
+     `rgb(0, 0, 0)` — while the `<style>` element's own rule on the same page reads back
+     correctly.
+- **The loader is not the problem, which is the useful half.** *Rendering* the same page paints
+  the linked colour — the green pixels are there — so the sheet reaches the cascade and it is
+  the CSSOM projection that stops at the element. Do not start by looking at fetching.
+- **Exit gate:** a linked sheet's `cssRules` enumerate its rules, and `getComputedStyle` reads a
+  value the linked sheet alone supplies.
 
 ---
 
@@ -1475,12 +1509,26 @@ fix beside the data: one — the runner could not read a corpus path back out of
   5.1% square against a reference that is 94.6% `rgb(18,18,18)` + the same 5.1%
   square. **The page renders and the document element is installed.**
 - **The entire difference is the square's colour** — ours `rgb(255,0,0)`, the
-  reference's `rgb(0,0,0)`. So it is the quirk the test is named for after all: the
-  table inherits `color: red` from the `<div>` instead of falling back to the initial
-  colour, and the test says so outright — *"Test passes if there is a square filled
-  with initial color and no red"*.
-- **Exit gate:** a table does not inherit `color` from a non-body ancestor in quirks
-  mode, and the square paints the initial colour.
+  reference's `rgb(0,0,0)`.
+- **And the second diagnosis was wrong too. It is not the quirk.** The quirk is implemented
+  (`Broiler.Layout/Engine/TablesInheritColorFromBodyQuirk.cs`), including the no-body arm, and
+  `TablesInheritColorFromBodyQuirkTests.With_No_Body_Element_A_Table_Takes_The_Initial_Colour`
+  passes. Probing the real document is what settles it: after the test's script runs,
+  `document.documentElement.children` is **`HEAD,BODY,DIV`**. A `<body>` exists — and the
+  stylesheet says `body { color: red }`, which is exactly the 40 000 red pixels the runner
+  reports (a 200×200 Ahem square, `006` and `007` alike).
+- **The real cause is script timing, and it is general.** The test's comment says *"At this
+  point, the `<body>` has not been created yet"* — it removes `documentElement` mid-parse so no
+  body is ever created. Broiler runs inline scripts **after** the parse, so the body already
+  exists and is cloned along with everything else. Reproduced directly, independently of this
+  test: a script in the `<head>` reports `document.body` already present, and a script reports
+  a `<p>` that appears *after* it in the source. Both are impossible during a real parse.
+- **So this is not a quirks fix and not a small one.** Nothing in the quirk can distinguish a
+  body the document has from a body the test prevented; closing it means running scripts at
+  their position in the parse.
+- **Exit gate:** an inline script observes the document as it stands at its own position — no
+  `document.body` before the body is open, and no elements that follow it — after which
+  `006`/`007` should follow from the quirk that is already there.
 
 ---
 
@@ -1674,16 +1722,16 @@ None of the four declares a `rel=match`.
 
 ## Runner and harness
 
-### The runner resolves scroll metrics against the wrong viewport
+### The runner resolves scroll metrics against the wrong viewport — **fixed**
 
-`new WptTestRunner(w, h)` renders at the given size, but the scroll metrics — `vh`
-lengths and the maximum scroll offset — resolve against the default 1024×768
-regardless. A page built to be "taller than the viewport" at 200×200 therefore
-scrolls to somewhere that is not the bottom of the canvas, and a test asserting on
-what is on screen fails for a reason that has nothing to do with what it is testing.
-`ScrollClampingTests` and `ViewTransitionOldCaptureScrollTests` pin their renders to
-the default size to work around it. **A real defect in the runner, not just a
-test-authoring trap.**
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#the-bridge-resolved-every-viewport-question-against-1024768-whatever-the-run-rendered-at).
+`DomBridge` held its viewport at 1024×768 and nothing ever assigned it, so
+`window.innerWidth`/`innerHeight`, `vw`/`vh`, media queries and the maximum scroll offset
+all answered for a viewport the render did not use. The size the runner renders at is now
+carried onto the bridge, and `ScrollClampingTests` gained two cases at 200×200 — the sizes
+the old ones could not tell apart. Layout was never affected, which is why this only ever
+showed up through a script.
 
 ### `?pipe=` is not emulated
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -454,24 +454,15 @@ other direction. None is a sizing bug.
 - **Exit gate:** a 2D canvas context that paints, at which point the first two
   become ordinary comparisons.
 
-### A column flex container destroys an inline replaced item when it stretches it
+### A column flex container destroys an inline replaced item — **fixed**
 
-- **Test:** `css-flexbox/aspect-ratio-intrinsic-size-007`
-  ([#1670](https://github.com/Broiler-Platform/Broiler/issues/1670).28), 35.4% against its
-  own reference, `MissingContent` over a 1008×10 strip.
-- **Owner:** `Broiler.Layout` (`Engine/CssBox.Flex.cs`). Main repo.
-- **Root cause.** A column flex container whose only child is inline-level takes the
-  `ContainsInlinesOnly` branch: the line boxes are built first, and the cross-axis stretch
-  is then applied as a *post*-pass that re-lays the item out at a target width. That is
-  destructive for an inline replaced `<img>`, which never goes through
-  `ResolveBlockUsedWidth` on the inline path, so the re-layout does not resize it the way
-  the pass assumes.
-- **The fix is to make the stretch width definite *before* the inline formatting context
-  runs** rather than re-running layout after it: a pre-pass over the in-flow items that
-  resolve to `stretch`, have no specified width and no auto inline margin, and are
-  replaced.
-- **Exit gate:** the test matches, and `css/css-flexbox/aspect-ratio` does not move
-  elsewhere.
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#a-column-flex-items-stretch-never-reached-the-image-inside-it).
+The diagnosis in this entry was right about the symptom and wrong about the mechanism. The
+stretch is not destructive; it simply never reaches the image, because a block-level image
+in a flex container is wrapped in an anonymous block and for a *column* container that
+wrapper becomes the item. `aspect-ratio-intrinsic-size-007` painted the 300×150 default
+object size and now matches at 100%; `css/css-flexbox` goes 436 → 438, +2 / −0.
 
 ### A size-contained `<svg>`, `<video>` or `<iframe>` still reports a size
 
@@ -493,28 +484,21 @@ containment**.
     `wpt-tests.yml` does not run `apply-pending-wpt-patches.sh` — so landing it upstream
     and bumping the pointer is the route.
 
-### An inline element's three box-model rects are all the same rectangle
+### An inline element's three box-model rects are all the same rectangle — **fixed**
 
-- **Tests:** the six `<img>` assertions still failing in
-  `contain-intrinsic-size-logical-003`, and — more to the point — `clientWidth` and
-  `clientHeight` on **every** inline element that has a border or padding.
-  `<img style="width: 50px; height: 30px; border: 3px solid">` reports
-  `getBoundingClientRect` 56×36 (right) and `clientWidth`/`clientHeight` 56×36 (wrong:
-  the client box excludes the border, so 50×30). The same declarations on a `<div>` or
-  an `inline-block` report 50×30 correctly.
-- **Owner:** `Broiler.HTML` (`HtmlContainerInt.CollectLayoutGeometry`).
-- **Root cause.** A `display: inline` box lays out as one rectangle per line box rather
-  than a single border box, so `box.Location`/`box.Size` are unset and the collector
-  rebuilds the border box from the union of the line rectangles — then sets all three
-  levels of `BoxGeometry` to that same rectangle, on the stated grounds that "inline
-  boxes contribute no box-model padding/border to line geometry in this engine". That
-  premise does not hold for a **replaced** inline: `CssLineBox.UpdateRectangle` adds the
-  box's border and padding to an image's line rectangle explicitly, and
-  `MeasureImageSize` adds them in the block axis, so the union genuinely *is* the border
-  box and the other two levels have to be deflated out of it.
-- **Exit gate:** an inline `<img>` with a border reports a client box smaller than its
-  border box by exactly that border. Submodule-side, so the same routing as the entry
-  above.
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#an-inline-replaced-elements-three-box-model-rects-were-all-the-same-rectangle).
+`clientWidth`/`clientHeight` on a bordered or padded inline `<img>` reported the border box
+and now report the padding box, agreeing with what a `<div>` carrying the same declarations
+always reported.
+
+**It moves no WPT test, and this entry was wrong about why it would.** The six `<img>`
+assertions of `contain-intrinsic-size-logical-003` named here are unchanged — the test holds
+at 42/96 — and reading them shows why: `client-width: expected 50, actual 0` beside
+`client-height: expected 0, actual 50` is a logical/physical axis transposition under
+`contain-intrinsic-size`'s logical properties, not a border deflation. Those six belong with
+[the size-containment entry](#a-size-contained-svg-video-or-iframe-still-reports-a-size)
+above, not here.
 
 ### A sticky box contributes its *stuck* position to the scroll container's overflow
 
@@ -1080,8 +1064,13 @@ the other five are unexamined.
     black. Only `flood-opacity` on an `feFlood` is read today.
   - **`mix-blend-mode` on a shape is unhandled**, so the `screen` compositing the reference relies on
     does not happen.
-  - **`style="background: …"` on the root `<svg>` is not painted**, leaving white where the reference
-    wants black.
+  - **`style="background: …"` on the root `<svg>` — fixed.** See
+    [the fixed entry](wpt-rendering-gaps-fixed.md#an-svg-images-root-background-was-never-painted).
+    It is painted for an SVG used *as an image*, which is where the canvas is the destination box;
+    an inline `<svg>` is left alone because its own CSS box already paints it. The other two on
+    this list landed with
+    [the SVG shape opacity and blend work](#fill-opacity-stroke-opacity-and-mix-blend-mode-on-an-svg-shape--fixed),
+    so all three are now closed and this entry is down to `cross-fade()` itself.
 
   Those three are worth more than this test: they apply to every SVG document Broiler renders, inline
   or as an image. They are the reason `Broiler reference vs Chromium reference` is only 67.4%.
@@ -1390,18 +1379,17 @@ express those, and does not claim to.
 - **Exit gate:** the three tests match, with a `Broiler.Layout` test over an intrinsic size scaled
   by a non-1x selection.
 
-### An invalid `image-set()` does not drop its declaration
+### An invalid `image-set()` does not drop its declaration — **fixed**
 
-- **Tests:** `css-images/image-set/image-set-negative-resolution-rendering` and `-2`.
-- **Owner:** `Broiler.CSS` (`CssDeclarationValidator`). **Submodule** — a fix ships as a patch.
-- **What it is.** A negative resolution is a parse error, so CSS Syntax 3 §9 drops the declaration
-  whole and the one cascaded under it applies; `-2` puts a green `url()` there and expects green.
-  The renderer sees only the winning value, so refusing it there leaves the property at its
-  *initial* value rather than at the previous declaration — the fallback has to happen in the
-  cascade. `CssImageSet.TryResolveLayers` already reports the parse error separately from a
-  function that validly selects nothing, so the validator has something to call.
-- **Deliberately not fixed yet:** two tests against a third pending submodule patch is the wrong
-  trade while the first two are still waiting to be applied.
+Closed: see
+[the fixed entry](wpt-rendering-gaps-fixed.md#a-declaration-whose-image-set-carried-a-negative-resolution-was-not-dropped).
+Both tests match at 100%; `css/css-images/image-set` goes 26 → 28 of 31.
+
+**The split this entry proposed is not available, and that is worth recording.** It read
+*"`CssImageSet.TryResolveLayers` already reports the parse error … so the validator has
+something to call"* — but `CssImageSet` lives in `Broiler.Layout`, which **references**
+`Broiler.CSS` and not the other way round. The check is self-contained in the cascade, so
+this one is a submodule patch with no main-repo half.
 
 ---
 
@@ -1460,8 +1448,24 @@ express those, and does not claim to.
   the border-box origin after the translate, so two errors cancel. And
   `visibility: hidden` takes an early return above the flood branch entirely, where an
   `feFlood` ignores its input and must still paint.
+- **Re-measured on 2026-08-23, and it is not the small job the split makes it sound.** The
+  main-repo/submodule shape is right — the region type and resolver here, a two-line call
+  there — but the *resolver* is the work, and the targets are near-misses rather than
+  blanks: `svg-filter-filter-units-user-space` **95.3%**, `svg-feflood-001` **97.6%**,
+  `empty-element-with-filter-002`/`-004` **98.7%** each, with
+  `feflood-with-filter-reference` already passing. `css/filter-effects` is 185 of 318.
+- **And one of its own tests is held up by the errors cancelling.**
+  `svg-filter-primitive-units-user-space` **passes today** because the correct local region
+  happens to land on the border-box origin after the translate — so fixing the region
+  without also moving the flood inside the transform layer is likely to *lose* it. The two
+  halves have to land together, which is what the exit gate says and what makes this a
+  feature rather than a patch. Its semantics are the real cost: `filterUnits` percentages
+  resolve against the *referencing element's* viewport (the test references one filter from
+  three different contexts, including an HTML `<div>` with a `transform`), and the primitive
+  subregion defaults to the filter region.
 - **Exit gate:** `filterUnits`/`primitiveUnits` resolve on both paths, and the flood is
-  emitted inside the transform layer.
+  emitted inside the transform layer — with `svg-filter-primitive-units-user-space` and the
+  185 currently passing staying passing.
 
 ## Dynamic stylesheets
 

--- a/patches/0003-html-column-flex-image-stretch.patch
+++ b/patches/0003-html-column-flex-image-stretch.patch
@@ -1,0 +1,64 @@
+From 9fcbcd1587b47fe74fc29996f488bb93fadbf66d Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 23 Aug 2026 11:44:25 +0000
+Subject: [PATCH] parse: let a stretched column flex item's image fill its
+ wrapper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A block-level image inside a flex/grid container is wrapped in an anonymous
+block, and for a *column* container that wrapper becomes the flex item. The
+cross-axis stretch then lands on the wrapper while the image keeps an auto
+width — which for an inline replaced box with no intrinsic size is the 300x150
+default object size. To the spec the image is the item, so it has to fill what
+was stretched.
+
+The predicate is Broiler.Layout's IsStretchedColumnFlexItem, beside the
+IsRowFlexItem this fix-up already asks, so the two readings of 'what is the
+item' cannot drift apart. It is asked before the reparent, while the image is
+still the container's own child and still carries the width, margins and
+alignment that CSS Flexbox 9.4 step 11 turns on.
+
+Measured over css/css-flexbox: 436 -> 438 passing, +2 / -0.
+---
+ .../Parse/DomParser.cs                           | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 024fd95..45d9321 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -971,6 +971,13 @@ internal sealed class DomParser
+             if (childBox is CssBoxImage && childBox.Display == CssConstants.Block
+                 && !Broiler.Layout.Engine.FlexGridItemBlockification.IsRowFlexItem(childBox))
+             {
++                // Asked before the reparent, while the image is still the flex container's own
++                // child: the predicate reads the *element's* width, margins and alignment, which
++                // are what §9.4 step 11 turns on, and the wrapper about to be inserted has none of
++                // them.
++                bool fillsStretchedItem =
++                    Broiler.Layout.Engine.FlexGridItemBlockification.IsStretchedColumnFlexItem(childBox);
++
+                 var block = CssBoxHelper.CreateBlock(childBox.ParentBox, baseUrl, null, childBox);
+                 childBox.ParentBox = block;
+                 childBox.Display = CssConstants.Inline;
+@@ -1010,6 +1017,15 @@ internal sealed class DomParser
+                     childBox.MarginLeft = "0";
+                     childBox.MarginRight = "0";
+                 }
++
++                // A column flex item's stretch lands on the wrapper, and to the spec the image
++                // *is* the item — so it has to fill what was stretched, or it keeps an `auto`
++                // width and falls back to the 300x150 default object size. The predicate lives
++                // beside IsRowFlexItem so the two readings of "what is the item" cannot drift.
++                else if (fillsStretchedItem)
++                {
++                    childBox.Width = "100%";
++                }
+             }
+             else
+             {
+-- 
+2.43.0
+

--- a/patches/0004-html-inline-replaced-box-model.patch
+++ b/patches/0004-html-inline-replaced-box-model.patch
@@ -1,0 +1,53 @@
+From 0eb8584fef44a68722e328e2198e4343b424419b Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 23 Aug 2026 12:20:07 +0000
+Subject: [PATCH] geometry: deflate an inline replaced box's padding and
+ content rects
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A display:inline box lays out as one rectangle per line rather than as a single
+border box, so the geometry collector rebuilds its border box from the union of
+those rectangles — and then set all three box-model levels to that same
+rectangle, on the stated grounds that inline boxes contribute no box-model
+padding or border to line geometry here.
+
+That premise holds for a non-replaced inline and not for a replaced one.
+CssLineBox.UpdateRectangle adds an image's border and padding to its line
+rectangle explicitly, and MeasureImageSize adds them in the block axis, so the
+union really is the border box and the other two levels have to be deflated out
+of it. <img style='width:50px;height:30px;border:3px;padding:4px'> reported
+getBoundingClientRect 64x44 — right — and clientWidth/clientHeight 64x44 too,
+where the client box excludes the border and must be 58x38. The same
+declarations on a <div> already reported 58x38, so the two paths disagreed with
+each other as well as with the spec.
+
+The split is BoxGeometry.ForInlineBox in Broiler.Layout, which owns the
+replaced/non-replaced distinction and the arithmetic; this is the call.
+---
+ Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+index f681d0a..5faf76f 100644
+--- a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
++++ b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+@@ -1004,9 +1004,11 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+             if (borderBox is { Width: 0, Height: 0 } && box.Rectangles.Count > 0)
+             {
+                 borderBox = UnionLineRectangles(box.Rectangles.Values);
+-                // Inline boxes contribute no box-model padding/border to line
+-                // geometry in this engine, so all three levels coincide.
+-                result[element] = new BoxGeometry(borderBox, borderBox, borderBox);
++                // A non-replaced inline contributes no box-model padding/border to line geometry
++                // in this engine, so its three levels coincide — but a *replaced* one's do not:
++                // the line rectangle already includes its border and padding, so they have to be
++                // deflated back out. BoxGeometry.ForInlineBox owns that split.
++                result[element] = BoxGeometry.ForInlineBox(borderBox, box);
+             }
+             else
+             {
+-- 
+2.43.0
+

--- a/patches/0005-css-image-set-negative-resolution.patch
+++ b/patches/0005-css-image-set-negative-resolution.patch
@@ -1,0 +1,148 @@
+From b816bfba43e01e63734a870deae323170c74b8e9 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 23 Aug 2026 12:36:58 +0000
+Subject: [PATCH] cascade: drop a declaration whose image-set() has a negative
+ resolution
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS Images 4 5.4 makes a <resolution> non-negative, so image-set(url(a) -1x, ...)
+is a parse error and CSS Syntax 3 9 drops the whole declaration, letting the one
+cascaded under it apply. WPT image-set-negative-resolution-rendering-2 puts a
+green url() behind it and expects green.
+
+It has to be refused in the cascade rather than at the renderer: only the winning
+value reaches the renderer, so declining it there leaves the property at its
+*initial* value instead of at the previous declaration. The renderer's own
+CssImageSet already reports the parse error, but it lives in Broiler.Layout,
+which references this assembly and not the other way round — so the check is
+self-contained here rather than a call into it.
+
+Resolutions are only looked for outside url() and outside quotes, so a file
+genuinely named sprite-1x.png does not invalidate the declaration that loads it.
+A zero resolution is deliberately not rejected: it parses and simply selects
+nothing, which is a different outcome from the declaration being dropped.
+
+Measured: css/css-images/image-set goes 26 -> 28 of 31, +2 / -0.
+---
+ Broiler.CSS.Dom/CssStyleEngine.Values.cs | 96 ++++++++++++++++++++++++
+ 1 file changed, 96 insertions(+)
+
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Values.cs b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+index 72c954b..3f75001 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Values.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+@@ -423,6 +423,15 @@ public sealed partial class CssStyleEngine
+             return false;
+         }
+ 
++        // CSS Images 4 §5.4: a <resolution> is non-negative, so `image-set(url(a) -1x, …)` is a
++        // parse error — CSS Syntax 3 §9 then drops the whole declaration and the one cascaded under
++        // it applies. It has to be refused *here*, in the cascade: only the winning value reaches
++        // the renderer, so declining it there leaves the property at its initial value rather than
++        // at the previous declaration. `image-set-negative-resolution-rendering-2` puts a green
++        // `url()` behind it and expects green.
++        if (ImageSetHasNegativeResolution(v))
++            return false;
++
+         switch (property.ToLowerInvariant())
+         {
+             case "white-space":
+@@ -2231,6 +2240,93 @@ public sealed partial class CssStyleEngine
+     /// anything containing a <c>(</c> — <c>calc(200px / 2)</c>, <c>min(…)</c>, <c>var(…)</c> —
+     /// are left alone, so this can only reject a token that no strict-mode grammar accepts.
+     /// </remarks>
++    /// <summary>
++    /// Whether the value contains an <c>image-set()</c> whose options include a negative
++    /// <c>&lt;resolution&gt;</c>, which CSS Images 4 §5.4 makes a parse error.
++    /// </summary>
++    /// <remarks>
++    /// Resolutions are only looked for <em>outside</em> a <c>url()</c> and outside quotes, so a file
++    /// genuinely named <c>sprite-1x.png</c> does not invalidate the declaration that loads it. A
++    /// zero resolution is deliberately not rejected: it parses and simply selects nothing, which is
++    /// a different outcome from the declaration being dropped.
++    /// </remarks>
++    private static bool ImageSetHasNegativeResolution(string value)
++    {
++        int at = value.IndexOf("image-set(", StringComparison.Ordinal);
++        if (at < 0)
++            return false;
++
++        int open = value.IndexOf('(', at);
++        int depth = 0, end = -1;
++        for (int i = open; i < value.Length; i++)
++        {
++            if (value[i] == '(') depth++;
++            else if (value[i] == ')' && --depth == 0) { end = i; break; }
++        }
++        if (end < 0)
++            return false;
++
++        // Walk the options, ignoring anything inside a nested function or a string.
++        int nested = 0;
++        char quote = '\0';
++        var token = new StringBuilder();
++        bool negative = false;
++
++        for (int i = open + 1; i < end; i++)
++        {
++            char c = value[i];
++
++            if (quote != '\0')
++            {
++                if (c == quote) quote = '\0';
++                continue;
++            }
++
++            if (c is '"' or '\'') { quote = c; token.Clear(); continue; }
++            if (c == '(') { nested++; token.Clear(); continue; }
++            if (c == ')') { if (nested > 0) nested--; token.Clear(); continue; }
++            if (nested > 0) continue;
++
++            if (c is ' ' or '\t' or ',')
++            {
++                if (token.Length > 0 && IsNegativeResolution(token.ToString()))
++                    negative = true;
++                token.Clear();
++            }
++            else
++            {
++                token.Append(c);
++            }
++        }
++
++        if (token.Length > 0 && IsNegativeResolution(token.ToString()))
++            negative = true;
++
++        return negative;
++    }
++
++    /// <summary>A <c>&lt;resolution&gt;</c> token whose value is below zero.</summary>
++    private static bool IsNegativeResolution(string token)
++    {
++        if (token.Length < 2 || token[0] != '-')
++            return false;
++
++        foreach (var unit in ResolutionUnits)
++        {
++            if (!token.EndsWith(unit, StringComparison.Ordinal))
++                continue;
++
++            var number = token.AsSpan(0, token.Length - unit.Length);
++            if (double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed))
++                return parsed < 0;
++        }
++
++        return false;
++    }
++
++    /// <summary>Longest first, so <c>dppx</c> is not read as <c>x</c>.</summary>
++    private static readonly string[] ResolutionUnits = ["dppx", "dpcm", "dpi", "x"];
++
+     private static bool HasUnitlessNonZeroLength(string value)
+     {
+         if (value.Contains('(', StringComparison.Ordinal))
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -33,6 +33,7 @@ succeeding and it is skipped rather than re-applied.
 | `0002-html-affine-transform-layer.patch` | `Broiler.HTML` | A rotated or skewed element is resampled through its matrix instead of being dropped on the floor: `transform: rotate(45deg)` painted a blank page and took its whole subtree with it. Pairs with `Broiler.Layout.IR.AffineLayerMap` in the main repo. Listed in the apply script. |
 | `0003-html-column-flex-image-stretch.patch` | `Broiler.HTML` | A column flex item's cross-axis stretch reaches the image inside the anonymous wrapper that became the item, instead of leaving it at the 300×150 default object size. Pairs with `Broiler.Layout.Engine.FlexGridItemBlockification.IsStretchedColumnFlexItem` in the main repo. Listed in the apply script. |
 | `0004-html-inline-replaced-box-model.patch` | `Broiler.HTML` | An inline replaced element's padding and content rects are deflated out of the line rectangle instead of all three box-model levels being the same rectangle, so `clientWidth`/`clientHeight` on a bordered or padded inline `<img>` stop reporting the border box. Pairs with `Broiler.Layout.BoxGeometry.ForInlineBox` in the main repo. Listed in the apply script. |
+| `0005-css-image-set-negative-resolution.patch` | `Broiler.CSS` | A declaration whose `image-set()` carries a negative `<resolution>` is dropped in the cascade, so the declaration under it applies instead of the property falling back to its initial value. No main-repo half — the dependency direction forbids one. Listed in the apply script. |
 
 ### `0001-html-svg-viewbox-intrinsic-ratio.patch`
 
@@ -172,3 +173,35 @@ padding and is not what that test measures.
 
 `Broiler.Cli.Tests` 50 → 49 failures with no new ones, `Broiler.Wpt.Tests` holds at 54,
 `Broiler.Layout.Tests` at 0.
+
+### `0005-css-image-set-negative-resolution.patch`
+
+CSS Images 4 §5.4 makes a `<resolution>` non-negative, so `image-set(url(a) -1x, …)` is a
+parse error and CSS Syntax 3 §9 drops the **whole declaration**, letting the one cascaded
+under it apply. `image-set-negative-resolution-rendering-2` puts a green `url()` behind it
+and expects green.
+
+**It has to be refused in the cascade, not at the renderer.** Only the winning value
+reaches the renderer, so declining it there leaves the property at its *initial* value
+rather than at the previous declaration — which is why the main-repo half already present
+in `CssUtils` (leave the property alone when `CssImageSet.TryResolveLayers` reports a parse
+error) could not close these two on its own.
+
+**This one has no main-repo half, and the open entry was wrong to imply it could.** That
+entry read *"`CssImageSet.TryResolveLayers` already reports the parse error separately from
+a function that validly selects nothing, so the validator has something to call."*
+`CssImageSet` lives in `Broiler.Layout`, which **references `Broiler.CSS`** and not the
+other way round, so the validator cannot call it. The check is therefore self-contained in
+the cascade — a scan that ignores anything inside `url()` or quotes, so a file genuinely
+named `sprite-1x.png` does not invalidate the declaration that loads it.
+
+A **zero** resolution is deliberately still accepted: it parses and simply selects nothing,
+which is a different outcome from the declaration being dropped.
+
+**Measured: `css/css-images/image-set` goes 26 → 28 of 31, +2 / −0**, and `css/css-images`
+as a whole 271 → 273 of 439. `Broiler.Cli.Tests` is unchanged at 49 failures.
+
+**A note for whoever measures next.** `Broiler.Cli.Tests.SpeculativePreloadScanTests` is
+**flaky under the full run**: two identical full runs of the suite gave 56 and 49 failures,
+differing by exactly its seven cases, and all ten pass in isolation. It cost a diagnosis
+here; re-run before attributing it to a change.

--- a/patches/README.md
+++ b/patches/README.md
@@ -31,6 +31,7 @@ succeeding and it is skipped rather than re-applied.
 | --- | --- | --- |
 | `0001-html-svg-viewbox-intrinsic-ratio.patch` | `Broiler.HTML` | An SVG image's `viewBox` gives it an intrinsic aspect ratio whatever `preserveAspectRatio` says (SVG 2 §8.2), and an absolute `width`/`height` it states is reported even when the other one is missing. Listed in the apply script. |
 | `0002-html-affine-transform-layer.patch` | `Broiler.HTML` | A rotated or skewed element is resampled through its matrix instead of being dropped on the floor: `transform: rotate(45deg)` painted a blank page and took its whole subtree with it. Pairs with `Broiler.Layout.IR.AffineLayerMap` in the main repo. Listed in the apply script. |
+| `0003-html-column-flex-image-stretch.patch` | `Broiler.HTML` | A column flex item's cross-axis stretch reaches the image inside the anonymous wrapper that became the item, instead of leaving it at the 300×150 default object size. Pairs with `Broiler.Layout.Engine.FlexGridItemBlockification.IsStretchedColumnFlexItem` in the main repo. Listed in the apply script. |
 
 ### `0001-html-svg-viewbox-intrinsic-ratio.patch`
 
@@ -98,3 +99,42 @@ carefully:
   the reference is Chromium's render rather than Broiler's: **192 of the 6 914
   golden-image failures declare a rotation or skew**, and a blank render can only
   lose against a reference that shows the rotated content.
+
+### `0003-html-column-flex-image-stretch.patch`
+
+A block-level image inside a flex or grid container is wrapped in an anonymous block
+(`DomParser.CorrectImgBoxes`), and for a **column** container that wrapper becomes the
+flex item — `FlexGridItemBlockification.IsRowFlexItem` exempts only *row* containers,
+deliberately, because block flow cannot position a block-level replaced box on its own.
+The cross-axis stretch therefore lands on the wrapper while the image inside keeps an
+`auto` width, which for an inline replaced box with no intrinsic size means the 300×150
+default object size. To the spec the image *is* the item, so it has to fill what was
+stretched.
+
+**The main-repo half carries the decision and the submodule half is one call**, which is
+the shape `CLAUDE.md` recommends: the patch is 16 lines, and
+`IsStretchedColumnFlexItem` — with the conditions, the reasoning and the counter-examples
+— sits beside the `IsRowFlexItem` this fix-up already asks, so the two readings of "what
+is the item" cannot drift apart. The predicate is asked *before* the reparent, while the
+image is still the container's own child and still carries the width, margins and
+alignment CSS Flexbox §9.4 step 11 turns on.
+
+**Measured over `css/css-flexbox`, 644 reftests: 436 → 438 passing, +2 / −0**
+(`aspect-ratio-intrinsic-size-007` and `flex-svg-no-intrinsic-column-001`).
+`css/css-images` (271/439), `css/css-masking/clip-path` (157/227) and `quirks` (21/25) do
+not move, and `Broiler.Wpt.Tests` holds at its 54 pre-existing failures.
+
+**Two conditions in the predicate exist because the first attempt lost two tests**, and
+they are worth keeping in mind for the general form of this gap. A percentage width sizes
+the *content* box while a stretch sizes the *border* box, so `width: 100%` is an exact
+stand-in only when the image has no inline-axis padding or border —
+`flex-aspect-ratio-intrinsic-padding-001`, whose assertion names the content box outright,
+overflowed by exactly its `padding: 20px`. And the container's cross size has to come from
+outside rather than from its contents: an `inline-flex` column container shrink-wraps to
+its items, so an item declared `100%` of it contributes nothing to the size it is a
+percentage of and the container collapses (`inline-flex-column-image-load`). Both of those
+passed before and pass now.
+
+**Outside those conditions the stretch still belongs on the replaced element and is still
+not applied.** That is the general form, and it wants the cross size pushed onto the box
+during flex layout rather than a declaration rewritten before it.

--- a/patches/README.md
+++ b/patches/README.md
@@ -32,6 +32,7 @@ succeeding and it is skipped rather than re-applied.
 | `0001-html-svg-viewbox-intrinsic-ratio.patch` | `Broiler.HTML` | An SVG image's `viewBox` gives it an intrinsic aspect ratio whatever `preserveAspectRatio` says (SVG 2 §8.2), and an absolute `width`/`height` it states is reported even when the other one is missing. Listed in the apply script. |
 | `0002-html-affine-transform-layer.patch` | `Broiler.HTML` | A rotated or skewed element is resampled through its matrix instead of being dropped on the floor: `transform: rotate(45deg)` painted a blank page and took its whole subtree with it. Pairs with `Broiler.Layout.IR.AffineLayerMap` in the main repo. Listed in the apply script. |
 | `0003-html-column-flex-image-stretch.patch` | `Broiler.HTML` | A column flex item's cross-axis stretch reaches the image inside the anonymous wrapper that became the item, instead of leaving it at the 300×150 default object size. Pairs with `Broiler.Layout.Engine.FlexGridItemBlockification.IsStretchedColumnFlexItem` in the main repo. Listed in the apply script. |
+| `0004-html-inline-replaced-box-model.patch` | `Broiler.HTML` | An inline replaced element's padding and content rects are deflated out of the line rectangle instead of all three box-model levels being the same rectangle, so `clientWidth`/`clientHeight` on a bordered or padded inline `<img>` stop reporting the border box. Pairs with `Broiler.Layout.BoxGeometry.ForInlineBox` in the main repo. Listed in the apply script. |
 
 ### `0001-html-svg-viewbox-intrinsic-ratio.patch`
 
@@ -138,3 +139,36 @@ passed before and pass now.
 **Outside those conditions the stretch still belongs on the replaced element and is still
 not applied.** That is the general form, and it wants the cross size pushed onto the box
 during flex layout rather than a declaration rewritten before it.
+
+### `0004-html-inline-replaced-box-model.patch`
+
+A `display: inline` box lays out as one rectangle per line rather than as a single
+border box, so `HtmlContainerInt.CollectLayoutGeometry` rebuilds its border box from the
+union of those rectangles — and then set **all three** box-model levels to that same
+rectangle, on the stated grounds that inline boxes contribute no box-model padding or
+border to line geometry in this engine.
+
+**That premise holds for a non-replaced inline and not for a replaced one.**
+`CssLineBox.UpdateRectangle` adds an image's border and padding to its line rectangle
+explicitly, and `MeasureImageSize` adds them in the block axis, so the union really *is*
+the border box and the other two levels have to be deflated out of it. Measured:
+`<img style="width:50px;height:30px;border:3px solid;padding:4px">` reported
+`getBoundingClientRect` **64×44** — right — and `clientWidth`/`clientHeight` **64×44**
+too, where the client box excludes the border and must be **58×38**. It now reports
+58×38, and a `<div>` with the same declarations reports 58×38 as it always did, so the
+two paths agree again. A non-replaced `<span>` is untouched.
+
+The main-repo half is `BoxGeometry.ForInlineBox`, which owns the replaced/non-replaced
+distinction and the arithmetic; the patch is the call.
+
+**It moves no WPT test, and the entry it came from was wrong about why it would.**
+`css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003` was named as
+carrying "the six `<img>` assertions still failing"; it holds at **42/96 before and
+after**, and those six are identical in both — `client-width: expected 50, actual 0`
+against `client-height: expected 0, actual 50` is a logical/physical axis transposition
+under `contain-intrinsic-size`'s logical properties, not a border deflation. What this
+fixes is the general API defect, which is every inline replaced element with a border or
+padding and is not what that test measures.
+
+`Broiler.Cli.Tests` 50 → 49 failures with no new ones, `Broiler.Wpt.Tests` holds at 54,
+`Broiler.Layout.Tests` at 0.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -380,6 +380,7 @@ PENDING_PATCHES=(
   "Broiler.HTML|patches/0002-html-affine-transform-layer.patch"
   "Broiler.HTML|patches/0003-html-column-flex-image-stretch.patch"
   "Broiler.HTML|patches/0004-html-inline-replaced-box-model.patch"
+  "Broiler.CSS|patches/0005-css-image-set-negative-resolution.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -378,6 +378,7 @@ set -euo pipefail
 PENDING_PATCHES=(
   "Broiler.HTML|patches/0001-html-svg-viewbox-intrinsic-ratio.patch"
   "Broiler.HTML|patches/0002-html-affine-transform-layer.patch"
+  "Broiler.HTML|patches/0003-html-column-flex-image-stretch.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -379,6 +379,7 @@ PENDING_PATCHES=(
   "Broiler.HTML|patches/0001-html-svg-viewbox-intrinsic-ratio.patch"
   "Broiler.HTML|patches/0002-html-affine-transform-layer.patch"
   "Broiler.HTML|patches/0003-html-column-flex-image-stretch.patch"
+  "Broiler.HTML|patches/0004-html-inline-replaced-box-model.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/DocumentCollectionBindingModuleTests.cs
+++ b/src/Broiler.Cli.Tests/DocumentCollectionBindingModuleTests.cs
@@ -125,4 +125,48 @@ document.getElementById('result').textContent = outcome;
         Assert.Contains("removed", result);
         Assert.DoesNotContain("threw:", result);
     }
+
+    /// <summary>
+    /// CSSOM §2.2: <c>document.styleSheets</c> is every sheet associated with the document, so a
+    /// <c>&lt;link rel=stylesheet&gt;</c> belongs in it beside a <c>&lt;style&gt;</c>, in document
+    /// order. A disabled <c>&lt;link&gt;</c> has no associated sheet and stays out (HTML §4.2.4).
+    /// </summary>
+    /// <remarks>
+    /// The main-document binding used to filter the element list to tag <c>style</c>, so an
+    /// external sheet was absent however well it loaded, while the sub-document collection counted
+    /// it — the same tree answered two different things depending on which document was asked. Both
+    /// now share one predicate, which is what this pins. Identity across two reads is here because
+    /// the collection is specified to be live and scripts compare sheet objects.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void StyleSheets_Includes_Linked_Sheets_In_Document_Order_And_Excludes_A_Disabled_Link()
+    {
+        var html = @"<!DOCTYPE html>
+<html><head>
+<link rel=""stylesheet"" href=""first.css"">
+<style>.x{color:red}</style>
+<link rel=""stylesheet"" href=""off.css"" disabled>
+<link rel=""icon"" href=""favicon.ico"">
+<a href=""not-a-sheet.css""></a>
+</head><body>
+<script>
+var s = document.styleSheets;
+var tags = [];
+for (var i = 0; i < s.length; i++) tags.push(s[i].ownerNode.tagName.toLowerCase());
+var out = document.createElement('div');
+out.id = 'result';
+out.textContent =
+  'sheets=' + s.length +
+  '|order=' + tags.join(',') +
+  '|identity=' + (s[0] === document.styleSheets[0] ? 'same' : 'different');
+document.body.appendChild(out);
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        // The enabled <link> and the <style>; the disabled <link>, the rel=icon <link> and the
+        // <a href> are all excluded.
+        Assert.Contains("sheets=2|order=link,style|identity=same", result);
+    }
 }

--- a/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
+++ b/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
@@ -308,4 +308,45 @@ try {
         // 'data-ssg-error' string is in it either way; only the written attribute has an '='.
         Assert.DoesNotContain("data-ssg-error=", result);
     }
+
+    /// <summary>
+    /// A page may probe <c>ViewTransition.prototype</c> for a member this engine does not have,
+    /// and doing so must not abort the script that contains the probe.
+    /// </summary>
+    /// <remarks>
+    /// WPT's <c>view-transition-waituntil-animation-manipulation</c> opens with
+    /// <c>failIfNot(ViewTransition.prototype.waitUntil, …)</c>. With no <c>ViewTransition</c>
+    /// global, evaluating the *argument* threw <c>ReferenceError</c> before <c>failIfNot</c> was
+    /// entered, so the whole inline script aborted — including the work at the bottom of it — and
+    /// the page reported nothing at all. The probe must read <c>undefined</c> and the statements
+    /// after it must still run. <c>waitUntil</c> is deliberately absent: it is unimplemented here,
+    /// and this pins that the *probe* is what stopped costing a page its script.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void Probing_ViewTransition_Prototype_Does_Not_Abort_The_Script()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var out;
+try {
+  var probe = typeof ViewTransition.prototype.waitUntil;
+  var t = document.startViewTransition(function () {});
+  var ctor;
+  try { new ViewTransition(); ctor = 'constructed'; } catch (e) { ctor = e.name; }
+  out = 'probe=' + probe + '|instance=' + (t instanceof ViewTransition) + '|ctor=' + ctor;
+} catch (e) {
+  out = 'aborted: ' + e.name;
+}
+document.getElementById('result').textContent = out;
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        // The probe reads undefined rather than throwing; the object startViewTransition returns is
+        // recognised by the interface; and the interface itself is not constructible (WebIDL).
+        Assert.Contains("probe=undefined|instance=true|ctor=TypeError", result);
+    }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -169,8 +169,40 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     }
 
     // viewport dimensions for window.innerWidth/innerHeight and element box-model properties
-    private int _viewportWidth = 1024;
-    private int _viewportHeight = 768;
+    private int _viewportWidth = DefaultViewportWidth;
+    private int _viewportHeight = DefaultViewportHeight;
+
+    /// <summary>The viewport a bridge assumes when its host does not say otherwise.</summary>
+    public const int DefaultViewportWidth = 1024;
+
+    /// <inheritdoc cref="DefaultViewportWidth"/>
+    public const int DefaultViewportHeight = 768;
+
+    /// <summary>
+    /// The CSS viewport this document is laid out against, in pixels. Everything the bridge
+    /// resolves against the viewport reads it: <c>window.innerWidth</c>/<c>innerHeight</c>,
+    /// <c>vw</c>/<c>vh</c> lengths, media-query evaluation, and the maximum scroll offset.
+    /// </summary>
+    /// <remarks>
+    /// These were fixed at 1024×768 and never written, so a host rendering at any other size got a
+    /// document whose script-visible geometry disagreed with the pixels: a page built to be "taller
+    /// than the viewport" at 200×200 scrolled to somewhere that was not the bottom of the canvas,
+    /// and a test asserting on what is on screen then failed for a reason that had nothing to do
+    /// with what it was testing. A host that renders at a size is expected to set this to the same
+    /// size; leaving it alone keeps the historical default.
+    /// </remarks>
+    public int ViewportWidth
+    {
+        get => _viewportWidth;
+        set => _viewportWidth = value > 0 ? value : DefaultViewportWidth;
+    }
+
+    /// <inheritdoc cref="ViewportWidth"/>
+    public int ViewportHeight
+    {
+        get => _viewportHeight;
+        set => _viewportHeight = value > 0 ? value : DefaultViewportHeight;
+    }
 
     /// <summary>
     /// Optional callback invoked after each queued timer, interval, animation-frame,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.DocumentCollectionHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.DocumentCollectionHost.cs
@@ -25,4 +25,7 @@ public sealed partial class DomBridge : Dom.Features.IDocumentCollectionHost
 
     JSObject Dom.Features.IDocumentCollectionHost.BuildStyleSheetObject(DomElement styleElement)
         => BuildStyleSheetObject(styleElement);
+
+    bool Dom.Features.IDocumentCollectionHost.HasAssociatedStyleSheet(DomElement element)
+        => HasAssociatedStyleSheet(element);
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollGeometry.cs
@@ -31,6 +31,43 @@ public sealed partial class DomBridge
         }
     }
 
+    /// <summary>
+    /// The descendants that contribute to <paramref name="element"/>'s <em>scrollable overflow
+    /// region</em>: every rendered descendant, except that a descendant which clips its own
+    /// overflow contributes its border box and nothing beneath it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// CSS Overflow 3 §3.1: a box's scrollable overflow region is the union of its own content and
+    /// its descendants' scrollable overflow — and a descendant that is itself a scroll container
+    /// has *already scrolled* its own overflow, so what it contributes upward is its border box.
+    /// Its clipped content is reachable by scrolling *it*, not by scrolling the ancestor.
+    /// </para>
+    /// <para>
+    /// The plain subtree walk unioned everything, so a 400×400 block inside a 120×100
+    /// <c>overflow: auto</c> box made the *document* report <c>scrollHeight</c> 401 for a page
+    /// whose content is 102px tall. That stayed invisible while the bridge held its viewport at
+    /// 1024×768 — 401 is under 768, so the maximum scroll came out 0 either way and nothing
+    /// moved. Once the bridge was given the size the run actually renders at, a 280×130 render had
+    /// a 271px scroll range that does not exist, and <c>scrollIntoView</c> on content inside one of
+    /// those containers scrolled the whole document to reach it.
+    /// </para>
+    /// </remarks>
+    private IEnumerable<DomElement> EnumerateScrollableOverflowDescendants(DomElement element)
+    {
+        foreach (var child in EnumerateRenderedChildren(element))
+        {
+            yield return child;
+
+            // The border box is the contribution; the subtree under it is not.
+            if (CssOverflow.ClipsOverflow(GetComputedProps(child)))
+                continue;
+
+            foreach (var descendant in EnumerateScrollableOverflowDescendants(child))
+                yield return descendant;
+        }
+    }
+
     private IEnumerable<DomElement> EnumerateRenderedChildren(DomElement element)
     {
         if (string.Equals(element.TagName, "slot", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -380,7 +380,7 @@ public sealed partial class DomBridge
         var includeEndMargins = IsViewportElementForMetrics(element);
         var marginPercentageBasis = (double)contentBox.Width;
 
-        foreach (var descendant in EnumerateRenderedDescendants(element))
+        foreach (var descendant in EnumerateScrollableOverflowDescendants(element))
         {
             if (!TryGetSharedLayoutGeometry(descendant, out var childBox))
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -44,19 +44,35 @@ public sealed partial class DomBridge
     {
         foreach (var element in root.Descendants().OfType<DomElement>())
         {
-            if (!(string.Equals(element.TagName, "style", StringComparison.OrdinalIgnoreCase) || IsExternalStylesheet(element)))
-                continue;
-
-            // A disabled <link> has no associated CSS style sheet, so it is absent from
-            // document.styleSheets (HTML §4.2.4 <link disabled>). A <style> whose sheet was
-            // disabled via CSSOM (CSSStyleSheet.disabled) still appears in the collection —
-            // only its rules stop applying — so it is not filtered here.
-            if (IsStyleSheetDisabled(element) &&
-                string.Equals(element.TagName, "link", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            results.Add(element);
+            if (HasAssociatedStyleSheet(element))
+                results.Add(element);
         }
+    }
+
+    /// <summary>
+    /// Whether the element has an associated CSS style sheet, and so belongs in a document's
+    /// <c>styleSheets</c> collection (CSSOM §2.2).
+    /// </summary>
+    /// <remarks>
+    /// Shared with the main-document binding through
+    /// <see cref="Dom.Features.IDocumentCollectionHost.HasAssociatedStyleSheet"/>. It is factored
+    /// out precisely because the two collections disagreed: this one has always counted
+    /// <c>&lt;link rel=stylesheet&gt;</c>, and the main document's filtered to tag <c>style</c>, so
+    /// the same tree answered two different things depending on which document was asked.
+    /// <para>
+    /// A disabled <c>&lt;link&gt;</c> has no associated sheet, so it is absent (HTML §4.2.4
+    /// <c>&lt;link disabled&gt;</c>). A <c>&lt;style&gt;</c> whose sheet was disabled through CSSOM
+    /// (<c>CSSStyleSheet.disabled</c>) still appears — only its rules stop applying — so it is not
+    /// filtered here.
+    /// </para>
+    /// </remarks>
+    private bool HasAssociatedStyleSheet(DomElement element)
+    {
+        bool isStyle = string.Equals(element.TagName, "style", StringComparison.OrdinalIgnoreCase);
+        if (!isStyle && !IsExternalStylesheet(element))
+            return false;
+
+        return !(!isStyle && IsStyleSheetDisabled(element));
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
@@ -148,6 +148,23 @@ public sealed partial class DomBridge
             function SVGElement() { throw new TypeError('Illegal constructor'); }
             function CanvasRenderingContext2D() { throw new TypeError('Illegal constructor'); }
 
+            // The object document.startViewTransition() returns has always existed here; the
+            // *interface* did not, and a page that probes it paid more than a missing feature
+            // costs. css-view-transitions/view-transition-waituntil-animation-manipulation opens
+            // with `failIfNot(ViewTransition.prototype.waitUntil, ...)`, so evaluating the
+            // *argument* threw ReferenceError before failIfNot was ever entered: the whole inline
+            // script aborted, including the onload assignment at the bottom of it, and
+            // startViewTransition was never called at all. The failure then reads as a compositing
+            // bug and is not one. With the interface present, `ViewTransition.prototype.waitUntil`
+            // is a plain undefined, the precondition is *reached*, and the page reports the
+            // precondition failure it was written to report.
+            //
+            // waitUntil is deliberately not defined. It is a proposal, not shipped here, and
+            // faking one would let the test past its own guard and into Web Animations calls this
+            // engine cannot answer either (there is no Animation constructor and no
+            // Element.prototype.animate) — a worse answer than an honest precondition failure.
+            function ViewTransition() { throw new TypeError('Illegal constructor'); }
+
             // ImageData, unlike the interfaces above, *is* constructible — HTML defines
             // new ImageData(w, h) and new ImageData(data, w, h) — so it gets a real body rather
             // than an illegal-constructor throw.
@@ -244,6 +261,16 @@ public sealed partial class DomBridge
                         && typeof o.getImageData === 'function'
                         && typeof o.fillRect === 'function'
                         && typeof o.fillStyle === 'string';
+                });
+
+                // A view transition is not a node either, and the bridge builds it as a plain
+                // object, so it answers from the members the interface is defined by. `types` and
+                // `skipTransition` together are what separate it from any other thenable-bearing
+                // object a page might hold.
+                define(ViewTransition, function (o) {
+                    return !!o && typeof o === 'object'
+                        && typeof o.skipTransition === 'function'
+                        && !!o.ready && !!o.finished && !!o.updateCallbackDone;
                 });
 
                 // Accepts an ImageData this constructor produced and one getImageData returned,

--- a/src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs
@@ -118,16 +118,16 @@ internal static class DocumentCollectionBinding
 
     public static JSValue GetStyleSheets(IDocumentCollectionHost host, in Arguments a)
     {
-        var styleEls = new List<DomElement>();
+        // CSSOM §2.2: every sheet associated with the document, which is a `<style>` *and* a
+        // `<link rel=stylesheet>`. This filtered to tag `style`, so an external sheet was missing
+        // however well it loaded. `host.Elements` is already in document order, which is the order
+        // the collection is defined in.
+        var arr = new JSArray();
         foreach (var el in host.Elements)
         {
-            if (string.Equals(el.TagName, "style", StringComparison.OrdinalIgnoreCase))
-                styleEls.Add(el);
+            if (host.HasAssociatedStyleSheet(el))
+                arr.Add(host.BuildStyleSheetObject(el));
         }
-
-        var arr = new JSArray();
-        foreach (var styleEl in styleEls)
-            arr.Add(host.BuildStyleSheetObject(styleEl));
         return arr;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/IDocumentCollectionHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/IDocumentCollectionHost.cs
@@ -34,4 +34,19 @@ internal interface IDocumentCollectionHost
     int CurrentScriptIndex { get; }
 
     JSObject BuildStyleSheetObject(DomElement styleElement);
+
+    /// <summary>
+    /// Whether <paramref name="element"/> has an associated CSS style sheet, and so belongs in
+    /// <c>document.styleSheets</c> (CSSOM §2.2: the collection is every sheet associated with the
+    /// document, a <c>&lt;link rel=stylesheet&gt;</c> included).
+    /// </summary>
+    /// <remarks>
+    /// The same predicate the sub-document collection uses, rather than a second reading of it.
+    /// This binding used to filter <see cref="Elements"/> to tag <c>style</c> on its own, so an
+    /// external sheet was absent from the main document's collection however well it loaded — a
+    /// page whose linked sheet demonstrably applied (<c>getComputedStyle</c> read the linked
+    /// colour) still reported <c>document.styleSheets.length === 0</c>. Sharing the predicate is
+    /// what keeps the two documents agreeing about what a document's stylesheets are.
+    /// </remarks>
+    bool HasAssociatedStyleSheet(DomElement element);
 }

--- a/src/Broiler.Wpt.Tests/ScrollClampingTests.cs
+++ b/src/Broiler.Wpt.Tests/ScrollClampingTests.cs
@@ -102,4 +102,49 @@ public class ScrollClampingTests : IDisposable
         Assert.True(body > 0);
         Assert.True(canvas < body);
     }
+
+    /// <summary>
+    /// The clamp has to be computed against the size the run actually renders at, not against the
+    /// bridge's own default.
+    /// </summary>
+    /// <remarks>
+    /// The tests above all render at 1024×768 — the bridge's built-in default — and passed for that
+    /// reason rather than on their own merits: <c>vh</c> lengths and the maximum scroll offset
+    /// resolved against 1024×768 whatever size the runner was constructed with, so a page built to
+    /// be taller than *its* viewport scrolled to somewhere that was not the bottom of the canvas.
+    /// This renders the same page small, where the two sizes disagree and the mismatch shows.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void TheEndOfTheScrollRangeIsTheRenderedViewportNotTheDefaultOne()
+    {
+        // 400vh of content in a 200×200 viewport: scrolling past the end must still come to rest
+        // with the body filling the view, exactly as it does at the default size.
+        var (canvas, body) = Render("window.scrollTo(0, 1e9);", w: 200, h: 200);
+
+        Assert.True(body > canvas,
+            $"expected the body to still fill most of the 200x200 viewport (body={body}, canvas={canvas})");
+    }
+
+    /// <summary>
+    /// <c>window.innerWidth</c>/<c>innerHeight</c> report the size the run renders at.
+    /// </summary>
+    /// <remarks>
+    /// This is the script-visible half of the same defect, and it is worth its own test because
+    /// *layout* was never wrong: the engine is handed the real width and height, so a <c>vh</c>
+    /// length in a stylesheet already resolved correctly. Only the bridge disagreed, which is
+    /// exactly the split that makes the bug hard to see — the page looks right and the script
+    /// reading its geometry is told something else.
+    /// </remarks>
+    [Fact(Timeout = 600000)]
+    public void WindowInnerSizeReportsTheRenderedViewport()
+    {
+        // The body is hidden unless the script sees the size it is actually being rendered at, so a
+        // bridge still reporting its 1024x768 default paints no body at all.
+        var (_, body) = Render(
+            "if (window.innerWidth !== 200 || window.innerHeight !== 200)" +
+            " { document.body.style.display = 'none'; }", w: 200, h: 200);
+
+        Assert.True(body > 0,
+            "window.innerWidth/innerHeight should report 200x200, the size this render was asked for");
+    }
 }

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -101,9 +101,15 @@ public class WptTestRunnerTests : IDisposable
         object? executed;
         try
         {
+            // Reflection binds positionally and does not fill in optional parameters, so every
+            // argument has to be passed — including the viewport, which the runner supplies from
+            // the size it is about to render at. These script-only cases never render, so they
+            // take the runner's own defaults.
             executed = method!.Invoke(
                 null,
-                [testHtml, new Uri(Path.GetFullPath(testFile)).AbsoluteUri, _tempDir, false]);
+                [testHtml, new Uri(Path.GetFullPath(testFile)).AbsoluteUri, _tempDir, false,
+                 Broiler.HtmlBridge.DomBridge.DefaultViewportWidth,
+                 Broiler.HtmlBridge.DomBridge.DefaultViewportHeight]);
         }
         finally
         {
@@ -3268,6 +3274,15 @@ input {
     for (const match of document.querySelectorAll('.target')) {
       match.scrollIntoView({ block: 'center', inline: 'end' });
     }
+    // Same reset, and for the same reason, as the percentage/absolute fixture above: the
+    // zoom: 2 container is 244px tall in a 240px viewport, so the document genuinely has
+    // 13.6px of scrollable overflow and scrollIntoView correctly continues outward into it
+    // (the root is a scroll container even under overflow: hidden -- CSS Overflow 3 SS3.3).
+    // That viewport scroll is incidental to the container alignment math being compared and
+    // the reference does not model it. It only became visible once the bridge was given the
+    // size the run actually renders at: while it held its own 1024x768 default, 253.6 was
+    // under 768 and the document could not scroll at all.
+    document.documentElement.scrollTo(0, 0);
   </script>
 </body>
 </html>";

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -1939,7 +1939,9 @@ internal sealed partial class WptTestRunner
                 html,
                 new Uri(Path.GetFullPath(testPath)).AbsoluteUri,
                 wptRoot,
-                batchStyleInvalidations: IsCrashTest(testPath));
+                batchStyleInvalidations: IsCrashTest(testPath),
+                viewportWidth: _width,
+                viewportHeight: _height);
             html = executed.Html ?? html;
             renderDocument = executed.Document;
             layoutAssertionFailures = ComputeLayoutAssertionFailures(executed.LayoutAssertions);
@@ -2801,7 +2803,7 @@ internal sealed partial class WptTestRunner
         Broiler.Dom.DomDocument? renderDocument;
         using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.Scripts))
         {
-            var executed = ExecuteScriptsWithDom(html, testBaseUrl, wptRoot);
+            var executed = ExecuteScriptsWithDom(html, testBaseUrl, wptRoot, viewportWidth: _width, viewportHeight: _height);
             html = executed.Html ?? html;
             renderDocument = executed.Document;
             LastLayoutAssertions = executed.LayoutAssertions;
@@ -3301,11 +3303,20 @@ internal sealed partial class WptTestRunner
         }
     }
 
+    /// <param name="viewportWidth">
+    /// The width the document is about to be rendered at, carried onto the bridge so the geometry
+    /// the scripts see agrees with the pixels the comparison is made from. It used to be fixed at
+    /// the bridge's own 1024x768 default whatever size the run asked for, so `vh` lengths and the
+    /// maximum scroll offset resolved against a viewport the render did not use.
+    /// </param>
+    /// <param name="viewportHeight"><inheritdoc cref="ExecuteScriptsWithDom" path="/param[@name='viewportWidth']"/></param>
     private static ExecutedDocument ExecuteScriptsWithDom(
         string html,
         string url,
         string? wptRoot = null,
-        bool batchStyleInvalidations = false)
+        bool batchStyleInvalidations = false,
+        int viewportWidth = DomBridge.DefaultViewportWidth,
+        int viewportHeight = DomBridge.DefaultViewportHeight)
     {
         // This method is what drives the bridge's headless geometry pass, and that pass builds a
         // container of its own — out of reach of the handlers the render is handed afterwards. Tell
@@ -3458,7 +3469,7 @@ internal sealed partial class WptTestRunner
             // positioning, animation snapshots, etc. via the DomBridge.
             using var microTaskContext2 = MicroTaskSynchronizationContext.Install(microTasks);
             using var context2 = new JSContext();
-            using var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
+            using var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop, ViewportWidth = viewportWidth, ViewportHeight = viewportHeight };
             bridge2.Attach(context2, html, url);
             // Inject browser API stubs so onload handlers etc. can reference them.
             try { context2.Eval(BrowserApiStubs); } catch { /* best-effort */ }
@@ -3488,7 +3499,7 @@ internal sealed partial class WptTestRunner
         // view and its HtmlContainer (hence the whole box tree and every sub-resource its image
         // load handlers hold), timer/animation queues, listener stores and observers. Leaving it
         // to the GC kept one of those sessions alive per rendered document.
-        using var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
+        using var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop, ViewportWidth = viewportWidth, ViewportHeight = viewportHeight };
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
         context["queueMicrotask"] = new JSFunction((in Arguments a) =>
         {


### PR DESCRIPTION
## Summary

This PR fixes five distinct bugs across the rendering pipeline: viewport dimensions were hardcoded and never updated, nested scroll containers inflated ancestor overflow, and three CSS rendering issues (flex item stretch, inline box geometry, and SVG backgrounds). It also adds a cascade-level check for negative resolutions in `image-set()`.

## Changes

### Viewport and scroll geometry (main repo)

- **Viewport dimensions are now settable** (`DomBridge.cs`): `ViewportWidth` and `ViewportHeight` were fixed at 1024×768 and never written. Everything the bridge resolves against the viewport — `window.innerWidth`/`innerHeight`, `vw`/`vh` lengths, media queries, maximum scroll offset — read these unwritten fields. The runner now passes the actual render size into both bridges it constructs. Existing hosts default to 1024×768 for backward compatibility.

- **Nested scroll containers no longer inflate ancestor overflow** (`LayoutMetrics.ScrollGeometry.cs`): CSS Overflow 3 §3.1 requires that a scroll container's border box (not its clipped content) contributes to an ancestor's scrollable overflow. `TryGetSharedScrollExtent` was unioning every descendant's border box without this stop, causing a 400×400 block inside a 120×100 `overflow: auto` box to report `scrollHeight` 401 on a 102px-tall page. This was invisible while the viewport was hardcoded at 768px tall; fixing the viewport exposed it.

### CSS rendering fixes (submodule patches + main repo)

- **Column flex items' images now fill their stretched wrapper** (`0003-html-column-flex-image-stretch.patch` + `FlexGridItemBlockification.cs`): A block-level image in a column flex container is wrapped in an anonymous block that becomes the flex item. The cross-axis stretch landed on the wrapper while the image kept an `auto` width (300×150 default). The predicate `IsStretchedColumnFlexItem` (in main repo) identifies when to apply `width: 100%` to the image before wrapping, so it fills the stretched container. Measured: `css/css-flexbox` 436 → 438 (+2).

- **Inline replaced elements' box-model rects are now correct** (`0004-html-inline-replaced-box-model.patch` + `BoxGeometry.cs`): A `display: inline` box lays out as one rectangle per line, so the geometry collector rebuilds its border box from the union of those rectangles. It was then setting all three box-model levels to that same rectangle. For a non-replaced inline this is correct; for a replaced inline (e.g., `<img>`), the line rectangle already includes border and padding, so the padding and content boxes must be deflated out. `<img style="border:3px;padding:4px">` now reports `clientWidth`/`clientHeight` correctly (excluding border), matching what a `<div>` with the same declarations reports.

- **SVG images now paint their root background** (`SvgRenderer.cs` + `SvgImageRaster.cs`): CSS Backgrounds §2.11.2 makes the root element's background the canvas's. For an SVG used as an image, that canvas is the destination box. Nothing painted it, so `<svg style="background: black">` came back transparent. `TryGetRootBackgroundColor` extracts the background from the root `<svg>` element and `SvgImageRaster.BuildDisplayList` emits it as the first item in the display list, behind the document.

### Cascade-level validation (submodule patch)

- **Negative resolutions in `image-set()` now drop the declaration** (`0005-css-image-set-negative-resolution.patch`): CSS Images 4 §5.4 makes `<resolution>` non-negative, so `image-set(url(a) -1x, …)` is a parse error. CSS Syntax 3 §9 drops the whole declaration, letting the cascaded one apply. This must happen in the cascade, not the renderer (only the winning value reaches the renderer, so declining it there leaves the property at its initial value instead of the previous declaration

https://claude.ai/code/session_01MsFGg4m1u8FBxta8wnB88z