### PR TITLE
Track 1 triage: three core-language fixes, four bullets retired, one cluster found

### DIFF
--- a/docs/broiler-js-gaps-roadmap.md
+++ b/docs/broiler-js-gaps-roadmap.md
@@ -138,18 +138,35 @@ exclusion; the dashboard records exact engine and suite revisions.
 
 ### Direct eval, parser, scope, and control flow
 
+Each bullet below was reproduced against the pinned ref before being worked on or retired;
+the ones marked **fixed** carry a minimal regression in
+`Broiler.JavaScript.Integration.Tests/Track1LanguageTests.cs`.
+
 - A captured read after deleting an eval-introduced `var` retains the torn-down cell instead of
-  re-resolving the name outward.
+  re-resolving the name outward. **Still reproduces.**
+- An empty statement does not correctly terminate a Directive Prologue. **Fixed:** a statement
+  that already ended at its own `;` was consuming a second one, deleting exactly the empty
+  statement that ends the prologue.
+- A parameter named `undefined` does not shadow the global binding. **Fixed:** the compiler
+  folded every identifier of that name to the undefined value; it now folds only a reference
+  that resolves to no binding.
+- Async and generator bodies do not enter the runtime strict-mode scope, so a failed strict
+  `[[Set]]` may not throw. **Still reproduces.**
+- **Early errors that never fire** — the cluster the modes and the named-error reporting made
+  visible, and the largest one here. `for (const x;;)`, a body `var` shadowing the head's
+  lexical name, a labelled function declaration as a loop body, `export` inside `eval`, and a
+  direct `var` colliding with a global lexical binding are accepted and RUN: each test reaches
+  its `$DONOTEVALUATE()`. About 30 files across `test/language/statements/{for,if,labeled}`,
+  `test/language/eval-code` and `test/language/global-code`.
 - `new.target` is rejected in a direct eval nested inside an eval-compiled function.
-- An empty statement does not correctly terminate a Directive Prologue.
-- Comment and regular-expression-literal lexical edge cases remain in the failure manifest.
-- Labeled and unlabeled `continue`, block-scoped loop bindings, and other lexical-environment
-  cases remain open.
+  **Does not reproduce**; `staging/sm/class/newTargetEval.js` passes. It is in the failure
+  manifest from an older run — confirm against a current CI run before removing the path.
+- Comment and regular-expression-literal lexical edge cases, labeled and unlabeled `continue`,
+  and block-scoped loop bindings. **Do not reproduce:** `test/language/comments`,
+  `test/language/asi` and the `for`/`if`/`while`/`do-while`/`labeled` directories pass apart
+  from the early-error cluster above.
 - Remaining Annex B cases must be reduced from the current manifest rather than reconstructed
   from deleted issue snapshots.
-- A parameter named `undefined` does not shadow the global binding.
-- Async and generator bodies do not enter the runtime strict-mode scope, so a failed strict
-  `[[Set]]` may not throw.
 
 Evidence:
 
@@ -162,10 +179,18 @@ Evidence:
 ### Objects, arrays, symbols, and Proxy-sensitive behavior
 
 - Symbol own keys enumerate by Symbol-creation order rather than property-creation order.
+  **Still reproduces**; fixing it needs a per-object record of the order symbol properties
+  were added, so it is a property-storage change rather than a sort to delete.
 - `slice`, `unshift`, `toReversed`, `reduceRight`, array mutation limits, near-maximum lengths,
-  and Proxy-created results retain confirmed failure paths.
+  and Proxy-created results retain confirmed failure paths. **Largely does not reproduce:** all
+  four directories pass except `slice/create-proto-from-ctor-realm-array.js`, a cross-realm
+  species case.
 - `Reflect.set(base, key, value, receiver)` gives a new receiver property the base property's
-  attributes instead of the all-true descriptor required by `CreateDataProperty`.
+  attributes instead of the all-true descriptor required by `CreateDataProperty`. **Fixed:**
+  the receiver-create paths in `JSObject.PropertyStorage` use the CreateDataProperty
+  attributes. No test262 file at the pinned ref reaches the case, so
+  `ReflectSetReceiverAttributesTests` — which pinned the deviation and now pins the fix — is
+  the only evidence there is.
 
 Evidence:
 


### PR DESCRIPTION
The work is in Broiler.JS — **Broiler-Platform/Broiler.JS#999**, whose commit this bumps the submodule pointer to — and this PR carries the pointer plus the roadmap that records the result.

Track 1 of `docs/broiler-js-gaps-roadmap.md` asks for one minimal reproduction per bullet before any fixing. Doing that first turned out to matter: of its ten core-language bullets, six reproduce and four do not, and the largest real cluster was not on the list at all.

## Fixed

- A parameter, `var`, `let` or catch parameter named `undefined` now shadows the global property. The compiler folded every identifier of that name to the undefined value, so `(function (undefined) { return undefined; })(5)` answered undefined.
- An empty statement ends a Directive Prologue again. The prologue scan was innocent: a statement that had already ended at its own `;` was consuming a second one, so the empty statement never reached the statement list and `'x'; ; 'use strict';` became two adjacent directives.
- `Reflect.set(base, k, v, receiver)` gives the receiver's new property the all-true descriptor `CreateDataProperty` mandates instead of a copy of the base's attributes.

None of the three is reachable by a test262 file at the pinned ref, so each carries an xUnit regression instead — 25 new tests, 12 of which fail on the pre-fix engine.

## Retired

`new.target` inside a nested direct eval, the Array `slice`/`unshift`/`toReversed`/`reduceRight` cluster, the comment and regular-expression literal edges, and `continue` with block-scoped loop bindings **do not currently reproduce**. The roadmap says so beside each bullet rather than deleting them, because the failure manifest still names one of them from an older run — that path should come out only after a current CI run confirms it.

## Found

About 30 **early errors that never fire**, made visible by track 0's host modes and named-error reporting: `for (const x;;)`, a body `var` shadowing the head's lexical name, a labelled function declaration as a loop body, `export` inside `eval`, and a direct `var` colliding with a global lexical binding. Each test runs to its `$DONOTEVALUATE()`. It is now track 1's largest open item.

## For the reviewer

Merge order: land Broiler.JS#999 first, then this, so the pointer resolves to a commit on that repo's `main`.

The riskiest change is in the parser and runs for every statement in every program; the sweeps that check it (a seeded 600-file sample, 876 cluster paths, 454 `asi`/`if`/`labeled`/`global-code`/`function-code` paths — zero changed verdicts in each) are described in the submodule PR.

Deliberately left out of this branch, as before: the untracked signing keystore in the working tree and a pre-existing local edit to `src/Broiler.Cli/Properties/launchSettings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
