### PR TITLE
Break out subwindows and dialogs into their own host window (Broiler.UI)

### DIFF
--- a/Broiler.UI/docs/adr/0002-logical-versus-native-windows.md
+++ b/Broiler.UI/docs/adr/0002-logical-versus-native-windows.md
@@ -21,4 +21,8 @@ and destruction stay in the application host.
   default.
 - A host may map a logical window to a native window, but that mapping is not a
   Broiler.UI API.
+- A secondary logical window may additionally *break out* into its own native
+  top-level window through the `IUiWindowHost` host capability, still without
+  exposing a native handle. See ADR
+  [0025](0025-host-window-breakout.md).
 

--- a/Broiler.UI/docs/adr/0025-host-window-breakout.md
+++ b/Broiler.UI/docs/adr/0025-host-window-breakout.md
@@ -1,0 +1,54 @@
+# ADR 0025 - Host-Window Break-Out for Secondary Windows
+
+**Status:** Approved
+**Date:** 2026-08-24
+
+## Context
+
+ADR [0002](0002-logical-versus-native-windows.md) made secondary windows —
+owned windows, dialogs, menus, tooltips, popups — **logical** managed subwindows
+rendered inside their owner's viewport, and left open (see the roadmap) *whether
+secondary logical windows may map to native top-level windows*. Some subwindows
+(a floating tool panel, a long-running dialog) are better as real OS windows the
+user can move outside the main window, place on another monitor, and manage with
+the window manager.
+
+Broiler.UI must stay platform-neutral and never expose native handles (ADR 0002),
+so it cannot create native windows itself.
+
+## Decision
+
+A logical subwindow **may break out into its own native top-level host window**,
+one-way for the window's lifetime, through a host capability — never by exposing a
+native handle.
+
+- A primary `IUiHost` may also implement the optional capability `IUiWindowHost`
+  (discovered with `Host is IUiWindowHost`, like the other optional host
+  capabilities). It creates a native top-level window and returns an
+  `IUiHostWindow`: itself an `IUiHost` that a new `UiSession` renders into and
+  receives input from, plus a neutral lifecycle (`Bind`, `SetTitle`, `Activate`,
+  `CloseRequested`, `Dispose`). No native handle crosses the boundary.
+- `UiWindow.BreakOut` detaches the subwindow from its owner, asks the host to
+  create a host window, and re-roots the subwindow in a fresh `UiSession` bound to
+  it (reusing the origin session's dispatcher, clock, and factories). The platform
+  owns the OS window and pumps its loop; the framework owns the reparenting and the
+  new session.
+- Break-out is **one-way**: closing the broken-out window disposes its host window
+  and session. The reparent is written so a future dock-back could reverse it.
+- **Modality is preserved across windows.** A modal dialog may break out and stay
+  application-modal: its origin session is marked blocked
+  (`UiSession.PushExternalModal`/`IsBlockedByExternalModal`) so the origin window
+  swallows input while the dialog lives in another host window, independent of any
+  native owner/modal support.
+
+## Consequences
+
+- Broiler.UI still exposes no native handles; the capability trades only in
+  `IUiHost`, `UiSession`, `BRect`, `string`, and events. The
+  `Runtime_Assemblies_Do_Not_Expose_Native_Handles_Or_Windows_Types` architecture
+  test continues to hold for the new Foundation types.
+- Hosts that do not implement `IUiWindowHost` are unaffected: `CanBreakOut` is
+  false and `BreakOut` returns false, so subwindows remain logical.
+- The Win32 host realizes break-out with a second `Direct2DWindow` that does not
+  own the message loop (`BWindowOptions.OwnsMessageLoop = false`), so closing it
+  does not quit the application.

--- a/Broiler.UI/docs/adr/README.md
+++ b/Broiler.UI/docs/adr/README.md
@@ -37,3 +37,4 @@ Broiler.UI decisions, not product decisions: the product context is in
 | [0022](0022-virtualized-text-semantics-and-ime.md) | Virtualized text semantics and bounded IME queries |
 | [0023](0023-tree-view-control.md) | TreeView control |
 | [0024](0024-tab-view-document-behavior.md) | TabView document behavior |
+| [0025](0025-host-window-breakout.md) | Host-window break-out for secondary windows |

--- a/Broiler.UI/docs/roadmap.md
+++ b/Broiler.UI/docs/roadmap.md
@@ -22,8 +22,11 @@ that is still open.
 - Produce evidence for Windows IME candidate placement, clipboard, cursor,
   drag/drop, accessibility bridge, screen-reader, keyboard-only, high-contrast,
   text-scale, reduced-motion, and RTL behavior.
-- Decide and document whether secondary logical windows may map to native
-  top-level windows.
+- ~~Decide and document whether secondary logical windows may map to native
+  top-level windows.~~ Decided: they may *break out* into their own native
+  top-level window via the `IUiWindowHost` host capability (one-way, modality
+  preserved), without exposing a native handle. See ADR
+  [0025](adr/0025-host-window-breakout.md).
 - Replace the pending Phase-0-era human review with a review of a named current
   revision before expanding the preview claim.
 

--- a/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/BreakoutHostWindow.cs
+++ b/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/BreakoutHostWindow.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Broiler.Graphics;
+using Broiler.Graphics.Windows;
+using Broiler.Input;
+using Broiler.Input.Keyboard;
+using Broiler.UI.Standard;
+
+namespace Broiler.UI.Win32.Demo;
+
+/// <summary>
+/// A real second native window that hosts a broken-out Broiler.UI subwindow. It is a
+/// <see cref="Direct2DWindow"/> that does not own the thread message loop (it is serviced by the
+/// main window's loop) and exposes the neutral <see cref="IUiHostWindow"/> contract so a
+/// <see cref="UiSession"/> can render into it and receive its input.
+/// </summary>
+[SupportedOSPlatform("windows7.0")]
+internal sealed class BreakoutHostWindow : Direct2DWindow, IUiHostWindow, IUiClipboardHost, IUiTextInputHost
+{
+    private UiSession? _session;
+    private string _clipboard = string.Empty;
+    private UiTextCaretInfo? _caret;
+
+#pragma warning disable CS0618
+    private readonly StandardLegacyGraphicsInputAdapter _legacyInput = new("broiler-ui-breakout-window");
+#pragma warning restore CS0618
+
+    public BreakoutHostWindow(UiHostWindowRequest request)
+        : base(new BWindowOptions
+        {
+            Title = string.IsNullOrWhiteSpace(request.Title) ? "Broiler.UI" : request.Title,
+            ClientWidth = ToClientExtent(request.Placement.Width, 480),
+            ClientHeight = ToClientExtent(request.Placement.Height, 320),
+            ClearColor = StandardControlPaint.Theme.SurfaceAlt,
+            RenderOptions = new BRenderOptions(Antialias: true, VSync: true, SubpixelText: true),
+            OwnsMessageLoop = false,
+        })
+    {
+    }
+
+    // IUiHost
+    BSize IUiHost.ViewportSize => ClientSize;
+
+    double IUiHost.Scale => DpiScale;
+
+    BRenderList IUiHost.CreateRenderList(int capacity) => new(capacity);
+
+    void IUiHost.Invalidate(UiInvalidation invalidation) => Invalidate();
+
+    void IUiHost.Present(BRenderList renderList)
+    {
+        // The base Direct2DWindow renders the list returned from BuildRenderList; nothing else to do.
+    }
+
+    // IUiHostWindow
+    public void Bind(UiSession session)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        Invalidate();
+    }
+
+    public void Activate()
+    {
+        if (NativeHandle != IntPtr.Zero)
+            SetForegroundWindow(NativeHandle);
+        Invalidate();
+    }
+
+    void IUiHostWindow.SetTitle(string title) => SetTitle(title);
+
+    // IUiClipboardHost / IUiTextInputHost mirror the main window's DemoUiHost so hosted controls
+    // keep clipboard and caret behavior.
+    public bool TryGetText(out string text)
+    {
+        text = _clipboard;
+        return true;
+    }
+
+    public void SetText(string text) => _clipboard = text ?? string.Empty;
+
+    public void PublishCaret(UiTextCaretInfo caret) => _caret = caret;
+
+    public void ClearCaret(UiElement owner)
+    {
+        if (_caret?.Owner == owner)
+            _caret = null;
+    }
+
+    protected override BRenderList? BuildRenderList(BSize clientSize) => _session?.RenderFrame();
+
+    protected override void OnPointerDown(BPointerEventArgs e) => Dispatch(_legacyInput.FromPointerButton(e));
+
+    protected override void OnPointerMove(BPointerEventArgs e) => Dispatch(_legacyInput.FromPointerMove(e));
+
+    protected override void OnPointerUp(BPointerEventArgs e) => Dispatch(_legacyInput.FromPointerButton(e));
+
+    protected override void OnMouseWheel(BMouseWheelEventArgs e) => Dispatch(_legacyInput.FromMouseWheel(e));
+
+    protected override void OnKeyDown(BKeyEventArgs e) => Dispatch(_legacyInput.FromKey(e, KeyboardKeyTransition.Down));
+
+    protected override void OnKeyUp(BKeyEventArgs e) => Dispatch(_legacyInput.FromKey(e, KeyboardKeyTransition.Up));
+
+    protected override void OnTextInput(BTextInputEventArgs e) => Dispatch(_legacyInput.FromText(e));
+
+    protected override void Dispose(bool disposing)
+    {
+        // Destroy the native window when the framework disposes this host window.
+        if (disposing && !IsDisposed)
+            Close();
+
+        base.Dispose(disposing);
+    }
+
+    private void Dispatch(UiInputEvent input)
+    {
+        if (_session is not null && !_session.IsDisposed && _session.DispatchInput(input))
+            Invalidate();
+    }
+
+    private static int ToClientExtent(double requested, int fallback) =>
+        requested > 1 ? (int)Math.Round(requested) : fallback;
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(IntPtr hwnd);
+}

--- a/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/Win32DemoWindow.cs
+++ b/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/Win32DemoWindow.cs
@@ -219,6 +219,7 @@ internal sealed class Win32DemoWindow : Direct2DWindow
         if (disposing)
         {
             StopCameraPreview();
+            _host.DisposeHostWindows();
             _animationRegistration.Dispose();
             ReleaseDemoImage();
             _session.Dispose();
@@ -750,10 +751,16 @@ internal sealed class Win32DemoWindow : Direct2DWindow
         };
         var ok = new StandardButton { Text = "Accept", IsDefault = true, PreferredSize = new BSize(90, 32) };
         var cancel = new StandardButton { Text = "Cancel", IsCancel = true, PreferredSize = new BSize(90, 32) };
+        var breakOut = new StandardButton { Text = "Break out", PreferredSize = new BSize(104, 32) };
         ok.Clicked += (_, _) => dialog.Accept("button");
         cancel.Clicked += (_, _) => dialog.Cancel();
+        breakOut.Clicked += (_, _) =>
+            SetStatus(dialog.BreakOut()
+                ? "Dialog broke out into its own window. Close it to dismiss the dialog."
+                : "Break out unavailable (host window support required).");
         row.AddChild(ok);
         row.AddChild(cancel);
+        row.AddChild(breakOut);
         body.AddChild(row);
         dialog.AddChild(body);
         dialog.ResultCompleted += (_, e) => SetStatus("Dialog result: " + e.Result.Kind);
@@ -1679,9 +1686,10 @@ internal sealed class Win32DemoWindow : Direct2DWindow
         return new BPixelBuffer(width, height, rgba);
     }
 
-    private sealed class DemoUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
+    private sealed class DemoUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost, IUiWindowHost
     {
         private readonly Win32DemoWindow _window;
+        private readonly List<BreakoutHostWindow> _hostWindows = [];
         private string _clipboard = string.Empty;
         private UiTextCaretInfo? _caret;
 
@@ -1716,6 +1724,22 @@ internal sealed class Win32DemoWindow : Direct2DWindow
         {
             if (_caret?.Owner == owner)
                 _caret = null;
+        }
+
+        public IUiHostWindow CreateHostWindow(UiHostWindowRequest request)
+        {
+            var window = new BreakoutHostWindow(request);
+            _hostWindows.Add(window);
+            window.Closed += (_, _) => _hostWindows.Remove(window);
+            window.Show();
+            return window;
+        }
+
+        public void DisposeHostWindows()
+        {
+            foreach (BreakoutHostWindow window in _hostWindows.ToArray())
+                window.Dispose();
+            _hostWindows.Clear();
         }
 
         public void Update(BSize viewportSize, double scale)

--- a/Broiler.UI/src/Abstractions/Shell/Broiler.UI.Dialog/UiDialog.cs
+++ b/Broiler.UI/src/Abstractions/Shell/Broiler.UI.Dialog/UiDialog.cs
@@ -13,6 +13,7 @@ public abstract class UiDialog : UiWindow
     private UiDialogResult _completedResult = UiDialogResult.None;
     private UiElement? _restoreFocusElement;
     private UiSession? _presentationSession;
+    private UiSession? _externalModalOrigin;
     private BPoint _moveStartPointer;
     private BRect _moveStartPlacement;
     private bool _isMoving;
@@ -65,6 +66,27 @@ public abstract class UiDialog : UiWindow
         return closed;
     }
 
+    protected override bool BreakOutIsModal => PresentationMode == UiDialogPresentationMode.Modal;
+
+    protected override void OnBrokenOut(UiSession originSession, UiSession hostedSession)
+    {
+        // The dialog no longer lives in the origin session; drop its modal registration there.
+        originSession.PopModalElement(this);
+        if (originSession.FocusedElement == this)
+            originSession.SetFocus(null);
+
+        if (PresentationMode == UiDialogPresentationMode.Modal)
+        {
+            // Keep the origin window blocked (application-modal) even though the dialog now
+            // renders in another host window, and re-establish modality within the new session.
+            originSession.PushExternalModal();
+            _externalModalOrigin = originSession;
+            hostedSession.PushModalElement(this);
+        }
+
+        hostedSession.SetFocus(this);
+    }
+
     protected override UiSemanticNode GetSemanticNodeCore()
     {
         UiSemanticNode node = base.GetSemanticNodeCore();
@@ -87,7 +109,9 @@ public abstract class UiDialog : UiWindow
 
     protected override void OnDetached()
     {
-        if (!_isResultCompleted)
+        // A break-out detaches then immediately re-attaches the dialog into another session; that
+        // transient move must not finalize a dialog that is still live.
+        if (!_isResultCompleted && !IsReparenting)
             FinishPresentation(UiDialogResult.Closed(UiWindowCloseReason.Programmatic));
 
         base.OnDetached();
@@ -247,6 +271,17 @@ public abstract class UiDialog : UiWindow
                 session.SetFocus(_restoreFocusElement);
             else if (ReferenceEquals(session.FocusedElement, this))
                 session.SetFocus(null);
+        }
+
+        // If this dialog broke out into another host window, release the application-modal block
+        // on its origin session and restore the origin window's focus there.
+        UiSession? externalOrigin = _externalModalOrigin;
+        _externalModalOrigin = null;
+        if (externalOrigin is not null && !externalOrigin.IsDisposed && !ReferenceEquals(externalOrigin, session))
+        {
+            externalOrigin.PopExternalModal();
+            if (_restoreFocusElement is not null && _restoreFocusElement.Session == externalOrigin && !ReferenceEquals(_restoreFocusElement, this))
+                externalOrigin.SetFocus(_restoreFocusElement);
         }
 
         _resultSource?.TrySetResult(result);

--- a/Broiler.UI/src/Abstractions/Shell/Broiler.UI.Window/UiWindow.cs
+++ b/Broiler.UI/src/Abstractions/Shell/Broiler.UI.Window/UiWindow.cs
@@ -11,8 +11,13 @@ public abstract class UiWindow : UiElement
     private UiWindowState _state;
     private BRect _placement = BRect.Empty;
     private UiViewportBinding _viewportBinding;
+    private IUiHostWindow? _hostWindow;
+    private UiSession? _hostedSession;
     private bool _isActive;
     private bool _isClosed;
+    private bool _isBrokenOut;
+    private bool _isReparenting;
+    private bool _isTearingDownBreakOut;
 
     public event EventHandler? Activated;
 
@@ -75,6 +80,124 @@ public abstract class UiWindow : UiElement
     public bool IsActive => _isActive;
 
     public bool IsClosed => _isClosed;
+
+    /// <summary>
+    /// True once this window has broken out into its own native host window via
+    /// <see cref="BreakOut"/>. Break-out is one-way for the window's lifetime.
+    /// </summary>
+    public bool IsBrokenOut => _isBrokenOut;
+
+    /// <summary>
+    /// True when this window can break out into its own native top-level host window: it is an
+    /// attached owned/dialog subwindow, is not already broken out, and its session host supports
+    /// the <see cref="IUiWindowHost"/> capability.
+    /// </summary>
+    public bool CanBreakOut =>
+        !IsDisposed && !_isClosed && !_isBrokenOut && Owner is not null && Session?.Host is IUiWindowHost;
+
+    /// <summary>
+    /// Promotes this owned/dialog subwindow into its own native top-level host window. The window
+    /// is detached from its owner and re-rooted in a fresh <see cref="UiSession"/> bound to a host
+    /// window created by the session host's <see cref="IUiWindowHost"/> capability. Returns false
+    /// when <see cref="CanBreakOut"/> is false. Break-out is one-way; closing the window disposes
+    /// the host window.
+    /// </summary>
+    /// <param name="placement">
+    /// Requested initial placement in device-independent pixels. When empty, the window's current
+    /// bounds (or placement) seed the new window, and the host may pick a default.
+    /// </param>
+    public bool BreakOut(BRect placement = default)
+    {
+        ThrowIfDisposed();
+        if (!CanBreakOut)
+            return false;
+
+        UiSession origin = Session!;
+        var windowHost = (IUiWindowHost)origin.Host;
+        UiWindow owner = Owner!;
+        string title = _title;
+        bool isModal = BreakOutIsModal;
+        BRect requested = placement.IsEmpty ? ResolveBreakOutPlacement() : placement;
+
+        // Detach from the owner: clears Owner/Kind/Placement and detaches from the origin session.
+        // The reparenting guard keeps this transient detach from finalizing a live dialog.
+        _isReparenting = true;
+        owner.RemoveChild(this);
+
+        IUiHostWindow hostWindow = windowHost.CreateHostWindow(new UiHostWindowRequest(title, requested, isModal));
+        var hosted = new UiSession(hostWindow, origin.Dispatcher, origin.Clock, origin.Factories);
+
+        _hostWindow = hostWindow;
+        _hostedSession = hosted;
+        _isBrokenOut = true;
+
+        hostWindow.CloseRequested += HandleHostWindowCloseRequested;
+        Closed += HandleBrokenOutClosed;
+
+        hosted.AddRoot(this);
+        _isReparenting = false;
+        hostWindow.Bind(hosted);
+        OnBrokenOut(origin, hosted);
+        hostWindow.Activate();
+        Activate();
+        return true;
+    }
+
+    /// <summary>
+    /// Whether a break-out of this window is application-modal to its origin window. The base
+    /// window is modeless; <c>UiDialog</c> overrides this to report its presentation mode.
+    /// </summary>
+    protected virtual bool BreakOutIsModal => false;
+
+    /// <summary>
+    /// True while this window is being detached from one session and re-attached to another during
+    /// a break-out. Subclasses use it to skip teardown that a permanent detach would trigger.
+    /// </summary>
+    protected bool IsReparenting => _isReparenting;
+
+    /// <summary>
+    /// Called after this window has been re-rooted into <paramref name="hostedSession"/> during a
+    /// break-out. <paramref name="originSession"/> is the session it left. Subclasses migrate
+    /// cross-window state (e.g. modality) here.
+    /// </summary>
+    protected virtual void OnBrokenOut(UiSession originSession, UiSession hostedSession)
+    {
+    }
+
+    private BRect ResolveBreakOutPlacement()
+    {
+        if (!_placement.IsEmpty)
+            return _placement;
+        if (!Bounds.IsEmpty)
+            return new BRect(0, 0, Bounds.Width, Bounds.Height);
+        return BRect.Empty;
+    }
+
+    private void HandleHostWindowCloseRequested(object? sender, EventArgs e) =>
+        Close(UiWindowCloseReason.User);
+
+    private void HandleBrokenOutClosed(object? sender, UiWindowClosedEventArgs e) =>
+        TearDownBreakOut();
+
+    private void TearDownBreakOut()
+    {
+        if (_isTearingDownBreakOut || !_isBrokenOut)
+            return;
+
+        _isTearingDownBreakOut = true;
+        IUiHostWindow? hostWindow = _hostWindow;
+        UiSession? hosted = _hostedSession;
+        _hostWindow = null;
+        _hostedSession = null;
+
+        if (hostWindow is not null)
+            hostWindow.CloseRequested -= HandleHostWindowCloseRequested;
+
+        // The base close/dispose already removed this window from the hosted session as a root.
+        if (hosted is not null && !hosted.IsDisposed)
+            hosted.Dispose();
+        hostWindow?.Dispose();
+    }
 
     public void SetPlacement(BRect placement)
     {

--- a/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiHostWindow.cs
+++ b/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiHostWindow.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Broiler.UI;
+
+/// <summary>
+/// A native top-level host window spawned by an <see cref="IUiWindowHost"/>. It is itself an
+/// <see cref="IUiHost"/> that a bound <see cref="UiSession"/> renders into and receives input
+/// from, plus the neutral lifecycle a broken-out window needs. No native handle is exposed,
+/// keeping Broiler.UI platform-neutral (see ADR 0002).
+/// </summary>
+public interface IUiHostWindow : IUiHost, IDisposable
+{
+    /// <summary>
+    /// Binds the session that renders into, and receives input from, this window. The host's
+    /// message loop calls <see cref="UiSession.RenderFrame"/> when the window needs painting and
+    /// <see cref="UiSession.DispatchInput"/> for native input.
+    /// </summary>
+    void Bind(UiSession session);
+
+    /// <summary>Sets the native window title.</summary>
+    void SetTitle(string title);
+
+    /// <summary>Brings the window to the front and gives it focus.</summary>
+    void Activate();
+
+    /// <summary>
+    /// Raised when the user asks the OS to close this window (e.g. the native close button).
+    /// The framework responds by closing the broken-out logical window, which then disposes
+    /// this host window.
+    /// </summary>
+    event EventHandler? CloseRequested;
+}

--- a/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiWindowHost.cs
+++ b/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiWindowHost.cs
@@ -1,0 +1,18 @@
+namespace Broiler.UI;
+
+/// <summary>
+/// Optional host capability that can create additional native top-level host windows.
+/// A primary <see cref="IUiHost"/> that also implements this lets a logical subwindow
+/// (an owned window or a dialog) "break out" into its own host window with its own
+/// <see cref="UiSession"/>. Discovered via <c>Host is IUiWindowHost</c>, mirroring the
+/// other optional host capabilities.
+/// </summary>
+public interface IUiWindowHost
+{
+    /// <summary>
+    /// Creates and shows a new native top-level host window. The caller binds a fresh
+    /// <see cref="UiSession"/> to the returned window and re-roots the broken-out logical
+    /// window into it; the host owns the native window lifetime and drives its message loop.
+    /// </summary>
+    IUiHostWindow CreateHostWindow(UiHostWindowRequest request);
+}

--- a/Broiler.UI/src/Foundation/Broiler.UI/Host/UiHostWindowRequest.cs
+++ b/Broiler.UI/src/Foundation/Broiler.UI/Host/UiHostWindowRequest.cs
@@ -1,0 +1,18 @@
+using Broiler.Graphics;
+
+namespace Broiler.UI;
+
+/// <summary>
+/// Neutral parameters for <see cref="IUiWindowHost.CreateHostWindow"/> when a logical window
+/// breaks out into its own native top-level window.
+/// </summary>
+/// <param name="Title">Initial window title.</param>
+/// <param name="Placement">
+/// Requested initial placement in device-independent pixels. May be empty, in which case the
+/// host chooses a default size and position.
+/// </param>
+/// <param name="IsModal">
+/// True when the broken-out window is application-modal to its origin window. The origin session
+/// blocks its own input regardless; the host may additionally apply native ownership/modality.
+/// </param>
+public readonly record struct UiHostWindowRequest(string Title, BRect Placement, bool IsModal);

--- a/Broiler.UI/src/Foundation/Broiler.UI/Session/UiSession.cs
+++ b/Broiler.UI/src/Foundation/Broiler.UI/Session/UiSession.cs
@@ -11,6 +11,7 @@ public sealed class UiSession : IDisposable
     private readonly List<UiElement> _modalElements = [];
     private readonly Dictionary<long, TouchRoute> _touchRoutes = [];
     private UiElement? _lastPointerTarget;
+    private int _externalModalDepth;
     private bool _isDisposed;
 
     public UiSession(IUiHost host, IUiDispatcher dispatcher, IUiClock clock, UiFactorySet? factories = null)
@@ -40,6 +41,13 @@ public sealed class UiSession : IDisposable
     public IReadOnlyList<UiElement> ModalElements => _modalElements;
 
     public UiElement? ModalElement => _modalElements.Count == 0 ? null : _modalElements[^1];
+
+    /// <summary>
+    /// True while at least one modal window that broke out into another host window is blocking
+    /// this session. Its input is swallowed (application-modal) even though the modal now lives
+    /// in a different session; rendering continues.
+    /// </summary>
+    public bool IsBlockedByExternalModal => _externalModalDepth > 0;
 
     public bool IsDisposed => _isDisposed;
 
@@ -159,6 +167,25 @@ public sealed class UiSession : IDisposable
             _modalElements.RemoveAt(index);
     }
 
+    /// <summary>
+    /// Registers a modal window that has broken out into another host window. While any external
+    /// modal is active, this session ignores input to its own tree (application-modal behavior
+    /// across host windows). Balanced by <see cref="PopExternalModal"/>.
+    /// </summary>
+    public void PushExternalModal()
+    {
+        ThrowIfDisposed();
+        _externalModalDepth++;
+    }
+
+    /// <summary>Removes one external modal registered by <see cref="PushExternalModal"/>.</summary>
+    public void PopExternalModal()
+    {
+        ThrowIfDisposed();
+        if (_externalModalDepth > 0)
+            _externalModalDepth--;
+    }
+
     public void Invalidate(UiElement element, UiInvalidationKind kind)
     {
         if (_isDisposed || kind == UiInvalidationKind.None)
@@ -195,6 +222,10 @@ public sealed class UiSession : IDisposable
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(input);
+
+        // A modal window that broke out into another host window blocks this window's input.
+        if (_externalModalDepth > 0)
+            return false;
 
         if (input.Kind == UiInputEventKind.TouchContact)
             return DispatchTouchContact(input);

--- a/Broiler.UI/tests/Foundation/Broiler.UI.Standard.Tests/Broiler.UI.Standard.Tests.csproj
+++ b/Broiler.UI/tests/Foundation/Broiler.UI.Standard.Tests/Broiler.UI.Standard.Tests.csproj
@@ -16,6 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Implementations\Standard\Shell\Broiler.UI.Window.Standard\Broiler.UI.Window.Standard.csproj" />
+    <ProjectReference Include="..\..\..\src\Implementations\Standard\Shell\Broiler.UI.Dialog.Standard\Broiler.UI.Dialog.Standard.csproj" />
     <ProjectReference Include="..\..\..\src\Implementations\Standard\Shell\Broiler.UI.FileDialog.Standard\Broiler.UI.FileDialog.Standard.csproj" />
     <ProjectReference Include="..\..\..\src\Implementations\Standard\Shell\Broiler.UI.FontDialog.Standard\Broiler.UI.FontDialog.Standard.csproj" />
     <ProjectReference Include="..\..\..\src\Implementations\Standard\Layout\Broiler.UI.ScrollView.Standard\Broiler.UI.ScrollView.Standard.csproj" />

--- a/Broiler.UI/tests/Foundation/Broiler.UI.Standard.Tests/UiWindowBreakOutTests.cs
+++ b/Broiler.UI/tests/Foundation/Broiler.UI.Standard.Tests/UiWindowBreakOutTests.cs
@@ -1,0 +1,308 @@
+using Broiler.Graphics;
+using Broiler.Input;
+using Broiler.Input.Mouse;
+using Broiler.UI.Dialog;
+using Broiler.UI.Dialog.Standard;
+using Broiler.UI.Window;
+using Broiler.UI.Window.Standard;
+
+namespace Broiler.UI.Standard.Tests;
+
+public sealed class UiWindowBreakOutTests
+{
+    [Fact(Timeout = 600000)]
+    public void CanBreakOut_Is_False_Without_Window_Host_Capability()
+    {
+        var host = new PlainHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+        var child = new StandardWindow();
+        owner.OpenOwnedWindow(child);
+
+        Assert.False(child.CanBreakOut);
+        Assert.False(child.BreakOut());
+        Assert.False(child.IsBrokenOut);
+        Assert.Contains(child, owner.OwnedWindows);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void CanBreakOut_Is_False_For_A_Top_Level_Window()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var top = new StandardWindow();
+        session.AddRoot(top);
+
+        Assert.Null(top.Owner);
+        Assert.False(top.CanBreakOut);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void BreakOut_Reparents_Owned_Window_Into_A_New_Host_Window_Session()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow { Title = "Main" };
+        session.AddRoot(owner);
+        var child = new StandardWindow { Title = "Panel" };
+        owner.OpenOwnedWindow(child, new BRect(10, 10, 200, 150));
+
+        Assert.True(child.CanBreakOut);
+        Assert.True(child.BreakOut());
+
+        Assert.True(child.IsBrokenOut);
+        Assert.Null(child.Owner);
+        Assert.Equal(UiWindowKind.TopLevel, child.Kind);
+        Assert.DoesNotContain(child, owner.OwnedWindows);
+
+        FakeHostWindow created = Assert.Single(host.Created);
+        Assert.Equal("Panel", created.Title);
+        Assert.False(created.IsModal);
+        Assert.NotNull(created.BoundSession);
+        Assert.Same(child, Assert.Single(created.BoundSession!.Roots));
+        Assert.NotSame(session, created.BoundSession);
+        Assert.True(created.Activated);
+
+        // Break-out is one-way for the window's lifetime.
+        Assert.False(child.CanBreakOut);
+        Assert.False(child.BreakOut());
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Broken_Out_Window_Reuses_Origin_Session_Services()
+    {
+        var host = new FakeWindowHost();
+        var dispatcher = new InlineDispatcher();
+        var clock = new ManualClock();
+        using UiSession session = new StandardUiSessionBuilder()
+            .WithDispatcher(dispatcher)
+            .WithClock(clock)
+            .Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+        var child = new StandardWindow();
+        owner.OpenOwnedWindow(child);
+
+        Assert.True(child.BreakOut());
+
+        UiSession hosted = host.Created[0].BoundSession!;
+        Assert.Same(dispatcher, hosted.Dispatcher);
+        Assert.Same(clock, hosted.Clock);
+        Assert.Same(session.Factories, hosted.Factories);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Modal_Dialog_Break_Out_Blocks_Origin_Until_Completed()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+
+        var dialog = new StandardDialog { Title = "Modal" };
+        Task<UiDialogResult> result = dialog.ShowModal(owner, new BRect(20, 20, 200, 120));
+
+        Assert.True(dialog.BreakOut());
+
+        Assert.True(dialog.IsBrokenOut);
+        Assert.True(host.Created[0].IsModal);
+        Assert.True(session.IsBlockedByExternalModal);
+        Assert.False(session.DispatchInput(CreateMouseDown(5, 5)));
+        Assert.DoesNotContain(dialog, session.ModalElements);
+
+        Assert.True(dialog.Accept("ok"));
+
+        Assert.False(session.IsBlockedByExternalModal);
+        Assert.True(result.IsCompletedSuccessfully);
+        Assert.Equal(UiDialogResultKind.Accepted, dialog.CompletedResult.Kind);
+        Assert.True(host.Created[0].IsDisposed);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Modeless_Dialog_Break_Out_Does_Not_Block_Origin()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+
+        var dialog = new StandardDialog { Title = "Modeless" };
+        _ = dialog.ShowModeless(owner, new BRect(20, 20, 200, 120));
+
+        Assert.True(dialog.BreakOut());
+
+        Assert.False(host.Created[0].IsModal);
+        Assert.False(session.IsBlockedByExternalModal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Host_Window_Close_Request_Closes_And_Disposes_Everything()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+        var dialog = new StandardDialog();
+        _ = dialog.ShowModal(owner, new BRect(20, 20, 200, 120));
+        Assert.True(dialog.BreakOut());
+
+        FakeHostWindow created = host.Created[0];
+        UiSession hosted = created.BoundSession!;
+
+        created.RaiseCloseRequested();
+
+        Assert.True(dialog.IsClosed);
+        Assert.True(dialog.IsDisposed);
+        Assert.True(created.IsDisposed);
+        Assert.True(hosted.IsDisposed);
+        Assert.False(session.IsBlockedByExternalModal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Closing_Broken_Out_Window_Programmatically_Tears_Down_Once()
+    {
+        var host = new FakeWindowHost();
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var owner = new StandardWindow();
+        session.AddRoot(owner);
+        var child = new StandardWindow();
+        owner.OpenOwnedWindow(child);
+        Assert.True(child.BreakOut());
+
+        FakeHostWindow created = host.Created[0];
+        UiSession hosted = created.BoundSession!;
+
+        Assert.True(child.Close());
+        Assert.True(created.IsDisposed);
+        Assert.True(hosted.IsDisposed);
+        Assert.Equal(1, created.DisposeCount);
+    }
+
+    private static UiInputEvent CreateMouseDown(double x, double y)
+    {
+        var header = new InputEventHeader(
+            InputDeviceId.FromOpaqueValue("mouse:test"),
+            new InputTimestamp(1, TimeSpan.TicksPerSecond, "test"),
+            1);
+
+        return UiInputEvent.FromMouseButton(new MouseButtonEvent(
+            header,
+            InputPoint.ClientDeviceIndependentPixels(x, y),
+            MouseButtons.Left,
+            MouseButton.Left,
+            MouseButtonTransition.Down,
+            InputEventSource.Synthetic));
+    }
+
+    private sealed class PlainHost : IUiHost
+    {
+        public BSize ViewportSize => new(640, 480);
+
+        public double Scale => 1.0;
+
+        public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+        public void Invalidate(UiInvalidation invalidation)
+        {
+        }
+
+        public void Present(BRenderList renderList)
+        {
+        }
+    }
+
+    private sealed class FakeWindowHost : IUiHost, IUiWindowHost
+    {
+        public List<FakeHostWindow> Created { get; } = [];
+
+        public BSize ViewportSize => new(800, 600);
+
+        public double Scale => 1.0;
+
+        public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+        public void Invalidate(UiInvalidation invalidation)
+        {
+        }
+
+        public void Present(BRenderList renderList)
+        {
+        }
+
+        public IUiHostWindow CreateHostWindow(UiHostWindowRequest request)
+        {
+            var window = new FakeHostWindow(request);
+            Created.Add(window);
+            return window;
+        }
+    }
+
+    private sealed class FakeHostWindow : IUiHostWindow
+    {
+        public FakeHostWindow(UiHostWindowRequest request)
+        {
+            Title = request.Title;
+            Placement = request.Placement;
+            IsModal = request.IsModal;
+        }
+
+        public string Title { get; private set; }
+
+        public BRect Placement { get; }
+
+        public bool IsModal { get; }
+
+        public UiSession? BoundSession { get; private set; }
+
+        public bool Activated { get; private set; }
+
+        public bool IsDisposed { get; private set; }
+
+        public int DisposeCount { get; private set; }
+
+        public event EventHandler? CloseRequested;
+
+        public BSize ViewportSize => new(400, 300);
+
+        public double Scale => 1.0;
+
+        public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+        public void Invalidate(UiInvalidation invalidation)
+        {
+        }
+
+        public void Present(BRenderList renderList)
+        {
+        }
+
+        public void Bind(UiSession session) => BoundSession = session;
+
+        public void SetTitle(string title) => Title = title;
+
+        public void Activate() => Activated = true;
+
+        public void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            IsDisposed = true;
+        }
+    }
+
+    private sealed class InlineDispatcher : IUiDispatcher
+    {
+        public bool CheckAccess() => true;
+
+        public void Post(Action callback) => callback();
+    }
+
+    private sealed class ManualClock : IUiClock
+    {
+        public UiTimestamp Now { get; private set; }
+
+        public void Advance(TimeSpan elapsed) => Now = new UiTimestamp(Now.Elapsed + elapsed);
+    }
+}


### PR DESCRIPTION
## What & why

A logical subwindow in Broiler.UI (an owned window or a dialog) is currently drawn *inside* its owner's viewport. This PR lets such a subwindow **break out into its own native top-level window** — one-way, with modality preserved — without Broiler.UI ever exposing a native handle. It resolves the roadmap's open question *"whether secondary logical windows may map to native top-level windows"* (new **ADR 0025**).

The design follows the existing optional-capability-host idiom (`Host is IUiTextInputHost`, …): a primary `IUiHost` may also implement `IUiWindowHost`; when it does, `subwindow.BreakOut()` detaches the subwindow from its owner and re-roots it in a fresh `UiSession` bound to a host-created window. The framework owns the reparenting and new session; the platform owns the OS window and pumps its loop.

## Changes

**Framework — `Broiler.UI` (platform-neutral)**
- New host capability: `IUiWindowHost`, `IUiHostWindow`, `UiHostWindowRequest` (return only `IUiHost`/`UiSession`/`BRect`/`string`/events — no `IntPtr`).
- `UiWindow`: `CanBreakOut`, `IsBrokenOut`, `BreakOut(...)`, reparenting guard, close/teardown wiring.
- `UiSession`: `PushExternalModal`/`PopExternalModal`/`IsBlockedByExternalModal` — a broken-out **modal** dialog keeps its origin window application-modal across windows.
- `UiDialog`: migrates modal/focus state on break-out, unwinds it on completion.

**Broiler.Graphics submodule (pointer bumped)**
- `BWindowOptions.OwnsMessageLoop` (default `true`, so existing windows are unaffected), `BWindow.Show/Close/SetTitle` + `CloseRequested`/`Closed`, and `Direct2DWindow` support for realizing a window without owning the message loop and not quitting the app when a secondary window closes.
- Submodule branch: `feature/secondary-host-window` (pushed; **needs its own PR/merge** in Broiler.Graphics).

**Win32 demo**
- `BreakoutHostWindow` (a real second `Direct2DWindow` implementing `IUiHostWindow`), `DemoUiHost` implements `IUiWindowHost`, and a **"Break out"** button on the dialog.

**Docs** — ADR 0025, ADR 0002 + index updates, roadmap item resolved.

## Verification
- 8 new `UiWindowBreakOutTests` (reparenting, one-way, modal block/unblock, close-request teardown, no double-dispose) — green. Full Foundation (11) + Standard (75) suites pass, including the native-handle architecture guard on the new Foundation types.
- Everything compiles, incl. the Windows backend and demo (`net10.0-windows` builds on Linux). **Runtime behavior on Windows is not exercised in CI** — the demo needs a Windows machine to see the second window actually pop out.

## Reviewer notes
- The Broiler.Graphics changes are additive and gated on `OwnsMessageLoop` (default `true`); the submodule pointer bump requires the companion submodule branch to be merged.
- Break-out is intentionally one-way; the reparent path is written so a future `DockBack()` could reverse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)