### PR TITLE
Add Documents CI, the PDF construct inventory, and the Phase 1 document contracts

### DIFF
--- a/.github/workflows/documents-pdf.yml
+++ b/.github/workflows/documents-pdf.yml
@@ -27,13 +27,21 @@ name: Documents And PDF
 #     application at all — Broiler.Documents.Tests/PdfDeliveryGuardTests.cs
 #     fails the build if that changes — so a host job today would gate nothing.
 #
-# The no-op guard below matters more than it looks. Three of the suites this
-# workflow runs (Graphics, Media.Image, Media.Image.Managed) are console runners
-# rather than xunit projects: `dotnet test` against them exits 0 having run
-# nothing at all. They are invoked with `dotnet run` so their exit code is the
-# failure count. The Documents solution is xunit and is checked for a plausible
-# executed-test count, because the roadmap is explicit that a skipped, empty, or
-# no-op job can never satisfy a later phase gate.
+# Scope: the Documents solution and its dependency closure, which today is
+# Broiler.Graphics and nothing else — Broiler.Documents.Model references it for
+# value types such as BColor. Broiler.Media is deliberately *not* gated here.
+# Nothing in the solution references it, so a Media failure would say nothing
+# about Documents, and its Windows leg turns on whether the runner image happens
+# to carry the Store-shipped WIC WebP codec, which is not a property of this
+# repository. Images reach the PDF codec at a later roadmap phase; the Media
+# paths and suites belong in this workflow then, not before.
+#
+# The no-op guard below matters more than it looks. The Graphics suite this
+# workflow runs is a console runner rather than an xunit project: `dotnet test`
+# against it exits 0 having run nothing at all. It is invoked with `dotnet run`
+# so its exit code is the failure count. The Documents solution is xunit and is
+# checked for a plausible executed-test count, because the roadmap is explicit
+# that a skipped, empty, or no-op job can never satisfy a later phase gate.
 
 on:
   # The two path lists are identical and must stay that way. They are written
@@ -42,7 +50,6 @@ on:
     paths:
       - 'Broiler.Documents/**'
       - 'Broiler.Graphics/**'
-      - 'Broiler.Media/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - '.github/workflows/documents-pdf.yml'
@@ -52,7 +59,6 @@ on:
     paths:
       - 'Broiler.Documents/**'
       - 'Broiler.Graphics/**'
-      - 'Broiler.Media/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - '.github/workflows/documents-pdf.yml'
@@ -144,16 +150,11 @@ jobs:
               throw "Only $executed tests executed, below the floor of $env:MINIMUM_EXECUTED_TESTS. A run this small means a project was skipped, not that the suite shrank."
           }
 
-      # The three suites below are console runners, not xunit projects. Their
-      # Main returns the failure count, so a non-zero exit fails the step.
+      # A console runner, not an xunit project: its Main returns the failure
+      # count, so a non-zero exit fails the step. It runs because
+      # Broiler.Documents.Model builds against Broiler.Graphics.
       - name: Run the Graphics test runner
         run: dotnet run --project Broiler.Graphics/Broiler.Graphics.Tests/Broiler.Graphics.Tests.csproj -c Release
-
-      - name: Run the Media image test runner
-        run: dotnet run --project Broiler.Media/Broiler.Media.Image.Tests/Broiler.Media.Image.Tests.csproj -c Release
-
-      - name: Run the managed image codec test runner
-        run: dotnet run --project Broiler.Media/Broiler.Media.Image.Managed.Tests/Broiler.Media.Image.Managed.Tests.csproj -c Release
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/documents-pdf.yml
+++ b/.github/workflows/documents-pdf.yml
@@ -1,0 +1,165 @@
+name: Documents And PDF
+
+# Required build/test checks for Broiler.Documents, including the PDF codec, on
+# Windows and Linux.
+#
+# This is the first pull-request-triggered workflow in the repository: every
+# other one is workflow_dispatch or tag-push, so until now the Documents
+# solution had no CI at all and its suites were only ever a local result. The
+# PDF support roadmap (Broiler.Documents/docs/pdf-support-roadmap.md §6.6) makes
+# this workflow a Phase 1 deliverable and a prerequisite for the later preview
+# gates.
+#
+# Two things this workflow deliberately does *not* do yet, because each is its
+# own gated piece of work rather than an oversight:
+#
+#   * No independent oracle. The roadmap's structural, extraction, and rendering
+#     oracles (qpdf, PDFium, Poppler, MuPDF, veraPDF) each need a licence review,
+#     a pinned build, and a row in tests/pdf/tools/manifest.json before they may
+#     run here — Poppler is GPL, MuPDF is AGPL with a named compliance path, and
+#     PDFium needs a full dependency SBOM rather than just a top-level licence.
+#     Adding one is a separate change; adding one *casually* is how a CI image
+#     acquires an obligation nobody recorded.
+#
+#   * No host-integration job. CLI, Writer, packaging, trimming, and AOT jobs
+#     activate at the roadmap's Phase 5/7 boundaries, together with the paths
+#     that would trigger them. The PDF package is currently registered in no
+#     application at all — Broiler.Documents.Tests/PdfDeliveryGuardTests.cs
+#     fails the build if that changes — so a host job today would gate nothing.
+#
+# The no-op guard below matters more than it looks. Three of the suites this
+# workflow runs (Graphics, Media.Image, Media.Image.Managed) are console runners
+# rather than xunit projects: `dotnet test` against them exits 0 having run
+# nothing at all. They are invoked with `dotnet run` so their exit code is the
+# failure count. The Documents solution is xunit and is checked for a plausible
+# executed-test count, because the roadmap is explicit that a skipped, empty, or
+# no-op job can never satisfy a later phase gate.
+
+on:
+  # The two path lists are identical and must stay that way. They are written
+  # out twice because the workflow parser does not support YAML anchors.
+  pull_request:
+    paths:
+      - 'Broiler.Documents/**'
+      - 'Broiler.Graphics/**'
+      - 'Broiler.Media/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - '.github/workflows/documents-pdf.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'Broiler.Documents/**'
+      - 'Broiler.Graphics/**'
+      - 'Broiler.Media/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - '.github/workflows/documents-pdf.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documents-pdf-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # A floor, not a target: it exists so a run that silently executes almost
+  # nothing fails instead of reporting success. Raise it deliberately; do not
+  # track it to the exact suite size, or every added test breaks CI.
+  MINIMUM_EXECUTED_TESTS: 400
+
+jobs:
+  documents:
+    name: Documents and PDF (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-24.04
+          - name: Windows
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The recursive default would also fetch Broiler.JS, Broiler.HTML and
+          # Broiler.CSS, none of which this solution references.
+          submodules: false
+
+      - name: Initialize the submodules this solution needs
+        shell: bash
+        run: |
+          # Broiler.Documents.Model references Broiler.Graphics; the HTML codec
+          # references Broiler.DOM. Broiler.Media is in-repo, and neither
+          # submodule has nested submodules of its own.
+          git submodule update --init Broiler.Graphics Broiler.DOM
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore Broiler.Documents/Broiler.Documents.slnx
+
+      - name: Build
+        # Separated from the test step so a compilation failure is a distinct
+        # result from a test failure. TreatWarningsAsErrors is on in the codec
+        # projects, so a new warning fails here.
+        run: dotnet build Broiler.Documents/Broiler.Documents.slnx -c Release --no-restore
+
+      - name: Test the Documents solution
+        run: >
+          dotnet test Broiler.Documents/Broiler.Documents.slnx
+          -c Release --no-build
+          --logger trx
+          --results-directory "${{ github.workspace }}/artifacts/test-results"
+
+      - name: Assert the test run was not silently empty
+        shell: pwsh
+        run: |
+          $resultsDirectory = Join-Path '${{ github.workspace }}' 'artifacts/test-results'
+          $results = Get-ChildItem -Path $resultsDirectory -Filter *.trx -Recurse -ErrorAction SilentlyContinue
+
+          if (-not $results) {
+              throw "No .trx result files were produced; the test step ran nothing."
+          }
+
+          $executed = 0
+          foreach ($result in $results) {
+              $counters = ([xml](Get-Content -Raw -LiteralPath $result.FullName)).TestRun.ResultSummary.Counters
+              if ($null -ne $counters) {
+                  $executed += [int]$counters.executed
+              }
+          }
+
+          Write-Host "$executed tests executed across $($results.Count) result files."
+
+          if ($executed -lt [int]$env:MINIMUM_EXECUTED_TESTS) {
+              throw "Only $executed tests executed, below the floor of $env:MINIMUM_EXECUTED_TESTS. A run this small means a project was skipped, not that the suite shrank."
+          }
+
+      # The three suites below are console runners, not xunit projects. Their
+      # Main returns the failure count, so a non-zero exit fails the step.
+      - name: Run the Graphics test runner
+        run: dotnet run --project Broiler.Graphics/Broiler.Graphics.Tests/Broiler.Graphics.Tests.csproj -c Release
+
+      - name: Run the Media image test runner
+        run: dotnet run --project Broiler.Media/Broiler.Media.Image.Tests/Broiler.Media.Image.Tests.csproj -c Release
+
+      - name: Run the managed image codec test runner
+        run: dotnet run --project Broiler.Media/Broiler.Media.Image.Managed.Tests/Broiler.Media.Image.Managed.Tests.csproj -c Release
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: documents-test-results-${{ matrix.name }}
+          path: artifacts/test-results
+          if-no-files-found: warn
+          retention-days: 14

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxDocumentCodec.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxDocumentCodec.cs
@@ -87,7 +87,8 @@ public sealed class DocxDocumentCodec : DocumentCodec
                     DocumentDiagnostic.Error(
                         "docx.limit.bytes",
                         "DOCX input exceeded MaxDocumentBytes and was not parsed."),
-                });
+                },
+                DocumentResultStatus.Rejected);
         }
 
         return DocxReader.Read(input.Bytes, effective);

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
@@ -30,12 +30,12 @@ internal static class DocxReader
                 diagnostics.Add(DocumentDiagnostic.Error(
                     "docx.package.document",
                     "DOCX package did not contain a main word/document.xml part."));
-                return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
+                return new DocumentReadResult(RichTextDocument.Empty, diagnostics, DocumentResultStatus.Rejected);
             }
 
             XDocument? documentXml = DocxPackage.LoadEntryXml(documentEntry, options.Limits, diagnostics, "docx.document.xml");
             if (documentXml is null)
-                return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
+                return new DocumentReadResult(RichTextDocument.Empty, diagnostics, DocumentResultStatus.Rejected);
 
             string baseDirectory = DocxPackage.BasePartDirectory(documentPart);
             DocxRelationships documentRelationships = DocxPackage.ReadRelationships(
@@ -67,21 +67,21 @@ internal static class DocxReader
                 options.Limits,
                 diagnostics);
             ReportUnreadParts(documentRelationships, diagnostics);
-            return new DocumentReadResult(document, diagnostics);
+            return new DocumentReadResult(document, diagnostics, DocumentReadResult.StatusFrom(diagnostics));
         }
         catch (InvalidDataException ex)
         {
             diagnostics.Add(DocumentDiagnostic.Error(
                 "docx.package.zip",
                 "DOCX ZIP package could not be opened: " + ex.GetType().Name + "."));
-            return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
+            return new DocumentReadResult(RichTextDocument.Empty, diagnostics, DocumentResultStatus.Rejected);
         }
         catch (XmlException ex)
         {
             diagnostics.Add(DocumentDiagnostic.Error(
                 "docx.xml",
                 "DOCX XML could not be parsed: " + ex.GetType().Name + "."));
-            return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
+            return new DocumentReadResult(RichTextDocument.Empty, diagnostics, DocumentResultStatus.Rejected);
         }
     }
 

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
@@ -49,7 +49,7 @@ public static class DocxWriter
 
         byte[] bytes = package.ToArray();
         destination.Write(bytes, 0, bytes.Length);
-        return new DocumentWriteResult(bytes.Length, context.Diagnostics);
+        return new DocumentWriteResult(bytes.Length, context.Diagnostics, DocumentWriteResult.StatusFrom(context.Diagnostics));
     }
 
     public static byte[] WriteToArray(RichTextDocument document, DocumentWriteOptions? options = null)

--- a/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
@@ -56,7 +56,7 @@ internal static class HtmlReader
             diagnostics.Add(DocumentDiagnostic.Error(
                 "html.parse",
                 $"HTML parser recovered by returning an empty document: {ex.GetType().Name}."));
-            return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
+            return new DocumentReadResult(RichTextDocument.Empty, diagnostics, DocumentResultStatus.Rejected);
         }
 
         foreach (HtmlParseDiagnostic diagnostic in parse.Diagnostics)
@@ -67,7 +67,7 @@ internal static class HtmlReader
             ? parse.Document.Body
             : parse.Document.DocumentElement is not null ? parse.Document.DocumentElement : parse.Document;
         ReadChildren(root, builder, InlineStyle.Default, ParagraphStyle.Default, preserveWhitespace: false);
-        return new DocumentReadResult(builder.Build(), diagnostics);
+        return new DocumentReadResult(builder.Build(), diagnostics, DocumentReadResult.StatusFrom(diagnostics));
     }
 
     private static void ReadChildren(

--- a/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
@@ -29,7 +29,7 @@ public static class HtmlWriter
 
         byte[] bytes = Encoding.UTF8.GetBytes(html);
         destination.Write(bytes, 0, bytes.Length);
-        return new DocumentWriteResult(bytes.Length, diagnostics);
+        return new DocumentWriteResult(bytes.Length, diagnostics, DocumentWriteResult.StatusFrom(diagnostics));
     }
 
     public static byte[] WriteToArray(RichTextDocument document, DocumentWriteOptions? options = null)

--- a/Broiler.Documents/Broiler.Documents.Markdown/MarkdownReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Markdown/MarkdownReader.cs
@@ -114,7 +114,7 @@ internal static class MarkdownReader
         }
 
         FlushParagraph(builder, paragraph, paragraphStyle);
-        return new DocumentReadResult(builder.Build(), diagnostics);
+        return new DocumentReadResult(builder.Build(), diagnostics, DocumentReadResult.StatusFrom(diagnostics));
     }
 
     private static void FlushParagraph(

--- a/Broiler.Documents/Broiler.Documents.Markdown/MarkdownWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Markdown/MarkdownWriter.cs
@@ -31,7 +31,7 @@ public static class MarkdownWriter
         builder.Append('\n');
         byte[] bytes = Encoding.UTF8.GetBytes(builder.ToString());
         destination.Write(bytes, 0, bytes.Length);
-        return new DocumentWriteResult(bytes.Length, diagnostics);
+        return new DocumentWriteResult(bytes.Length, diagnostics, DocumentWriteResult.StatusFrom(diagnostics));
     }
 
     public static byte[] WriteToArray(RichTextDocument document, DocumentWriteOptions? options = null)

--- a/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfCodecTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfCodecTests.cs
@@ -82,11 +82,11 @@ public sealed class PdfRoundTripTests
         var codec = new PdfDocumentCodec();
         using var buffer = new MemoryStream();
         PdfWriteResult write = codec.WritePdf(document, buffer, options);
-        Assert.NotEqual(PdfResultStatus.Rejected, write.Status);
+        Assert.NotEqual(DocumentResultStatus.Rejected, write.Status);
 
         buffer.Position = 0;
         PdfReadResult read = codec.ReadPdf(buffer);
-        Assert.NotEqual(PdfResultStatus.Rejected, read.Status);
+        Assert.NotEqual(DocumentResultStatus.Rejected, read.Status);
         return read.Document;
     }
 

--- a/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfSecurityTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfSecurityTests.cs
@@ -126,7 +126,7 @@ public sealed class PdfSecurityTests
         var options = new PdfReadOptions(pdfLimits: new PdfLimits(maxPageCount: 5));
         PdfReadResult result = Read(builder.Build(catalog), options);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.Limit);
     }
 
@@ -138,7 +138,7 @@ public sealed class PdfSecurityTests
 
         PdfReadResult result = Read(PdfFileBuilder.SinglePage(content), options);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.Limit);
     }
 
@@ -148,8 +148,8 @@ public sealed class PdfSecurityTests
         var options = new PdfReadOptions(pdfLimits: new PdfLimits(maxExtractedCharacters: 4));
         PdfReadResult result = Read(PdfFileBuilder.SinglePage(PdfFileBuilder.ShowText("Much longer than four")), options);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
-        Assert.NotEqual(PdfResultStatus.Success, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.NotEqual(DocumentResultStatus.Success, result.Status);
     }
 
     [Fact]
@@ -158,10 +158,11 @@ public sealed class PdfSecurityTests
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
 
-        var options = new PdfReadOptions(cancellationToken: cancellation.Token);
-        PdfReadResult result = Read(PdfFileBuilder.SinglePage(PdfFileBuilder.ShowText("Cancelled")), options);
+        using var input = DocumentInput.FromBytes(PdfFileBuilder.SinglePage(PdfFileBuilder.ShowText("Cancelled")));
+        var request = new DocumentReadRequest(input, PdfReadOptions.Default, cancellation.Token);
+        DocumentReadResult result = new PdfDocumentCodec().Read(request);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.Cancelled);
     }
 

--- a/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfStructureTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfStructureTests.cs
@@ -16,7 +16,7 @@ public sealed class PdfStructureTests
     {
         PdfReadResult result = Read(PdfFileBuilder.SinglePage(PdfFileBuilder.ShowText("Hello")));
 
-        Assert.NotEqual(PdfResultStatus.Rejected, result.Status);
+        Assert.NotEqual(DocumentResultStatus.Rejected, result.Status);
         Assert.Equal(1, result.PageCount);
         Assert.Contains("Hello", result.Document.PlainText);
     }
@@ -54,7 +54,7 @@ public sealed class PdfStructureTests
 
         PdfReadResult result = Read(builder.Build(catalog, $"/Encrypt {encrypt} 0 R"));
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.EncryptionUnsupported);
         Assert.Equal(0, result.PageCount);
 
@@ -69,7 +69,7 @@ public sealed class PdfStructureTests
         byte[] pdf = BuildStreamedFile();
         PdfReadResult result = Read(pdf);
 
-        Assert.NotEqual(PdfResultStatus.Rejected, result.Status);
+        Assert.NotEqual(DocumentResultStatus.Rejected, result.Status);
         Assert.Equal(1, result.PageCount);
         Assert.Contains("Streamed", result.Document.PlainText);
         Assert.DoesNotContain(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.XrefRecovered);
@@ -94,7 +94,7 @@ public sealed class PdfStructureTests
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.XrefRecovered);
 
         // A recovered document is never reported as a clean parse.
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public sealed class PdfStructureTests
         PdfReadResult result = Read(builder.Build(catalog));
 
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.FilterLzwUnsupported);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
     }
 
     [Fact]
@@ -293,7 +293,7 @@ public sealed class PdfStructureTests
 
         PdfReadResult result = Read(pdf, options);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.Limit);
     }
 
@@ -302,7 +302,7 @@ public sealed class PdfStructureTests
     {
         PdfReadResult result = Read(PdfFileBuilder.Latin1("this is not a PDF at all"));
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.HeaderMissing);
     }
 

--- a/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfTextExtractionTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfTextExtractionTests.cs
@@ -224,7 +224,7 @@ public sealed class PdfTextExtractionTests
         PdfReadResult result = Read(builder.Build(catalog));
 
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.FilterDctUnsupported);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
     }
 
     [Fact]
@@ -309,7 +309,7 @@ public sealed class PdfTextExtractionTests
         PdfReadResult result = Read(PdfFileBuilder.SinglePage("q 1 0 0 1 0 0 cm Q\n"));
 
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.TextOcrRequired);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
     }
 
     [Fact]

--- a/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfWriterTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf.Tests/PdfWriterTests.cs
@@ -25,7 +25,7 @@ public sealed class PdfWriterTests
         (byte[] bytes, PdfWriteResult result) = Write(RichTextDocument.FromPlainText("Hello, PDF."));
         string text = Latin1(bytes);
 
-        Assert.Equal(PdfDestinationState.Committed, result.DestinationState);
+        Assert.Equal(DocumentDestinationState.Committed, result.DestinationState);
         Assert.Equal(1, result.PageCount);
         Assert.StartsWith("%PDF-1.7", text);
         Assert.EndsWith("%%EOF\n", text);
@@ -157,7 +157,7 @@ public sealed class PdfWriterTests
         Assert.DoesNotContain("javascript", text, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("/Subtype /Link", text);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.UriRejected);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
 
         // The text itself is still written; only the activation is withheld.
         Assert.Contains("(Click)", text);
@@ -234,7 +234,7 @@ public sealed class PdfWriterTests
             new PdfWriteOptions(compressStreams: false));
 
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.WriteCharacterUnsupported);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
         Assert.Contains("(Greek: ???)", Latin1(bytes));
     }
 
@@ -260,7 +260,7 @@ public sealed class PdfWriterTests
         PdfWriteResult result = Write(document).Result;
 
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.WriteImageNotComposed);
-        Assert.Equal(PdfResultStatus.Partial, result.Status);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
     }
 
     [Fact]
@@ -290,8 +290,8 @@ public sealed class PdfWriterTests
         var options = new PdfWriteOptions(pdfLimits: new PdfLimits(maxOutputBytes: 64));
         (byte[] bytes, PdfWriteResult result) = Write(RichTextDocument.FromPlainText("Too big for the budget."), options);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
-        Assert.Equal(PdfDestinationState.NotStarted, result.DestinationState);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentDestinationState.NotStarted, result.DestinationState);
         Assert.Empty(bytes);
     }
 
@@ -302,8 +302,8 @@ public sealed class PdfWriterTests
         PdfWriteResult result = new PdfDocumentCodec()
             .WritePdf(RichTextDocument.FromPlainText("Doomed."), failing);
 
-        Assert.Equal(PdfResultStatus.Rejected, result.Status);
-        Assert.Equal(PdfDestinationState.PartialDestination, result.DestinationState);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentDestinationState.PartialDestination, result.DestinationState);
         Assert.Contains(result.Diagnostics, d => d.Code == PdfDiagnosticCodes.WritePartialDestination);
     }
 

--- a/Broiler.Documents/Broiler.Documents.Pdf/PdfDocumentCodec.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/PdfDocumentCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using Broiler.Documents.Model;
 using Broiler.Documents.Pdf.Writing;
 
@@ -109,14 +110,44 @@ public sealed class PdfDocumentCodec : DocumentCodec
     /// Reads a PDF. Malformed-but-recoverable input produces diagnostics rather
     /// than exceptions; input that cannot yield a usable document produces a
     /// result whose <see cref="PdfReadResult.Status"/> is
-    /// <see cref="PdfResultStatus.Rejected"/> and an empty document that no host
+    /// <see cref="DocumentResultStatus.Rejected"/> and an empty document that no host
     /// may present.
     /// </summary>
     public override DocumentReadResult Read(Stream source, DocumentReadOptions? options = null) =>
         ReadPdf(source, AsPdfOptions(options));
 
+    /// <summary>
+    /// Reads through the request contract, taking cancellation from the request —
+    /// its single owner — and probing and reading through the same replayable
+    /// input.
+    /// </summary>
+    public override DocumentReadResult Read(DocumentReadRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateOptions(request.Options, Name, out PdfReadOptions? typed, out DocumentReadResult? rejection))
+            return rejection!;
+
+        PdfReadOptions effective = typed ?? new PdfReadOptions(request.Options.Limits);
+
+        byte[] bytes;
+        try
+        {
+            bytes = request.Input.Materialize(effective.PdfLimits.MaxInputBytes).ToArray();
+        }
+        catch (DocumentException e)
+        {
+            return RejectedRead(effective, DocumentDiagnosticCodes.InputTooLarge, e.Message);
+        }
+
+        return PdfReader.Read(bytes, effective, _services, request.CancellationToken);
+    }
+
     /// <summary>The typed read, returning the PDF-specific result.</summary>
-    public PdfReadResult ReadPdf(Stream source, PdfReadOptions? options = null)
+    public PdfReadResult ReadPdf(
+        Stream source,
+        PdfReadOptions? options = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
         PdfReadOptions effective = options ?? PdfReadOptions.Default;
@@ -132,7 +163,7 @@ public sealed class PdfDocumentCodec : DocumentCodec
             sink.Error(PdfDiagnosticCodes.Limit, e.Message);
             return new PdfReadResult(
                 RichTextDocument.Empty,
-                PdfResultStatus.Rejected,
+                DocumentResultStatus.Rejected,
                 PdfDocumentMetadata.Empty,
                 Structure.PdfVersion.Unknown,
                 0,
@@ -140,7 +171,7 @@ public sealed class PdfDocumentCodec : DocumentCodec
                 sink.Build());
         }
 
-        return PdfReader.Read(bytes, effective, _services);
+        return PdfReader.Read(bytes, effective, _services, cancellationToken);
     }
 
     /// <summary>
@@ -154,12 +185,43 @@ public sealed class PdfDocumentCodec : DocumentCodec
         DocumentWriteOptions? options = null) =>
         WritePdf(document, destination, AsPdfOptions(options));
 
+    /// <summary>Writes through the request contract, taking cancellation from the request.</summary>
+    public override DocumentWriteResult Write(DocumentWriteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateOptions(request.Options, Name, out PdfWriteOptions? typed, out DocumentWriteResult? rejection))
+            return rejection!;
+
+        return PdfWriter.Write(
+            request.Document,
+            request.Destination,
+            typed ?? PdfWriteOptions.Default,
+            _services,
+            request.CancellationToken);
+    }
+
     /// <summary>The typed write, returning the PDF-specific result.</summary>
     public PdfWriteResult WritePdf(
         RichTextDocument document,
         Stream destination,
-        PdfWriteOptions? options = null) =>
-        PdfWriter.Write(document, destination, options ?? PdfWriteOptions.Default, _services);
+        PdfWriteOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        PdfWriter.Write(document, destination, options ?? PdfWriteOptions.Default, _services, cancellationToken);
+
+    private static PdfReadResult RejectedRead(PdfReadOptions options, string code, string message)
+    {
+        var sink = new PdfDiagnosticSink(options.PdfLimits.MaxDiagnostics);
+        sink.Error(code, message);
+        return new PdfReadResult(
+            RichTextDocument.Empty,
+            DocumentResultStatus.Rejected,
+            PdfDocumentMetadata.Empty,
+            Structure.PdfVersion.Unknown,
+            0,
+            Array.Empty<Structure.PdfExtensionDeclaration>(),
+            sink.Build());
+    }
 
     // A codec validates the option object it was handed rather than downcasting
     // opportunistically: a caller that passes plain DocumentReadOptions gets the

--- a/Broiler.Documents/Broiler.Documents.Pdf/PdfOptions.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/PdfOptions.cs
@@ -1,53 +1,20 @@
 using System;
-using System.Threading;
 using Broiler.Documents.Pdf.Text;
 
 namespace Broiler.Documents.Pdf;
 
-/// <summary>
-/// Whether a read or write produced a usable result, independently of whether it
-/// produced diagnostics.
-/// </summary>
-/// <remarks>
-/// Severity and status answer different questions. A document can carry a dozen
-/// warnings and still be a complete rendering of its supported subset
-/// (<see cref="Success"/>); another can carry one warning that means a page was
-/// dropped (<see cref="Partial"/>). Hosts branch on this, never on a diagnostic
-/// count.
-/// </remarks>
-public enum PdfResultStatus
-{
-    /// <summary>The declared supported subset was processed; the result is usable.</summary>
-    Success,
-
-    /// <summary>
-    /// A usable result exists, but named content or features were skipped or
-    /// remain uncertain. A host must have the caller opt in before replacing an
-    /// open document or publishing this output.
-    /// </summary>
-    Partial,
-
-    /// <summary>No usable result exists and none may be accepted.</summary>
-    Rejected,
-}
-
-/// <summary>How far a write got before it stopped.</summary>
-public enum PdfDestinationState
-{
-    /// <summary>Nothing was written; the destination is untouched.</summary>
-    NotStarted,
-
-    /// <summary>The complete output reached the destination.</summary>
-    Committed,
-
-    /// <summary>
-    /// Bytes reached a caller-owned stream and then the write stopped. The prefix
-    /// is not a valid PDF and the caller owns discarding it.
-    /// </summary>
-    PartialDestination,
-}
+// The result-status and destination-state enums that used to live here are now
+// the shared DocumentResultStatus and DocumentDestinationState: they were always
+// format-neutral, and the RTF, DOCX, HTML and Markdown codecs report them too, so
+// they meet the containment rule's second-consumer test (PDF roadmap §3).
 
 /// <summary>Options for reading a PDF.</summary>
+/// <remarks>
+/// Cancellation is deliberately absent: it belongs to
+/// <see cref="DocumentReadRequest"/>, and a second copy here would create a
+/// precedence question the contract refuses to answer. Options carry settings;
+/// the request carries the operation (PDF roadmap §6.1).
+/// </remarks>
 public sealed class PdfReadOptions : DocumentReadOptions
 {
     public static new PdfReadOptions Default { get; } = new();
@@ -57,15 +24,13 @@ public sealed class PdfReadOptions : DocumentReadOptions
         PdfLimits? pdfLimits = null,
         bool mapPageBreaks = false,
         bool includeInvisibleText = true,
-        PdfUriPolicy? uriPolicy = null,
-        CancellationToken cancellationToken = default)
+        PdfUriPolicy? uriPolicy = null)
         : base(limits)
     {
         PdfLimits = pdfLimits ?? PdfLimits.Default;
         MapPageBreaks = mapPageBreaks;
         IncludeInvisibleText = includeInvisibleText;
         UriPolicy = uriPolicy;
-        CancellationToken = cancellationToken;
     }
 
     /// <summary>The PDF-specific budgets, composed with the shared limits.</summary>
@@ -91,9 +56,6 @@ public sealed class PdfReadOptions : DocumentReadOptions
     /// policy from <see cref="PdfCodecServices"/>.
     /// </summary>
     public PdfUriPolicy? UriPolicy { get; }
-
-    /// <summary>Cancellation observed at every documented parsing checkpoint.</summary>
-    public CancellationToken CancellationToken { get; }
 }
 
 /// <summary>Options for writing a PDF.</summary>
@@ -115,8 +77,7 @@ public sealed class PdfWriteOptions : DocumentWriteOptions
         PdfFontFamilyKind defaultFamily = PdfFontFamilyKind.SansSerif,
         float defaultFontSize = 12f,
         string? fileIdentifier = null,
-        PdfUriPolicy? uriPolicy = null,
-        CancellationToken cancellationToken = default)
+        PdfUriPolicy? uriPolicy = null)
     {
         if (defaultFontSize is <= 0 or > 1600 || !float.IsFinite(defaultFontSize))
             throw new ArgumentOutOfRangeException(nameof(defaultFontSize));
@@ -129,7 +90,6 @@ public sealed class PdfWriteOptions : DocumentWriteOptions
         DefaultFontSize = defaultFontSize;
         FileIdentifier = fileIdentifier;
         UriPolicy = uriPolicy;
-        CancellationToken = cancellationToken;
     }
 
     public PdfPageSetup PageSetup { get; }
@@ -160,8 +120,6 @@ public sealed class PdfWriteOptions : DocumentWriteOptions
 
     /// <summary>Overrides the composed URI policy for this write.</summary>
     public PdfUriPolicy? UriPolicy { get; }
-
-    public CancellationToken CancellationToken { get; }
 }
 
 /// <summary>Page geometry for the writer, in points.</summary>

--- a/Broiler.Documents/Broiler.Documents.Pdf/PdfReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/PdfReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Broiler.Documents.Model;
 using Broiler.Documents.Pdf.Filters;
 using Broiler.Documents.Pdf.Structure;
@@ -22,18 +23,22 @@ namespace Broiler.Documents.Pdf;
 /// </remarks>
 internal static class PdfReader
 {
-    public static PdfReadResult Read(byte[] data, PdfReadOptions options, PdfCodecServices services)
+    public static PdfReadResult Read(
+        byte[] data,
+        PdfReadOptions options,
+        PdfCodecServices services,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(data);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(services);
 
         var diagnostics = new PdfDiagnosticSink(options.PdfLimits.MaxDiagnostics);
-        var budget = new PdfWorkBudget(options.PdfLimits, options.CancellationToken);
+        var budget = new PdfWorkBudget(options.PdfLimits, cancellationToken);
 
         try
         {
-            return ReadCore(data, options, services, budget, diagnostics);
+            return ReadCore(data, options, services, budget, diagnostics, cancellationToken);
         }
         catch (PdfLimitExceededException e)
         {
@@ -52,7 +57,8 @@ internal static class PdfReader
         PdfReadOptions options,
         PdfCodecServices services,
         PdfWorkBudget budget,
-        PdfDiagnosticSink diagnostics)
+        PdfDiagnosticSink diagnostics,
+        CancellationToken cancellationToken)
     {
         if (data.LongLength > options.PdfLimits.MaxInputBytes)
         {
@@ -62,7 +68,7 @@ internal static class PdfReader
             return Rejected(diagnostics);
         }
 
-        var pipeline = new PdfFilterPipeline(services.StreamFilters, options.CancellationToken);
+        var pipeline = new PdfFilterPipeline(services.StreamFilters, cancellationToken);
         PdfObjectStore? store = PdfObjectStore.Load(data, budget, diagnostics, pipeline);
         if (store is null)
         {
@@ -150,11 +156,11 @@ internal static class PdfReader
             ? RichTextDocument.Empty
             : RichTextDocument.FromParagraphs(paragraphs);
 
-        PdfResultStatus status = paragraphs.Count == 0
-            ? PdfResultStatus.Partial
+        DocumentResultStatus status = paragraphs.Count == 0
+            ? DocumentResultStatus.Partial
             : diagnostics.HasSkips || diagnostics.HasErrors || store.WasRecovered
-                ? PdfResultStatus.Partial
-                : PdfResultStatus.Success;
+                ? DocumentResultStatus.Partial
+                : DocumentResultStatus.Success;
 
         return new PdfReadResult(
             document,
@@ -237,7 +243,7 @@ internal static class PdfReader
     private static PdfReadResult Rejected(PdfDiagnosticSink diagnostics) =>
         new(
             RichTextDocument.Empty,
-            PdfResultStatus.Rejected,
+            DocumentResultStatus.Rejected,
             PdfDocumentMetadata.Empty,
             PdfVersion.Unknown,
             0,

--- a/Broiler.Documents/Broiler.Documents.Pdf/PdfResults.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/PdfResults.cs
@@ -10,31 +10,30 @@ namespace Broiler.Documents.Pdf;
 /// learned about the file.
 /// </summary>
 /// <remarks>
-/// The status is the load-bearing field. <see cref="PdfResultStatus.Rejected"/>
-/// means the <see cref="DocumentReadResult.Document"/> is a placeholder that no
-/// host may present, and a rejected read never replaces an open document or
-/// produces an output file.
+/// <see cref="DocumentReadResult.Status"/> is the load-bearing field.
+/// <see cref="DocumentResultStatus.Rejected"/> means the document is a
+/// placeholder that no host may present, and a rejected read never replaces an
+/// open document or produces an output file. The status lives on the shared base
+/// so a host that only knows about <see cref="DocumentReadResult"/> still sees
+/// it — a PDF-local copy would shadow it and quietly report success.
 /// </remarks>
 public sealed class PdfReadResult : DocumentReadResult
 {
     public PdfReadResult(
         RichTextDocument document,
-        PdfResultStatus status,
+        DocumentResultStatus status,
         PdfDocumentMetadata metadata,
         PdfVersion declaredVersion,
         int pageCount,
         IReadOnlyList<PdfExtensionDeclaration> extensions,
         IEnumerable<DocumentDiagnostic>? diagnostics = null)
-        : base(document, diagnostics)
+        : base(document, diagnostics, status)
     {
-        Status = status;
         Metadata = metadata ?? PdfDocumentMetadata.Empty;
         DeclaredVersion = declaredVersion;
         PageCount = pageCount;
         Extensions = extensions ?? Array.Empty<PdfExtensionDeclaration>();
     }
-
-    public PdfResultStatus Status { get; }
 
     /// <summary>The normalized metadata allowlist; never raw Info or XMP data.</summary>
     public PdfDocumentMetadata Metadata { get; }
@@ -52,9 +51,6 @@ public sealed class PdfReadResult : DocumentReadResult
     /// diagnostics; no declaration here ever enabled a feature.
     /// </summary>
     public IReadOnlyList<PdfExtensionDeclaration> Extensions { get; }
-
-    /// <summary>True when a host may present the document to a user.</summary>
-    public bool IsUsable => Status != PdfResultStatus.Rejected;
 }
 
 /// <summary>The outcome of writing a PDF.</summary>
@@ -62,26 +58,14 @@ public sealed class PdfWriteResult : DocumentWriteResult
 {
     public PdfWriteResult(
         long bytesWritten,
-        PdfResultStatus status,
-        PdfDestinationState destinationState,
+        DocumentResultStatus status,
+        DocumentDestinationState destinationState,
         int pageCount,
         IEnumerable<DocumentDiagnostic>? diagnostics = null)
-        : base(bytesWritten, diagnostics)
+        : base(bytesWritten, diagnostics, status, destinationState)
     {
-        Status = status;
-        DestinationState = destinationState;
         PageCount = pageCount;
     }
-
-    public PdfResultStatus Status { get; }
-
-    /// <summary>
-    /// How far the destination got. <see cref="PdfResultStatus.Success"/> requires
-    /// <see cref="PdfDestinationState.Committed"/>; a rejection paired with
-    /// <see cref="PdfDestinationState.PartialDestination"/> tells a caller-owned
-    /// stream that an unusable prefix needs discarding.
-    /// </summary>
-    public PdfDestinationState DestinationState { get; }
 
     public int PageCount { get; }
 }

--- a/Broiler.Documents/Broiler.Documents.Pdf/Writing/PdfPageLayout.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/Writing/PdfPageLayout.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using Broiler.Documents.Model;
 using Broiler.Documents.Pdf.Text;
 using Broiler.Graphics;
@@ -88,17 +89,20 @@ internal sealed class PdfPageLayout
     private readonly IPdfFontMetricsProvider _metrics;
     private readonly PdfUriPolicy _uriPolicy;
     private readonly PdfDiagnosticSink _diagnostics;
+    private readonly CancellationToken _cancellationToken;
 
     public PdfPageLayout(
         PdfWriteOptions options,
         IPdfFontMetricsProvider metrics,
         PdfUriPolicy uriPolicy,
-        PdfDiagnosticSink diagnostics)
+        PdfDiagnosticSink diagnostics,
+        CancellationToken cancellationToken)
     {
         _options = options;
         _metrics = metrics;
         _uriPolicy = uriPolicy;
         _diagnostics = diagnostics;
+        _cancellationToken = cancellationToken;
     }
 
     public List<PdfLayoutPage> Build(RichTextDocument document)
@@ -115,7 +119,7 @@ internal sealed class PdfPageLayout
 
         foreach (RichTextParagraph paragraph in document.Paragraphs)
         {
-            _options.CancellationToken.ThrowIfCancellationRequested();
+            _cancellationToken.ThrowIfCancellationRequested();
 
             ParagraphStyle style = paragraph.Style;
             double lineSpacing = style.LineSpacing > 0 ? style.LineSpacing : 1f;
@@ -243,7 +247,7 @@ internal sealed class PdfPageLayout
 
         foreach (Word word in EnumerateWords(paragraph, marker))
         {
-            _options.CancellationToken.ThrowIfCancellationRequested();
+            _cancellationToken.ThrowIfCancellationRequested();
 
             double wordWidth = word.Width;
             bool fits = used + wordWidth <= available || current.Pieces.Count == 0;

--- a/Broiler.Documents/Broiler.Documents.Pdf/Writing/PdfWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/Writing/PdfWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Text;
 using Broiler.Documents.Model;
 using Broiler.Documents.Pdf.Text;
@@ -43,19 +44,26 @@ internal sealed class PdfWriter
     private readonly PdfDiagnosticSink _diagnostics;
     private readonly List<long> _offsets = [];
     private readonly MemoryStream _buffer = new();
+    private readonly CancellationToken _cancellationToken;
 
-    private PdfWriter(PdfWriteOptions options, PdfCodecServices services, PdfDiagnosticSink diagnostics)
+    private PdfWriter(
+        PdfWriteOptions options,
+        PdfCodecServices services,
+        PdfDiagnosticSink diagnostics,
+        CancellationToken cancellationToken)
     {
         _options = options;
         _services = services;
         _diagnostics = diagnostics;
+        _cancellationToken = cancellationToken;
     }
 
     public static PdfWriteResult Write(
         RichTextDocument document,
         Stream destination,
         PdfWriteOptions options,
-        PdfCodecServices services)
+        PdfCodecServices services,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(document);
         ArgumentNullException.ThrowIfNull(destination);
@@ -63,7 +71,7 @@ internal sealed class PdfWriter
         ArgumentNullException.ThrowIfNull(services);
 
         var diagnostics = new PdfDiagnosticSink(options.PdfLimits.MaxDiagnostics);
-        var writer = new PdfWriter(options, services, diagnostics);
+        var writer = new PdfWriter(options, services, diagnostics, cancellationToken);
 
         byte[] bytes;
         int pageCount;
@@ -76,12 +84,12 @@ internal sealed class PdfWriter
         catch (PdfLimitExceededException e)
         {
             diagnostics.Error(PdfDiagnosticCodes.Limit, e.Message);
-            return new PdfWriteResult(0, PdfResultStatus.Rejected, PdfDestinationState.NotStarted, 0, diagnostics.Build());
+            return new PdfWriteResult(0, DocumentResultStatus.Rejected, DocumentDestinationState.NotStarted, 0, diagnostics.Build());
         }
         catch (OperationCanceledException)
         {
             diagnostics.Error(PdfDiagnosticCodes.Cancelled, "The write was cancelled before any byte reached the destination.");
-            return new PdfWriteResult(0, PdfResultStatus.Rejected, PdfDestinationState.NotStarted, 0, diagnostics.Build());
+            return new PdfWriteResult(0, DocumentResultStatus.Rejected, DocumentDestinationState.NotStarted, 0, diagnostics.Build());
         }
 
         long written = 0;
@@ -95,14 +103,14 @@ internal sealed class PdfWriter
             diagnostics.Error(
                 PdfDiagnosticCodes.WritePartialDestination,
                 "The destination stream failed part-way through the write. The bytes already written are not a usable PDF and must be discarded.");
-            return new PdfWriteResult(written, PdfResultStatus.Rejected, PdfDestinationState.PartialDestination, pageCount, diagnostics.Build());
+            return new PdfWriteResult(written, DocumentResultStatus.Rejected, DocumentDestinationState.PartialDestination, pageCount, diagnostics.Build());
         }
 
-        PdfResultStatus status = diagnostics.HasSkips || diagnostics.HasErrors
-            ? PdfResultStatus.Partial
-            : PdfResultStatus.Success;
+        DocumentResultStatus status = diagnostics.HasSkips || diagnostics.HasErrors
+            ? DocumentResultStatus.Partial
+            : DocumentResultStatus.Success;
 
-        return new PdfWriteResult(written, status, PdfDestinationState.Committed, pageCount, diagnostics.Build());
+        return new PdfWriteResult(written, status, DocumentDestinationState.Committed, pageCount, diagnostics.Build());
     }
 
     private (byte[] Bytes, int PageCount) Build(RichTextDocument document)
@@ -117,7 +125,7 @@ internal sealed class PdfWriter
                 "Line breaking used the built-in approximate metric model. Pagination is deterministic and reproducible, but glyph advances in a viewer will differ slightly from the measured ones.");
         }
 
-        var layout = new PdfPageLayout(_options, metrics, policy, _diagnostics);
+        var layout = new PdfPageLayout(_options, metrics, policy, _diagnostics, _cancellationToken);
         List<PdfLayoutPage> pages = layout.Build(document);
 
         if (pages.Count > _options.PdfLimits.MaxPageCount)
@@ -172,7 +180,7 @@ internal sealed class PdfWriter
 
         for (int i = 0; i < pages.Count; i++)
         {
-            _options.CancellationToken.ThrowIfCancellationRequested();
+            _cancellationToken.ThrowIfCancellationRequested();
             WritePage(pages[i], pageObjects[i], fonts, fontObjects, policy);
         }
 

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfOptions.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfOptions.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Broiler.Documents.Rtf;
+
+/// <summary>
+/// RTF-specific read options.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only settings no other codec can use belong to a format. That turns out to be
+/// a shorter list than the roadmap assumed: the group-depth and binary-payload
+/// limits look like RTF concepts, but DOCX enforces both as well — style
+/// inheritance depth and part size — so under the repository's own containment
+/// rule they are genuinely shared and stay on <see cref="DocumentLimits"/>.
+/// The default code page is the one read setting with a single consumer.
+/// </para>
+/// <para>
+/// This type does not redeclare that setting; it fixes where callers should set
+/// it. Passing the plain <see cref="DocumentReadOptions"/> still works and still
+/// carries the code page, because moving the storage would have broken every
+/// existing caller for no behavioral gain. Passing <em>another</em> codec's
+/// option type is a structured rejection rather than a silent fallback.
+/// </para>
+/// </remarks>
+public sealed class RtfReadOptions : DocumentReadOptions
+{
+    /// <summary>Windows-1252, the RTF default when no <c>\ansicpg</c> is present.</summary>
+    public new const int Windows1252CodePage = DocumentReadOptions.Windows1252CodePage;
+
+    public static new RtfReadOptions Default { get; } = new();
+
+    public RtfReadOptions(
+        DocumentLimits? limits = null,
+        int defaultCodePage = Windows1252CodePage)
+        : base(limits, defaultCodePage)
+    {
+    }
+}
+
+/// <summary>
+/// RTF-specific write options.
+/// </summary>
+/// <remarks>
+/// The RTF writer always escapes non-ASCII as <c>\uN?</c> under <c>\uc1</c>, so
+/// <see cref="DocumentWriteOptions.AsciiOnly"/> has exactly one implemented
+/// value. This type pins it, and the writer reports a caller that asks for the
+/// other one instead of silently ignoring the request — a public knob that reads
+/// as configurable but is not is precisely the contract defect the component
+/// roadmap asks this migration to clear.
+/// </remarks>
+public sealed class RtfWriteOptions : DocumentWriteOptions
+{
+    public static new RtfWriteOptions Default { get; } = new();
+
+    public RtfWriteOptions()
+        : base(asciiOnly: true)
+    {
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfReader.cs
@@ -58,12 +58,14 @@ public static class RtfReader
         private bool _sawStar;
         private bool _reportedCodePage;
         private bool _reportedEmbedded;
+        private readonly bool _embeddedDecodingRequested;
 
         private State _state;
 
         public Worker(DocumentReadOptions options, IReadOnlyList<DocumentDiagnostic> tokenizerDiagnostics)
         {
             _diagnostics.AddRange(tokenizerDiagnostics);
+            _embeddedDecodingRequested = options.DecodeEmbeddedObjects;
             _builder = new Accumulator(options.Limits.MaxParagraphCount);
             _state = new State
             {
@@ -108,7 +110,7 @@ public static class RtfReader
             if (_builder.LimitHit)
                 _diagnostics.Add(DocumentDiagnostic.Warning("rtf.paragraphs", "Document exceeded MaxParagraphCount; extra paragraphs were dropped."));
 
-            return new DocumentReadResult(document, _diagnostics);
+            return new DocumentReadResult(document, _diagnostics, DocumentReadResult.StatusFrom(_diagnostics));
         }
 
         private void HandleGroupEnd()
@@ -162,7 +164,17 @@ public static class RtfReader
                     _state.Dest = RtfDestination.Skip;
                     if (!_reportedEmbedded)
                     {
-                        _diagnostics.Add(DocumentDiagnostic.Info("rtf.embedded", "Embedded pictures/objects are not imported and were skipped."));
+                        // A caller that asked for image decoding gets a warning under
+                        // the shared capability code, not the bland note: it asked for
+                        // something this reader cannot do, and the document it receives
+                        // is missing content it expected.
+                        _diagnostics.Add(_embeddedDecodingRequested
+                            ? DocumentDiagnostic.Warning(
+                                DocumentDiagnosticCodes.CapabilityNotComposed,
+                                "Embedded image decoding was requested, but this reader composes no image service; pictures and objects were skipped.")
+                            : DocumentDiagnostic.Info(
+                                "rtf.embedded",
+                                "Embedded pictures/objects are not imported and were skipped."));
                         _reportedEmbedded = true;
                     }
 

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
@@ -25,11 +25,21 @@ public static class RtfWriter
     {
         ArgumentNullException.ThrowIfNull(document);
         ArgumentNullException.ThrowIfNull(destination);
-        _ = options;
 
         var fonts = new ResourceTable<string>(StringComparer.Ordinal);
         var colors = new ResourceTable<BColor>(EqualityComparer<BColor>.Default);
         var diagnostics = new List<DocumentDiagnostic>();
+
+        // The writer always escapes non-ASCII as \uN?; there is no raw-byte mode.
+        // A caller asking for one is told, rather than silently given the escaped
+        // form it did not ask for.
+        if (options is { AsciiOnly: false })
+        {
+            diagnostics.Add(DocumentDiagnostic.Warning(
+                DocumentDiagnosticCodes.CapabilityNotComposed,
+                "This writer emits non-ASCII characters as \\uN? escapes only; raw high bytes are not implemented, so AsciiOnly=false was not honoured."));
+        }
+
         var reported = new HashSet<string>(StringComparer.Ordinal);
         CollectResources(document, fonts, colors);
 
@@ -51,7 +61,7 @@ public static class RtfWriter
 
         byte[] bytes = Encoding.ASCII.GetBytes(sb.ToString());
         destination.Write(bytes, 0, bytes.Length);
-        return new DocumentWriteResult(bytes.Length, diagnostics);
+        return new DocumentWriteResult(bytes.Length, diagnostics, DocumentWriteResult.StatusFrom(diagnostics));
     }
 
     /// <summary>Serialize to a byte array (convenience over the stream overload).</summary>

--- a/Broiler.Documents/Broiler.Documents.Tests/DocumentContractTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Tests/DocumentContractTests.cs
@@ -1,0 +1,386 @@
+using Broiler.Documents.Model;
+
+namespace Broiler.Documents.Tests;
+
+/// <summary>
+/// The request, status, and option-validation contracts that every codec shares.
+/// </summary>
+public sealed class DocumentContractTests
+{
+    /// <summary>A codec that only implements the stream methods, as every codec did before.</summary>
+    private sealed class LegacyCodec : DocumentCodec
+    {
+        public LegacyCodec()
+            : base(new DocumentFormatDescriptor("LEGACY", ["text/legacy"], [".legacy"]))
+        {
+        }
+
+        public int StreamReads { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        public override DocumentProbeResult Probe(DocumentProbeRequest request) =>
+            DocumentProbeResult.Match(DocumentProbeConfidence.Certain, Descriptor.Name);
+
+        public override DocumentReadResult Read(Stream source, DocumentReadOptions? options = null)
+        {
+            StreamReads++;
+            using var reader = new StreamReader(source);
+            return new DocumentReadResult(RichTextDocument.FromPlainText(reader.ReadToEnd()));
+        }
+
+        public override DocumentWriteResult Write(
+            RichTextDocument document,
+            Stream destination,
+            DocumentWriteOptions? options = null)
+        {
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(document.PlainText);
+            destination.Write(bytes);
+            return new DocumentWriteResult(bytes.Length);
+        }
+    }
+
+    /// <summary>A codec with its own option type, which it validates.</summary>
+    private sealed class TypedCodec : DocumentCodec
+    {
+        public sealed class Options : DocumentReadOptions
+        {
+            public Options(string marker = "typed") => Marker = marker;
+
+            public string Marker { get; }
+        }
+
+        public sealed class WriteOptions : DocumentWriteOptions;
+
+        public TypedCodec()
+            : base(new DocumentFormatDescriptor("TYPED", ["text/typed"], [".typed"]))
+        {
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        public override DocumentProbeResult Probe(DocumentProbeRequest request) =>
+            DocumentProbeResult.Match(DocumentProbeConfidence.Certain, Descriptor.Name);
+
+        public override DocumentReadResult Read(Stream source, DocumentReadOptions? options = null)
+        {
+            if (!TryValidateOptions(options ?? DocumentReadOptions.Default, Name, out Options? typed, out DocumentReadResult? rejection))
+                return rejection!;
+
+            return new DocumentReadResult(RichTextDocument.FromPlainText(typed?.Marker ?? "default"));
+        }
+
+        public override DocumentWriteResult Write(
+            RichTextDocument document,
+            Stream destination,
+            DocumentWriteOptions? options = null)
+        {
+            if (!TryValidateOptions(options ?? DocumentWriteOptions.Default, Name, out WriteOptions? _, out DocumentWriteResult? rejection))
+                return rejection!;
+
+            return new DocumentWriteResult(0);
+        }
+    }
+
+    /// <summary>Another codec's option types, to prove a mismatch is rejected.</summary>
+    private sealed class ForeignReadOptions : DocumentReadOptions;
+
+    private sealed class ForeignWriteOptions : DocumentWriteOptions;
+
+    /// <summary>A codec that never claims anything, so selection can fail honestly.</summary>
+    private sealed class NeverMatchesCodec : DocumentCodec
+    {
+        public NeverMatchesCodec()
+            : base(new DocumentFormatDescriptor("NEVER", ["text/never"], [".never"]))
+        {
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => false;
+
+        public override DocumentProbeResult Probe(DocumentProbeRequest request) => DocumentProbeResult.NoMatch();
+
+        public override DocumentReadResult Read(Stream source, DocumentReadOptions? options = null) =>
+            throw new InvalidOperationException("A codec that never matches must never be asked to read.");
+
+        public override DocumentWriteResult Write(
+            RichTextDocument document,
+            Stream destination,
+            DocumentWriteOptions? options = null) =>
+            throw new InvalidOperationException("This codec cannot write.");
+    }
+
+    private static byte[] Bytes(string text) => System.Text.Encoding.UTF8.GetBytes(text);
+
+    // ---- request adapters -----------------------------------------------------
+
+    [Fact]
+    public void A_Codec_That_Only_Implements_Streams_Still_Serves_Requests()
+    {
+        var codec = new LegacyCodec();
+        using DocumentInput input = DocumentInput.FromBytes(Bytes("legacy content"));
+
+        DocumentReadResult result = codec.Read(new DocumentReadRequest(input));
+
+        Assert.Equal("legacy content", result.Document.PlainText);
+        Assert.Equal(1, codec.StreamReads);
+    }
+
+    [Fact]
+    public async Task The_Default_Async_Read_Matches_The_Synchronous_One()
+    {
+        var codec = new LegacyCodec();
+        using DocumentInput input = DocumentInput.FromBytes(Bytes("async content"));
+
+        DocumentReadResult result = await codec.ReadAsync(new DocumentReadRequest(input));
+
+        Assert.Equal("async content", result.Document.PlainText);
+    }
+
+    [Fact]
+    public void A_Request_Cancelled_Before_It_Starts_Rejects_Without_Reading()
+    {
+        var codec = new LegacyCodec();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using DocumentInput input = DocumentInput.FromBytes(Bytes("never read"));
+
+        DocumentReadResult result = codec.Read(new DocumentReadRequest(input, null, cancellation.Token));
+
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.Contains(result.Diagnostics, d => d.Code == DocumentDiagnosticCodes.Cancelled);
+        Assert.Equal(0, codec.StreamReads);
+    }
+
+    [Fact]
+    public void A_Write_Request_Cancelled_Before_It_Starts_Leaves_The_Destination_Untouched()
+    {
+        var codec = new LegacyCodec();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var destination = new MemoryStream();
+
+        DocumentWriteResult result = codec.Write(
+            new DocumentWriteRequest(RichTextDocument.FromPlainText("x"), destination, null, cancellation.Token));
+
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentDestinationState.NotStarted, result.DestinationState);
+        Assert.Empty(destination.ToArray());
+    }
+
+    [Fact]
+    public void A_Write_Request_Refuses_A_Read_Only_Destination()
+    {
+        using var destination = new MemoryStream(new byte[8], writable: false);
+
+        Assert.Throws<ArgumentException>(() =>
+            new DocumentWriteRequest(RichTextDocument.Empty, destination));
+    }
+
+    // ---- typed options --------------------------------------------------------
+
+    [Fact]
+    public void A_Codec_Accepts_Its_Own_Option_Type()
+    {
+        var codec = new TypedCodec();
+        using var source = new MemoryStream(Bytes("x"));
+
+        DocumentReadResult result = codec.Read(source, new TypedCodec.Options("chosen"));
+
+        Assert.Equal(DocumentResultStatus.Success, result.Status);
+        Assert.Equal("chosen", result.Document.PlainText);
+    }
+
+    [Fact]
+    public void A_Codec_Accepts_The_Plain_Shared_Options_And_Applies_Its_Own_Defaults()
+    {
+        var codec = new TypedCodec();
+        using var source = new MemoryStream(Bytes("x"));
+
+        // A caller that knows nothing about this format is not an error.
+        DocumentReadResult result = codec.Read(source, new DocumentReadOptions());
+
+        Assert.Equal(DocumentResultStatus.Success, result.Status);
+        Assert.Equal("default", result.Document.PlainText);
+    }
+
+    [Fact]
+    public void A_Codec_Rejects_Another_Codecs_Option_Type_Rather_Than_Ignoring_It()
+    {
+        var codec = new TypedCodec();
+        using var source = new MemoryStream(Bytes("x"));
+
+        DocumentReadResult result = codec.Read(source, new ForeignReadOptions());
+
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        DocumentDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(DocumentDiagnosticCodes.OptionsInvalid, diagnostic.Code);
+
+        // The message names both types so the caller can see what it passed.
+        Assert.Contains(nameof(TypedCodec.Options), diagnostic.Message);
+        Assert.Contains(nameof(ForeignReadOptions), diagnostic.Message);
+    }
+
+    [Fact]
+    public void The_Write_Side_Rejects_A_Foreign_Option_Type_Too()
+    {
+        var codec = new TypedCodec();
+        using var destination = new MemoryStream();
+
+        DocumentWriteResult result = codec.Write(RichTextDocument.Empty, destination, new ForeignWriteOptions());
+
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+        Assert.Equal(DocumentDestinationState.NotStarted, result.DestinationState);
+        Assert.Empty(destination.ToArray());
+    }
+
+    // ---- status derivation ----------------------------------------------------
+
+    [Fact]
+    public void Informational_Diagnostics_Alone_Leave_A_Result_Successful()
+    {
+        DocumentDiagnostic[] diagnostics = [DocumentDiagnostic.Info("x.note", "Nothing was lost.")];
+
+        Assert.Equal(DocumentResultStatus.Success, DocumentReadResult.StatusFrom(diagnostics));
+        Assert.Equal(DocumentResultStatus.Success, DocumentWriteResult.StatusFrom(diagnostics));
+    }
+
+    [Theory]
+    [InlineData(DocumentDiagnosticSeverity.Warning)]
+    [InlineData(DocumentDiagnosticSeverity.Error)]
+    public void Anything_Above_Informational_Makes_A_Result_Partial(DocumentDiagnosticSeverity severity)
+    {
+        DocumentDiagnostic[] diagnostics = [new(severity, "x.skipped", "A construct was skipped.")];
+
+        Assert.Equal(DocumentResultStatus.Partial, DocumentReadResult.StatusFrom(diagnostics));
+    }
+
+    [Fact]
+    public void Status_And_Severity_Are_Independent()
+    {
+        // The point of the separation: a result can carry an error diagnostic and
+        // still be usable, and a host must branch on the status rather than on
+        // whether any diagnostic happens to be an error.
+        var result = new DocumentReadResult(
+            RichTextDocument.FromPlainText("recovered"),
+            [DocumentDiagnostic.Error("x.recovered", "A construct was recovered.")],
+            DocumentResultStatus.Partial);
+
+        Assert.True(result.HasErrors);
+        Assert.True(result.IsUsable);
+        Assert.Equal(DocumentResultStatus.Partial, result.Status);
+    }
+
+    [Fact]
+    public void A_Rejection_Is_Never_Usable()
+    {
+        DocumentReadResult result = DocumentReadResult.Rejected(DocumentDiagnosticCodes.InputUnreadable, "No.");
+
+        Assert.False(result.IsUsable);
+        Assert.Equal(DocumentResultStatus.Rejected, result.Status);
+    }
+
+    // ---- diagnostic locations -------------------------------------------------
+
+    [Fact]
+    public void A_Diagnostic_May_Carry_A_Location_And_Reads_Well_Without_One()
+    {
+        var located = DocumentDiagnostic.Warning(
+            "x.here",
+            "Something happened.",
+            new DocumentDiagnosticLocation(byteOffset: 42, pageNumber: 3, part: "/word/document.xml"));
+
+        Assert.Contains("offset 42", located.ToString());
+        Assert.Contains("page 3", located.ToString());
+        Assert.Contains("/word/document.xml", located.ToString());
+
+        Assert.Null(DocumentDiagnostic.Info("x.plain", "No location.").Location);
+    }
+
+    // ---- catalog selection ----------------------------------------------------
+
+    [Fact]
+    public void SelectAndRead_Probes_And_Reads_Through_One_Non_Seekable_Pass()
+    {
+        var catalog = new DocumentCodecCatalog([new LegacyCodec()]);
+        using var source = new DocumentInputTests_ForwardOnly(Bytes("selected content"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        DocumentCodecSelection selection = catalog.SelectAndRead(input);
+
+        Assert.Equal("LEGACY", selection.Codec!.Name);
+        Assert.True(selection.IsUsable);
+        Assert.Equal("selected content", selection.Result.Document.PlainText);
+    }
+
+    [Fact]
+    public void SelectAndRead_Reports_When_Nothing_Recognizes_The_Source()
+    {
+        var catalog = new DocumentCodecCatalog([new NeverMatchesCodec()]);
+        using DocumentInput input = DocumentInput.FromBytes(Bytes("not a document"));
+
+        DocumentCodecSelection selection = catalog.SelectAndRead(input);
+
+        Assert.Null(selection.Codec);
+        Assert.False(selection.IsUsable);
+        Assert.Contains(
+            selection.Result.Diagnostics,
+            d => d.Code == DocumentDiagnosticCodes.InputUnreadable);
+    }
+
+    [Fact]
+    public async Task SelectAndReadAsync_Matches_The_Synchronous_Path()
+    {
+        var catalog = new DocumentCodecCatalog([new LegacyCodec()]);
+        using DocumentInput input = DocumentInput.FromBytes(Bytes("async selection"));
+
+        DocumentCodecSelection selection = await catalog.SelectAndReadAsync(input);
+
+        Assert.Equal("LEGACY", selection.Codec!.Name);
+        Assert.Equal("async selection", selection.Result.Document.PlainText);
+    }
+
+    /// <summary>A non-seekable stream, so the selection path is exercised honestly.</summary>
+    private sealed class DocumentInputTests_ForwardOnly : Stream
+    {
+        private readonly MemoryStream _inner;
+
+        public DocumentInputTests_ForwardOnly(byte[] data) => _inner = new MemoryStream(data);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Tests/DocumentInputTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Tests/DocumentInputTests.cs
@@ -1,0 +1,214 @@
+namespace Broiler.Documents.Tests;
+
+/// <summary>
+/// The property that matters: a source can be probed and then read once, whether
+/// or not it can seek, without losing the probed bytes and without buffering the
+/// whole thing.
+/// </summary>
+public sealed class DocumentInputTests
+{
+    private static byte[] Bytes(string text) => System.Text.Encoding.ASCII.GetBytes(text);
+
+    /// <summary>A stream that refuses to seek, like a pipe or a network body.</summary>
+    private sealed class ForwardOnlyStream : Stream
+    {
+        private readonly MemoryStream _inner;
+
+        public ForwardOnlyStream(byte[] data) => _inner = new MemoryStream(data);
+
+        public int ReadCalls { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ReadCalls++;
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    [Fact]
+    public void A_Non_Seekable_Source_Can_Be_Probed_And_Then_Read_In_Full()
+    {
+        using var source = new ForwardOnlyStream(Bytes("HEADER-then-the-body"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        Assert.Equal("HEADER", System.Text.Encoding.ASCII.GetString(input.Peek(6).Span));
+
+        using Stream stream = input.OpenStream();
+        using var reader = new StreamReader(stream, System.Text.Encoding.ASCII);
+
+        // The probed prefix is replayed, not lost.
+        Assert.Equal("HEADER-then-the-body", reader.ReadToEnd());
+    }
+
+    [Fact]
+    public void Peeking_Twice_Returns_The_Same_Bytes_Without_Re_Reading()
+    {
+        using var source = new ForwardOnlyStream(Bytes("abcdefghij"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        ReadOnlyMemory<byte> first = input.Peek(4);
+        int callsAfterFirst = source.ReadCalls;
+        ReadOnlyMemory<byte> second = input.Peek(4);
+
+        Assert.Equal(first.ToArray(), second.ToArray());
+        Assert.Equal(callsAfterFirst, source.ReadCalls);
+    }
+
+    [Fact]
+    public void A_Peek_Longer_Than_The_Source_Returns_What_Exists()
+    {
+        using var source = new ForwardOnlyStream(Bytes("short"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        Assert.Equal(5, input.Peek(4096).Length);
+    }
+
+    [Fact]
+    public void A_Seekable_Source_Rewinds_Instead_Of_Buffering()
+    {
+        using var source = new MemoryStream(Bytes("HEADER-then-the-body"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        input.Peek(6);
+        using Stream stream = input.OpenStream();
+        using var reader = new StreamReader(stream, System.Text.Encoding.ASCII);
+
+        Assert.Equal("HEADER-then-the-body", reader.ReadToEnd());
+    }
+
+    [Fact]
+    public void Materialize_Refuses_A_Source_Past_Its_Ceiling()
+    {
+        using var source = new ForwardOnlyStream(new byte[4096]);
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        Assert.Throws<DocumentException>(() => input.Materialize(1024));
+    }
+
+    [Fact]
+    public void A_Known_Length_Rejects_An_Oversized_Source_Before_Reading_It()
+    {
+        using var source = new MemoryStream(new byte[4096]);
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        Assert.Equal(4096, input.KnownLength);
+        Assert.Throws<DocumentException>(() => input.Materialize(1024));
+
+        // Nothing was consumed on the way to the refusal.
+        Assert.Equal(0, source.Position);
+    }
+
+    [Fact]
+    public void A_Non_Seekable_Source_Reports_No_Known_Length()
+    {
+        using var source = new ForwardOnlyStream(Bytes("body"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        Assert.Null(input.KnownLength);
+        Assert.False(input.CanSeek);
+    }
+
+    [Fact]
+    public void Materialize_Includes_The_Probed_Prefix()
+    {
+        using var source = new ForwardOnlyStream(Bytes("PREFIXbody"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+
+        input.Peek(6);
+
+        Assert.Equal("PREFIXbody", System.Text.Encoding.ASCII.GetString(input.Materialize(1024).Span));
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_Matches_The_Synchronous_Result()
+    {
+        using var source = new ForwardOnlyStream(Bytes("PREFIXbody"));
+        using DocumentInput input = DocumentInput.FromStream(source);
+        input.Peek(6);
+
+        ReadOnlyMemory<byte> bytes = await input.MaterializeAsync(1024);
+
+        Assert.Equal("PREFIXbody", System.Text.Encoding.ASCII.GetString(bytes.Span));
+    }
+
+    [Fact]
+    public void The_Caller_Keeps_Its_Stream_By_Default()
+    {
+        var source = new MemoryStream(Bytes("body"));
+        using (DocumentInput input = DocumentInput.FromStream(source))
+        {
+            using Stream stream = input.OpenStream();
+            stream.ReadByte();
+        }
+
+        // Disposing the input, and the stream it handed out, left the caller's
+        // stream usable.
+        source.Position = 0;
+        Assert.Equal((byte)'b', (byte)source.ReadByte());
+        source.Dispose();
+    }
+
+    [Fact]
+    public void Ownership_Can_Be_Transferred_Explicitly()
+    {
+        var source = new MemoryStream(Bytes("body"));
+        using (DocumentInput.FromStream(source, leaveOpen: false))
+        {
+        }
+
+        Assert.Throws<ObjectDisposedException>(() => source.ReadByte());
+    }
+
+    [Fact]
+    public void A_Memory_Input_Neither_Copies_Nor_Consumes()
+    {
+        byte[] data = Bytes("in memory");
+        using DocumentInput input = DocumentInput.FromBytes(data);
+
+        Assert.Equal(data.Length, input.KnownLength);
+        Assert.True(input.CanSeek);
+        Assert.Equal("in ", System.Text.Encoding.ASCII.GetString(input.Peek(3).Span));
+        Assert.Equal(data, input.Materialize(1024).ToArray());
+        Assert.Equal(data, input.Materialize(1024).ToArray());
+    }
+
+    [Fact]
+    public void Using_A_Disposed_Input_Throws_Rather_Than_Misbehaving()
+    {
+        DocumentInput input = DocumentInput.FromBytes(Bytes("x"));
+        input.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => input.Peek(1));
+        Assert.Throws<ObjectDisposedException>(() => input.OpenStream());
+        Assert.Throws<ObjectDisposedException>(() => input.Materialize(16));
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Tests/PdfPhaseZeroGuardTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Tests/PdfPhaseZeroGuardTests.cs
@@ -19,6 +19,7 @@ public sealed class PdfPhaseZeroGuardTests
         "Broiler.Documents/docs/pdf-corpus-manifest.json",
         "Broiler.Documents/docs/pdf-phase0-status.md",
         "Broiler.Documents/docs/pdf-extension-points.md",
+        "Broiler.Documents/docs/pdf-construct-inventory.md",
         "Broiler.Documents/docs/adr/0007-pdf-component-scope-and-delivery.md",
         "Broiler.Documents/docs/adr/0008-pdf-codec-requests-results-and-commit.md",
         "Broiler.Documents/docs/adr/0009-pdf-security-resources-and-privacy.md",

--- a/Broiler.Documents/Broiler.Documents/DocumentCodec.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentCodec.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Broiler.Documents.Model;
 
 namespace Broiler.Documents;
@@ -10,6 +12,25 @@ namespace Broiler.Documents;
 /// are registered explicitly into a <see cref="DocumentCodecCatalog"/> — there is
 /// no hidden global registration (ADR 0003).
 /// </summary>
+/// <remarks>
+/// <para>
+/// There are two entry points per direction, and they are not alternatives of
+/// equal standing. The request forms (<see cref="Read(DocumentReadRequest)"/> and
+/// <see cref="Write(DocumentWriteRequest)"/>) are the contract: they carry a
+/// replayable input, typed options, limits, and cancellation in one place, with
+/// exactly one owner per value. The stream forms are compatibility adapters kept
+/// for existing callers, and they are what a codec implements — so a codec
+/// written before the request contract existed keeps working unchanged, and one
+/// that can do better overrides the request form (PDF roadmap §6.1).
+/// </para>
+/// <para>
+/// The asynchronous forms exist so a host with real async I/O never has to block.
+/// Their default implementations complete synchronously rather than pushing work
+/// to a thread pool, and no adapter here calls <c>.Result</c>, <c>.Wait()</c>, or
+/// <c>GetAwaiter().GetResult()</c> in either direction: sync-over-async is how a
+/// UI thread deadlocks.
+/// </para>
+/// </remarks>
 public abstract class DocumentCodec
 {
     protected DocumentCodec(DocumentFormatDescriptor descriptor)
@@ -21,10 +42,10 @@ public abstract class DocumentCodec
 
     public string Name => Descriptor.Name;
 
-    /// <summary>True when <see cref="Read"/> is implemented for this format.</summary>
+    /// <summary>True when <see cref="Read(Stream, DocumentReadOptions)"/> is implemented for this format.</summary>
     public abstract bool CanRead { get; }
 
-    /// <summary>True when <see cref="Write"/> is implemented for this format.</summary>
+    /// <summary>True when <see cref="Write(RichTextDocument, Stream, DocumentWriteOptions)"/> is implemented for this format.</summary>
     public abstract bool CanWrite { get; }
 
     /// <summary>Judge whether a byte prefix is this codec's format.</summary>
@@ -42,4 +63,157 @@ public abstract class DocumentCodec
         RichTextDocument document,
         Stream destination,
         DocumentWriteOptions? options = null);
+
+    /// <summary>
+    /// Read through the request contract. The default implementation opens the
+    /// request's input and calls <see cref="Read(Stream, DocumentReadOptions)"/>,
+    /// which is correct for any codec that reads a stream front to back; a codec
+    /// that wants the input's length, random access, or cancellation checkpoints
+    /// overrides this instead.
+    /// </summary>
+    public virtual DocumentReadResult Read(DocumentReadRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.CancellationToken.IsCancellationRequested)
+        {
+            return DocumentReadResult.Rejected(
+                DocumentDiagnosticCodes.Cancelled,
+                "The read was cancelled before it began.");
+        }
+
+        try
+        {
+            using Stream source = request.Input.OpenStream();
+            return Read(source, request.Options);
+        }
+        catch (DocumentException e)
+        {
+            return DocumentReadResult.Rejected(DocumentDiagnosticCodes.InputTooLarge, e.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            return DocumentReadResult.Rejected(
+                DocumentDiagnosticCodes.Cancelled,
+                "The read was cancelled before it produced a usable document.");
+        }
+    }
+
+    /// <summary>
+    /// Write through the request contract. The default implementation calls
+    /// <see cref="Write(RichTextDocument, Stream, DocumentWriteOptions)"/>.
+    /// </summary>
+    public virtual DocumentWriteResult Write(DocumentWriteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.CancellationToken.IsCancellationRequested)
+        {
+            return DocumentWriteResult.Rejected(
+                DocumentDiagnosticCodes.Cancelled,
+                "The write was cancelled before any byte reached the destination.");
+        }
+
+        try
+        {
+            return Write(request.Document, request.Destination, request.Options);
+        }
+        catch (OperationCanceledException)
+        {
+            return DocumentWriteResult.Rejected(
+                DocumentDiagnosticCodes.Cancelled,
+                "The write was cancelled before any byte reached the destination.");
+        }
+    }
+
+    /// <summary>
+    /// The asynchronous read. The default completes synchronously; a codec with
+    /// genuinely asynchronous I/O overrides it.
+    /// </summary>
+    public virtual ValueTask<DocumentReadResult> ReadAsync(DocumentReadRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ValueTask.FromResult(Read(request));
+    }
+
+    /// <summary>
+    /// The asynchronous write. The default completes synchronously; a codec with
+    /// genuinely asynchronous I/O overrides it.
+    /// </summary>
+    public virtual ValueTask<DocumentWriteResult> WriteAsync(DocumentWriteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ValueTask.FromResult(Write(request));
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="options"/> is the type this codec needs,
+    /// returning the rejection to hand back when it is not.
+    /// </summary>
+    /// <remarks>
+    /// A codec calls this <em>before</em> touching its input or destination, so a
+    /// wrong option object costs nothing and changes nothing. Options that merely
+    /// come from the shared base are fine — they carry the shared settings and the
+    /// codec fills in its own defaults for the rest. Only an object of a
+    /// <em>different</em> codec's option type is a rejection.
+    /// </remarks>
+    protected static bool TryValidateOptions<TOptions>(
+        DocumentReadOptions options,
+        string codecName,
+        out TOptions? typed,
+        out DocumentReadResult? rejection)
+        where TOptions : DocumentReadOptions
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options is TOptions match)
+        {
+            typed = match;
+            rejection = null;
+            return true;
+        }
+
+        typed = null;
+
+        // The exact base type carries only shared settings, so it is always
+        // acceptable: the codec supplies its own defaults for the rest. Any other
+        // type belongs to a different codec.
+        if (options.GetType() == typeof(DocumentReadOptions))
+        {
+            rejection = null;
+            return true;
+        }
+
+        rejection = DocumentReadResult.InvalidOptions(codecName, typeof(TOptions), options.GetType());
+        return false;
+    }
+
+    /// <summary>The write-side counterpart of <see cref="TryValidateOptions{TOptions}(DocumentReadOptions, string, out TOptions, out DocumentReadResult)"/>.</summary>
+    protected static bool TryValidateOptions<TOptions>(
+        DocumentWriteOptions options,
+        string codecName,
+        out TOptions? typed,
+        out DocumentWriteResult? rejection)
+        where TOptions : DocumentWriteOptions
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options is TOptions match)
+        {
+            typed = match;
+            rejection = null;
+            return true;
+        }
+
+        typed = null;
+
+        if (options.GetType() == typeof(DocumentWriteOptions))
+        {
+            rejection = null;
+            return true;
+        }
+
+        rejection = DocumentWriteResult.InvalidOptions(codecName, typeof(TOptions), options.GetType());
+        return false;
+    }
 }

--- a/Broiler.Documents/Broiler.Documents/DocumentCodecCatalog.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentCodecCatalog.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Broiler.Documents;
 
@@ -75,6 +77,76 @@ public sealed class DocumentCodecCatalog
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Selects a codec for <paramref name="input"/> and reads it, probing and
+    /// reading through the same replayable input.
+    /// </summary>
+    /// <remarks>
+    /// This is the authoritative read path, and its point is that probing a
+    /// non-seekable source cannot consume bytes the codec then needs: the
+    /// prefix the probe looked at is replayed ahead of the rest. A caller that
+    /// selects and opens separately has to solve that itself, usually by
+    /// buffering the whole source.
+    /// </remarks>
+    public DocumentCodecSelection SelectAndRead(
+        DocumentInput input,
+        DocumentReadOptions? options = null,
+        DocumentSourceHints? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        DocumentReadOptions effective = options ?? DocumentReadOptions.Default;
+
+        ReadOnlyMemory<byte> prefix = input.Peek(effective.Limits.MaxProbeBytes);
+        DocumentCodecMatch? match = Select(prefix, hints, effective.Limits);
+
+        if (match is null)
+        {
+            return new DocumentCodecSelection(
+                null,
+                DocumentReadResult.Rejected(
+                    DocumentDiagnosticCodes.InputUnreadable,
+                    "No composed codec recognized the source. The catalog holds " +
+                    $"{_codecs.Count} codecs; none matched its content signature, filename, or MIME hint."));
+        }
+
+        if (!match.Codec.CanRead)
+        {
+            return new DocumentCodecSelection(
+                match,
+                DocumentReadResult.Rejected(
+                    DocumentDiagnosticCodes.CapabilityNotComposed,
+                    $"The {match.Codec.Name} codec recognized the source but does not implement reading."));
+        }
+
+        var request = new DocumentReadRequest(input, effective, cancellationToken);
+        return new DocumentCodecSelection(match, match.Codec.Read(request));
+    }
+
+    /// <summary>The asynchronous form of <see cref="SelectAndRead"/>.</summary>
+    public async ValueTask<DocumentCodecSelection> SelectAndReadAsync(
+        DocumentInput input,
+        DocumentReadOptions? options = null,
+        DocumentSourceHints? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        DocumentReadOptions effective = options ?? DocumentReadOptions.Default;
+
+        ReadOnlyMemory<byte> prefix = input.Peek(effective.Limits.MaxProbeBytes);
+        DocumentCodecMatch? match = Select(prefix, hints, effective.Limits);
+
+        if (match is null || !match.Codec.CanRead)
+        {
+            // Reuse the synchronous path's wording for the two non-reading cases;
+            // neither touches the input, so there is nothing to await.
+            return SelectAndRead(input, effective, hints, cancellationToken);
+        }
+
+        var request = new DocumentReadRequest(input, effective, cancellationToken);
+        return new DocumentCodecSelection(match, await match.Codec.ReadAsync(request).ConfigureAwait(false));
     }
 
     private static byte[] ReadPrefix(Stream stream, int maxBytes)

--- a/Broiler.Documents/Broiler.Documents/DocumentCodecSelection.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentCodecSelection.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Broiler.Documents;
+
+/// <summary>
+/// The outcome of <see cref="DocumentCodecCatalog.SelectAndRead"/>: which codec
+/// was chosen, if any, and what reading with it produced.
+/// </summary>
+/// <remarks>
+/// The two failures a caller has to tell apart are "nothing recognized this" and
+/// "something recognized it and then could not read it". Both arrive here as a
+/// rejected <see cref="Result"/>, but only the second has a <see cref="Match"/>,
+/// so a host can name the format it declined to open.
+/// </remarks>
+public sealed class DocumentCodecSelection
+{
+    public DocumentCodecSelection(DocumentCodecMatch? match, DocumentReadResult result)
+    {
+        Match = match;
+        Result = result ?? throw new ArgumentNullException(nameof(result));
+    }
+
+    /// <summary>The chosen codec and its probe verdict, or null when none matched.</summary>
+    public DocumentCodecMatch? Match { get; }
+
+    /// <summary>The read outcome.</summary>
+    public DocumentReadResult Result { get; }
+
+    /// <summary>The chosen codec, or null when none matched.</summary>
+    public DocumentCodec? Codec => Match?.Codec;
+
+    /// <summary>True when a codec matched and its result is usable.</summary>
+    public bool IsUsable => Match is not null && Result.IsUsable;
+}

--- a/Broiler.Documents/Broiler.Documents/DocumentDiagnostic.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentDiagnostic.cs
@@ -1,6 +1,68 @@
 using System;
+using System.Globalization;
 
 namespace Broiler.Documents;
+
+/// <summary>
+/// Where in a source a diagnostic applies, in whatever terms the format has.
+/// </summary>
+/// <remarks>
+/// Formats disagree about what a location even is — RTF has a byte offset, DOCX
+/// has a part name, PDF has an object number and a page. Rather than inventing a
+/// single coordinate none of them uses, this carries the few that generalize and
+/// leaves the rest to the format's own diagnostic text. Every field is optional;
+/// a diagnostic with no useful location simply has none.
+/// </remarks>
+public sealed class DocumentDiagnosticLocation
+{
+    public DocumentDiagnosticLocation(
+        long? byteOffset = null,
+        int? paragraphIndex = null,
+        int? pageNumber = null,
+        string? part = null)
+    {
+        if (byteOffset < 0)
+            throw new ArgumentOutOfRangeException(nameof(byteOffset));
+        if (paragraphIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(paragraphIndex));
+        if (pageNumber < 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNumber));
+
+        ByteOffset = byteOffset;
+        ParagraphIndex = paragraphIndex;
+        PageNumber = pageNumber;
+        Part = part;
+    }
+
+    /// <summary>Offset into the source bytes.</summary>
+    public long? ByteOffset { get; }
+
+    /// <summary>Index of the produced paragraph, for a projection-time problem.</summary>
+    public int? ParagraphIndex { get; }
+
+    /// <summary>One-based page number, for a paginated format.</summary>
+    public int? PageNumber { get; }
+
+    /// <summary>
+    /// A named component of a container format — a DOCX part, a PDF object. It
+    /// names a structure, never a filesystem path, so it stays safe to log.
+    /// </summary>
+    public string? Part { get; }
+
+    public override string ToString()
+    {
+        var parts = new System.Collections.Generic.List<string>(4);
+        if (Part is not null)
+            parts.Add(Part);
+        if (PageNumber is { } page)
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"page {page}"));
+        if (ParagraphIndex is { } paragraph)
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"paragraph {paragraph}"));
+        if (ByteOffset is { } offset)
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"offset {offset}"));
+        return parts.Count == 0 ? "unknown location" : string.Join(", ", parts);
+    }
+}
 
 /// <summary>
 /// A single note produced while reading or writing a document — an unsupported
@@ -11,7 +73,11 @@ namespace Broiler.Documents;
 /// </summary>
 public sealed class DocumentDiagnostic
 {
-    public DocumentDiagnostic(DocumentDiagnosticSeverity severity, string code, string message)
+    public DocumentDiagnostic(
+        DocumentDiagnosticSeverity severity,
+        string code,
+        string message,
+        DocumentDiagnosticLocation? location = null)
     {
         if (string.IsNullOrWhiteSpace(code))
             throw new ArgumentException("A diagnostic needs a stable code.", nameof(code));
@@ -21,6 +87,7 @@ public sealed class DocumentDiagnostic
         Severity = severity;
         Code = code;
         Message = message;
+        Location = location;
     }
 
     public DocumentDiagnosticSeverity Severity { get; }
@@ -29,14 +96,20 @@ public sealed class DocumentDiagnostic
 
     public string Message { get; }
 
-    public static DocumentDiagnostic Info(string code, string message) =>
-        new(DocumentDiagnosticSeverity.Info, code, message);
+    /// <summary>Where the diagnostic applies, when the codec can say.</summary>
+    public DocumentDiagnosticLocation? Location { get; }
 
-    public static DocumentDiagnostic Warning(string code, string message) =>
-        new(DocumentDiagnosticSeverity.Warning, code, message);
+    public static DocumentDiagnostic Info(string code, string message, DocumentDiagnosticLocation? location = null) =>
+        new(DocumentDiagnosticSeverity.Info, code, message, location);
 
-    public static DocumentDiagnostic Error(string code, string message) =>
-        new(DocumentDiagnosticSeverity.Error, code, message);
+    public static DocumentDiagnostic Warning(string code, string message, DocumentDiagnosticLocation? location = null) =>
+        new(DocumentDiagnosticSeverity.Warning, code, message, location);
 
-    public override string ToString() => $"{Severity} {Code}: {Message}";
+    public static DocumentDiagnostic Error(string code, string message, DocumentDiagnosticLocation? location = null) =>
+        new(DocumentDiagnosticSeverity.Error, code, message, location);
+
+    public override string ToString() =>
+        Location is null
+            ? $"{Severity} {Code}: {Message}"
+            : $"{Severity} {Code} ({Location}): {Message}";
 }

--- a/Broiler.Documents/Broiler.Documents/DocumentDiagnosticCodes.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentDiagnosticCodes.cs
@@ -1,0 +1,53 @@
+namespace Broiler.Documents;
+
+/// <summary>
+/// The format-neutral diagnostic codes every codec may emit. Format-specific
+/// codes live with their codec (<c>PdfDiagnosticCodes</c>, the <c>rtf.*</c> and
+/// <c>docx.*</c> families).
+/// </summary>
+/// <remarks>
+/// Codes are API. A host branches on them, so a code is never renamed or reused
+/// for a different condition; messages may change. No diagnostic carries document
+/// text, a password, a metadata value, or a local path (ADR 0004).
+/// </remarks>
+public static class DocumentDiagnosticCodes
+{
+    /// <summary>
+    /// The options handed to a codec were not the type it requires. This is a
+    /// structured rejection rather than a silent downcast or a quiet fallback to
+    /// defaults: a caller that passes DOCX options to the RTF codec has a bug,
+    /// and hiding it would apply settings the caller never asked for.
+    /// </summary>
+    public const string OptionsInvalid = "document.options.invalid";
+
+    /// <summary>
+    /// A cross-format value was supplied twice — once on the request and once on
+    /// the format options. There is no precedence rule to fall back on; exactly
+    /// one owner is the contract.
+    /// </summary>
+    public const string OptionsConflict = "document.options.conflict";
+
+    /// <summary>The source exceeded the byte ceiling for this read.</summary>
+    public const string InputTooLarge = "document.input.too-large";
+
+    /// <summary>The source could not be read at all.</summary>
+    public const string InputUnreadable = "document.input.unreadable";
+
+    /// <summary>The operation was cancelled at a checkpoint.</summary>
+    public const string Cancelled = "document.operation.cancelled";
+
+    /// <summary>
+    /// A capability the caller asked for is not composed into this codec
+    /// instance, so the construct it applies to was skipped rather than guessed.
+    /// </summary>
+    public const string CapabilityNotComposed = "document.capability.not-composed";
+
+    /// <summary>Source metadata was dropped rather than carried into the result or output.</summary>
+    public const string MetadataDropped = "document.metadata.dropped";
+
+    /// <summary>A URI failed the active output policy and stayed inert source data.</summary>
+    public const string UriRejected = "document.uri.rejected";
+
+    /// <summary>Diagnostics were capped; the message carries only the suppressed count.</summary>
+    public const string DiagnosticsTruncated = "document.diagnostics.truncated";
+}

--- a/Broiler.Documents/Broiler.Documents/DocumentInput.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentInput.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Broiler.Documents;
+
+/// <summary>
+/// A document source that can be probed and then read once, without losing the
+/// probed bytes and without copying the whole source twice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Selecting a codec means reading a prefix; reading the document means reading
+/// that same prefix again. On a seekable stream that is a rewind. On a network
+/// stream, a pipe, or a browser upload it is not, and the naive fix — buffer the
+/// entire source before probing — turns a bounded read into an unbounded one.
+/// <see cref="DocumentInput"/> holds the probed prefix and replays it ahead of
+/// the remaining source, so a non-seekable source can be probed and read exactly
+/// once (PDF roadmap §6.1).
+/// </para>
+/// <para>
+/// <b>Ownership is explicit.</b> An input created over a caller's stream does not
+/// close it unless the caller says so. Disposing an input never disposes a buffer
+/// the caller still owns.
+/// </para>
+/// <para>
+/// <b>There is no ambient spooling.</b> Materialization is memory-only and always
+/// bounded by an explicit ceiling; nothing here opens a temporary file, consults
+/// a temp directory, or writes to disk. That keeps the type usable in a
+/// memory-only WebAssembly host, and it keeps document bytes from landing in a
+/// location with no agreed retention or privacy policy. A host that wants
+/// spooling supplies it above this type, with its own directory, quota,
+/// permission, cleanup, and crash-recovery policy.
+/// </para>
+/// </remarks>
+public abstract class DocumentInput : IDisposable
+{
+    private bool _disposed;
+
+    /// <summary>The source length when it is known without consuming the source.</summary>
+    /// <remarks>
+    /// Null means "not known cheaply", not "empty". A caller enforcing a size
+    /// limit must still bound its read; a known length only lets it reject early.
+    /// </remarks>
+    public abstract long? KnownLength { get; }
+
+    /// <summary>True when the underlying source can be re-read without buffering.</summary>
+    public abstract bool CanSeek { get; }
+
+    /// <summary>
+    /// Returns up to <paramref name="byteCount"/> leading bytes, buffering them so
+    /// a later <see cref="OpenStream"/> or <see cref="Materialize"/> still sees
+    /// them. Repeated calls are cheap and return the same bytes.
+    /// </summary>
+    public ReadOnlyMemory<byte> Peek(int byteCount)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (byteCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(byteCount));
+        return byteCount == 0 ? ReadOnlyMemory<byte>.Empty : PeekCore(byteCount);
+    }
+
+    /// <summary>
+    /// Opens the whole source from its first byte, including any bytes already
+    /// handed out by <see cref="Peek"/>. The returned stream is owned by the
+    /// caller and disposing it does not dispose this input.
+    /// </summary>
+    public Stream OpenStream()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return OpenStreamCore();
+    }
+
+    /// <summary>
+    /// Reads the whole source into memory, refusing to exceed
+    /// <paramref name="maxBytes"/>.
+    /// </summary>
+    /// <exception cref="DocumentException">
+    /// The source is longer than <paramref name="maxBytes"/>. The ceiling is
+    /// enforced while reading, so an oversized source is refused rather than
+    /// buffered and then measured.
+    /// </exception>
+    public ReadOnlyMemory<byte> Materialize(long maxBytes)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes));
+
+        if (KnownLength is { } length && length > maxBytes)
+            throw TooLarge(maxBytes);
+
+        return MaterializeCore(maxBytes);
+    }
+
+    /// <summary>The asynchronous form of <see cref="Materialize"/>.</summary>
+    public ValueTask<ReadOnlyMemory<byte>> MaterializeAsync(long maxBytes, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes));
+
+        if (KnownLength is { } length && length > maxBytes)
+            throw TooLarge(maxBytes);
+
+        return MaterializeAsyncCore(maxBytes, cancellationToken);
+    }
+
+    protected abstract ReadOnlyMemory<byte> PeekCore(int byteCount);
+
+    protected abstract Stream OpenStreamCore();
+
+    protected abstract ReadOnlyMemory<byte> MaterializeCore(long maxBytes);
+
+    protected abstract ValueTask<ReadOnlyMemory<byte>> MaterializeAsyncCore(long maxBytes, CancellationToken cancellationToken);
+
+    /// <summary>An input over bytes the caller already holds. Nothing is copied.</summary>
+    public static DocumentInput FromBytes(ReadOnlyMemory<byte> bytes) => new MemoryDocumentInput(bytes);
+
+    /// <summary>
+    /// An input over a stream. <paramref name="leaveOpen"/> defaults to true: the
+    /// caller opened the stream and keeps it.
+    /// </summary>
+    public static DocumentInput FromStream(Stream source, bool leaveOpen = true)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (!source.CanRead)
+            throw new ArgumentException("A document input needs a readable stream.", nameof(source));
+        return new StreamDocumentInput(source, leaveOpen);
+    }
+
+    internal static DocumentException TooLarge(long maxBytes) =>
+        new($"The document source is larger than the {maxBytes}-byte limit for this read.");
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+
+    // ---- implementations ------------------------------------------------------
+
+    private sealed class MemoryDocumentInput : DocumentInput
+    {
+        private readonly ReadOnlyMemory<byte> _bytes;
+
+        public MemoryDocumentInput(ReadOnlyMemory<byte> bytes) => _bytes = bytes;
+
+        public override long? KnownLength => _bytes.Length;
+
+        public override bool CanSeek => true;
+
+        protected override ReadOnlyMemory<byte> PeekCore(int byteCount) =>
+            _bytes[..Math.Min(byteCount, _bytes.Length)];
+
+        protected override Stream OpenStreamCore() => new ReadOnlyMemoryStream(_bytes);
+
+        protected override ReadOnlyMemory<byte> MaterializeCore(long maxBytes) =>
+            _bytes.Length > maxBytes ? throw TooLarge(maxBytes) : _bytes;
+
+        protected override ValueTask<ReadOnlyMemory<byte>> MaterializeAsyncCore(long maxBytes, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(MaterializeCore(maxBytes));
+        }
+    }
+
+    private sealed class StreamDocumentInput : DocumentInput
+    {
+        private readonly Stream _source;
+        private readonly bool _leaveOpen;
+        private byte[] _prefix = [];
+        private int _prefixLength;
+        private int _prefixConsumed;
+
+        public StreamDocumentInput(Stream source, bool leaveOpen)
+        {
+            _source = source;
+            _leaveOpen = leaveOpen;
+        }
+
+        public override long? KnownLength
+        {
+            get
+            {
+                if (!_source.CanSeek)
+                    return null;
+                try
+                {
+                    return _source.Length - _source.Position + (_prefixLength - _prefixConsumed);
+                }
+                catch (NotSupportedException)
+                {
+                    return null;
+                }
+            }
+        }
+
+        public override bool CanSeek => _source.CanSeek;
+
+        protected override ReadOnlyMemory<byte> PeekCore(int byteCount)
+        {
+            EnsureBuffered(byteCount);
+            return _prefix.AsMemory(_prefixConsumed, Math.Min(byteCount, _prefixLength - _prefixConsumed));
+        }
+
+        // Buffers forward until the prefix holds `byteCount` unconsumed bytes or
+        // the source ends. Only the probe prefix is ever held this way.
+        private void EnsureBuffered(int byteCount)
+        {
+            int available = _prefixLength - _prefixConsumed;
+            if (available >= byteCount)
+                return;
+
+            int needed = byteCount - available;
+            if (_prefix.Length < _prefixLength + needed)
+                Array.Resize(ref _prefix, _prefixLength + needed);
+
+            while (needed > 0)
+            {
+                int read = _source.Read(_prefix, _prefixLength, needed);
+                if (read == 0)
+                    break;
+                _prefixLength += read;
+                needed -= read;
+            }
+        }
+
+        protected override Stream OpenStreamCore()
+        {
+            ReadOnlyMemory<byte> replay = _prefix.AsMemory(_prefixConsumed, _prefixLength - _prefixConsumed);
+            _prefixConsumed = _prefixLength;
+
+            if (_source.CanSeek && replay.Length > 0)
+            {
+                // A seekable source needs no replay buffer: rewinding past the
+                // probed bytes is cheaper and keeps one stream in play.
+                _source.Position -= replay.Length;
+                replay = ReadOnlyMemory<byte>.Empty;
+            }
+
+            return replay.Length == 0
+                ? new NonClosingStream(_source)
+                : new PrefixedStream(replay, _source);
+        }
+
+        protected override ReadOnlyMemory<byte> MaterializeCore(long maxBytes)
+        {
+            using Stream stream = OpenStreamCore();
+            var buffer = new MemoryStream();
+            byte[] chunk = ArrayPool<byte>.Shared.Rent(81920);
+            try
+            {
+                while (true)
+                {
+                    int read = stream.Read(chunk, 0, chunk.Length);
+                    if (read == 0)
+                        break;
+                    if (buffer.Length + read > maxBytes)
+                        throw TooLarge(maxBytes);
+                    buffer.Write(chunk, 0, read);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(chunk);
+            }
+
+            return buffer.ToArray();
+        }
+
+        protected override async ValueTask<ReadOnlyMemory<byte>> MaterializeAsyncCore(long maxBytes, CancellationToken cancellationToken)
+        {
+            using Stream stream = OpenStreamCore();
+            var buffer = new MemoryStream();
+            byte[] chunk = ArrayPool<byte>.Shared.Rent(81920);
+            try
+            {
+                while (true)
+                {
+                    int read = await stream.ReadAsync(chunk.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    if (read == 0)
+                        break;
+                    if (buffer.Length + read > maxBytes)
+                        throw TooLarge(maxBytes);
+                    await buffer.WriteAsync(chunk.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(chunk);
+            }
+
+            return buffer.ToArray();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_leaveOpen)
+                _source.Dispose();
+        }
+    }
+
+    /// <summary>A read-only stream over memory the caller owns.</summary>
+    private sealed class ReadOnlyMemoryStream : Stream
+    {
+        private readonly ReadOnlyMemory<byte> _bytes;
+        private int _position;
+
+        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> bytes) => _bytes = bytes;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _bytes.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set => _position = (int)Math.Clamp(value, 0, _bytes.Length);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            int available = Math.Min(buffer.Length, _bytes.Length - _position);
+            if (available <= 0)
+                return 0;
+            _bytes.Span.Slice(_position, available).CopyTo(buffer);
+            _position += available;
+            return available;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long target = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                _ => _bytes.Length + offset,
+            };
+            Position = target;
+            return _position;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>The buffered probe prefix followed by the remaining source.</summary>
+    private sealed class PrefixedStream : Stream
+    {
+        private readonly ReadOnlyMemory<byte> _prefix;
+        private readonly Stream _source;
+        private int _prefixPosition;
+
+        public PrefixedStream(ReadOnlyMemory<byte> prefix, Stream source)
+        {
+            _prefix = prefix;
+            _source = source;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (_prefixPosition < _prefix.Length)
+            {
+                int available = Math.Min(buffer.Length, _prefix.Length - _prefixPosition);
+                _prefix.Span.Slice(_prefixPosition, available).CopyTo(buffer);
+                _prefixPosition += available;
+                return available;
+            }
+
+            return _source.Read(buffer);
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_prefixPosition < _prefix.Length)
+            {
+                int available = Math.Min(buffer.Length, _prefix.Length - _prefixPosition);
+                _prefix.Slice(_prefixPosition, available).CopyTo(buffer);
+                _prefixPosition += available;
+                return available;
+            }
+
+            return await _source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>Wraps a stream so the caller's stream survives the reader disposing it.</summary>
+    private sealed class NonClosingStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonClosingStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+
+        public override void Flush() => _inner.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/Broiler.Documents/Broiler.Documents/DocumentReadOptions.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentReadOptions.cs
@@ -9,7 +9,7 @@ namespace Broiler.Documents;
 /// </summary>
 /// <remarks>
 /// The type is open for derivation so a codec can carry its own immutable option
-/// object through the shared <see cref="DocumentCodec.Read"/> signature. Only
+/// object through the shared <see cref="DocumentCodec.Read(System.IO.Stream, DocumentReadOptions)"/> signature. Only
 /// behavior genuinely shared by several codecs belongs here; a codec validates
 /// the concrete option type it was handed rather than downcasting opportunistically
 /// (PDF roadmap §6.1).
@@ -36,13 +36,36 @@ public class DocumentReadOptions
 
     public DocumentLimits Limits { get; }
 
-    /// <summary>Fallback code page for <c>\'hh</c> bytes when the document declares none.</summary>
+    /// <summary>
+    /// Fallback code page for <c>\'hh</c> bytes when the document declares none.
+    /// </summary>
+    /// <remarks>
+    /// Consumed by the RTF codec only; every other codec ignores it. New callers
+    /// should set it through <c>RtfReadOptions</c>, which is where it belongs —
+    /// it stays here because moving the storage would break existing callers
+    /// without changing any behavior.
+    /// </remarks>
     public int DefaultCodePage { get; }
 
     /// <summary>
-    /// When true, a codec may decode embedded images through a delegated image
-    /// codec (still limit-bounded). Off by default; embedded OLE objects are
-    /// never instantiated regardless (ADR 0004).
+    /// Asks a codec to decode embedded images through a delegated image codec.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>No codec in this release acts on it.</b> The RTF reader skips
+    /// <c>\pict</c> and object destinations whichever way it is set, and the PDF
+    /// codec composes no image decoder at all. A codec that is asked for it and
+    /// cannot provide it emits
+    /// <see cref="DocumentDiagnosticCodes.CapabilityNotComposed"/>, so a caller
+    /// that expected images finds out rather than receiving a document silently
+    /// missing them.
+    /// </para>
+    /// <para>
+    /// The setting is kept, rather than removed, because the eventual
+    /// caller-composed image path is a planned capability with a designed shape:
+    /// bounded, delegated, and explicitly permitted. Embedded OLE objects are
+    /// never instantiated regardless of this value (ADR 0004).
+    /// </para>
+    /// </remarks>
     public bool DecodeEmbeddedObjects { get; }
 }

--- a/Broiler.Documents/Broiler.Documents/DocumentReadResult.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentReadResult.cs
@@ -7,33 +7,97 @@ using Broiler.Documents.Model;
 namespace Broiler.Documents;
 
 /// <summary>
-/// The outcome of reading a document: a best-effort <see cref="RichTextDocument"/>
-/// plus any diagnostics. Reads do not throw on malformed-but-recoverable input
-/// (ADR 0003/0004); unsupported or skipped constructs surface as diagnostics.
+/// The outcome of reading a document: a best-effort <see cref="RichTextDocument"/>,
+/// a <see cref="Status"/> saying whether a host may use it, and any diagnostics.
+/// Reads do not throw on malformed-but-recoverable input (ADR 0003/0004);
+/// unsupported or skipped constructs surface as diagnostics.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Open for derivation so a codec can return the same result through the shared
-/// <see cref="DocumentCodec.Read"/> signature while adding format-specific detail
-/// (<c>PdfReadResult</c> adds a success/partial/rejected status, page count, and
-/// normalized metadata). Format-specific state never moves into this base until a
-/// second non-PDF consumer exists (PDF roadmap §3 containment rule).
+/// <see cref="DocumentCodec.Read(System.IO.Stream, DocumentReadOptions)"/> signature while adding format-specific detail
+/// (<c>PdfReadResult</c> adds the page count, declared version, and normalized
+/// metadata). Format-specific state never moves into this base until a second
+/// consumer exists (PDF roadmap §3 containment rule).
+/// </para>
+/// <para>
+/// <see cref="Status"/> is the load-bearing field, not <see cref="HasErrors"/>:
+/// a document can carry warnings and still be complete, and it can carry none and
+/// still be missing a page.
+/// </para>
 /// </remarks>
 public class DocumentReadResult
 {
-    public DocumentReadResult(RichTextDocument document, IEnumerable<DocumentDiagnostic>? diagnostics = null)
+    private static readonly ReadOnlyCollection<DocumentDiagnostic> EmptyDiagnostics =
+        Array.AsReadOnly(Array.Empty<DocumentDiagnostic>());
+
+    public DocumentReadResult(
+        RichTextDocument document,
+        IEnumerable<DocumentDiagnostic>? diagnostics = null,
+        DocumentResultStatus status = DocumentResultStatus.Success)
     {
         Document = document ?? throw new ArgumentNullException(nameof(document));
         Diagnostics = diagnostics is null
             ? EmptyDiagnostics
             : Array.AsReadOnly(diagnostics.ToArray());
+        Status = status;
     }
-
-    private static readonly ReadOnlyCollection<DocumentDiagnostic> EmptyDiagnostics =
-        Array.AsReadOnly(Array.Empty<DocumentDiagnostic>());
 
     public RichTextDocument Document { get; }
 
     public IReadOnlyList<DocumentDiagnostic> Diagnostics { get; }
 
+    /// <summary>Whether a host may use <see cref="Document"/>, and on what terms.</summary>
+    public DocumentResultStatus Status { get; }
+
+    /// <summary>True when a host may present the document at all.</summary>
+    public bool IsUsable => Status != DocumentResultStatus.Rejected;
+
     public bool HasErrors => Diagnostics.Any(static d => d.Severity == DocumentDiagnosticSeverity.Error);
+
+    /// <summary>
+    /// Derives a status from diagnostics, for a read that <em>did</em> produce a
+    /// document.
+    /// </summary>
+    /// <remarks>
+    /// Anything above informational means content was skipped, clamped, or
+    /// recovered, which is exactly what <see cref="DocumentResultStatus.Partial"/>
+    /// tells a host to ask about before committing. It never returns
+    /// <see cref="DocumentResultStatus.Rejected"/>: that is a statement about
+    /// there being no usable document at all, which only the caller with the
+    /// document in hand can make.
+    /// </remarks>
+    public static DocumentResultStatus StatusFrom(IEnumerable<DocumentDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        foreach (DocumentDiagnostic diagnostic in diagnostics)
+        {
+            if (diagnostic.Severity != DocumentDiagnosticSeverity.Info)
+                return DocumentResultStatus.Partial;
+        }
+
+        return DocumentResultStatus.Success;
+    }
+
+    /// <summary>
+    /// A rejection carrying one diagnostic and an empty document. Used for the
+    /// failures that are decided before, or instead of, parsing — invalid
+    /// options, an oversized source, cancellation.
+    /// </summary>
+    public static DocumentReadResult Rejected(string code, string message) =>
+        new(
+            RichTextDocument.Empty,
+            [DocumentDiagnostic.Error(code, message)],
+            DocumentResultStatus.Rejected);
+
+    /// <summary>
+    /// The rejection a codec returns when it was handed options of the wrong
+    /// type. It names both types so the caller can see what it passed.
+    /// </summary>
+    public static DocumentReadResult InvalidOptions(string codecName, Type expected, Type actual) =>
+        Rejected(
+            DocumentDiagnosticCodes.OptionsInvalid,
+            $"The {codecName} codec requires {expected.Name} but was given {actual.Name}. " +
+            "Options of the wrong type are rejected rather than ignored, because silently " +
+            "falling back to defaults would apply settings the caller did not choose.");
 }

--- a/Broiler.Documents/Broiler.Documents/DocumentRequests.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentRequests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Threading;
+using Broiler.Documents.Model;
+
+namespace Broiler.Documents;
+
+/// <summary>
+/// Everything a codec needs to read one document: where the bytes come from,
+/// which options apply, and how to stop.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cross-format values live here and nowhere else. Limits and cancellation are
+/// the request's, not the format options'; a format option object that tried to
+/// carry its own copy would create a precedence question with no good answer, so
+/// the contract is one owner rather than a rule about which copy wins
+/// (PDF roadmap §6.1).
+/// </para>
+/// <para>
+/// The request does not own <see cref="Input"/>. Whoever created the input
+/// disposes it, which keeps a request cheap to build, pass, and discard.
+/// </para>
+/// </remarks>
+public sealed class DocumentReadRequest
+{
+    public DocumentReadRequest(
+        DocumentInput input,
+        DocumentReadOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Input = input ?? throw new ArgumentNullException(nameof(input));
+        Options = options ?? DocumentReadOptions.Default;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>The source, probed and read through the same replayable input.</summary>
+    public DocumentInput Input { get; }
+
+    /// <summary>
+    /// The options. A codec that needs its own option type validates this before
+    /// touching the input and rejects a mismatch rather than downcasting
+    /// opportunistically.
+    /// </summary>
+    public DocumentReadOptions Options { get; }
+
+    /// <summary>The limits in force, taken from the options.</summary>
+    public DocumentLimits Limits => Options.Limits;
+
+    public CancellationToken CancellationToken { get; }
+
+    /// <summary>Builds a request over a stream the caller keeps.</summary>
+    public static DocumentReadRequest FromStream(
+        Stream source,
+        DocumentReadOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(DocumentInput.FromStream(source), options, cancellationToken);
+
+    /// <summary>Builds a request over bytes the caller already holds.</summary>
+    public static DocumentReadRequest FromBytes(
+        ReadOnlyMemory<byte> bytes,
+        DocumentReadOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(DocumentInput.FromBytes(bytes), options, cancellationToken);
+}
+
+/// <summary>
+/// Everything a codec needs to write one document: the content, the destination,
+/// which options apply, and how to stop.
+/// </summary>
+/// <remarks>
+/// The destination is the caller's stream and stays the caller's: a codec neither
+/// closes it nor rewinds it. When a write stops after bytes have already reached
+/// an unstaged stream, the result says so through
+/// <see cref="DocumentDestinationState.PartialDestination"/> rather than
+/// pretending the destination is clean.
+/// </remarks>
+public sealed class DocumentWriteRequest
+{
+    public DocumentWriteRequest(
+        RichTextDocument document,
+        Stream destination,
+        DocumentWriteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Document = document ?? throw new ArgumentNullException(nameof(document));
+        Destination = destination ?? throw new ArgumentNullException(nameof(destination));
+        if (!destination.CanWrite)
+            throw new ArgumentException("A document destination needs a writable stream.", nameof(destination));
+
+        Options = options ?? DocumentWriteOptions.Default;
+        CancellationToken = cancellationToken;
+    }
+
+    public RichTextDocument Document { get; }
+
+    /// <summary>The destination, owned by the caller.</summary>
+    public Stream Destination { get; }
+
+    public DocumentWriteOptions Options { get; }
+
+    public CancellationToken CancellationToken { get; }
+}

--- a/Broiler.Documents/Broiler.Documents/DocumentResultStatus.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentResultStatus.cs
@@ -1,0 +1,64 @@
+namespace Broiler.Documents;
+
+/// <summary>
+/// Whether an operation produced a usable result, independently of whether it
+/// produced diagnostics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Severity and status answer different questions, and conflating them is how a
+/// host ends up either refusing perfectly good documents or silently accepting
+/// gutted ones. A read can carry a dozen warnings and still be a complete
+/// rendering of the format's supported subset (<see cref="Success"/>); another
+/// can carry a single warning that means a page was dropped
+/// (<see cref="Partial"/>). Hosts branch on this, never on a diagnostic count or
+/// on <see cref="DocumentReadResult.HasErrors"/>.
+/// </para>
+/// <para>
+/// CLI exit codes, host prompts, batch continuation, and telemetry all derive
+/// from this value (ADR 0008).
+/// </para>
+/// </remarks>
+public enum DocumentResultStatus
+{
+    /// <summary>
+    /// The format's declared supported subset was processed and the result is
+    /// usable under the documented contract.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// A usable result exists, but named content or features were skipped or
+    /// remain uncertain. A host must obtain explicit caller approval before
+    /// replacing an open document with it or publishing it as output.
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// No usable result exists, and no host may accept one. The accompanying
+    /// document or output is a placeholder, not content.
+    /// </summary>
+    Rejected,
+}
+
+/// <summary>How far a write got before it stopped.</summary>
+/// <remarks>
+/// The commit point is the atomic file replace, the publication of a complete
+/// output buffer, or the first byte written to an unstaged caller-owned stream —
+/// whichever the destination uses. <see cref="DocumentResultStatus.Success"/>
+/// requires <see cref="Committed"/>.
+/// </remarks>
+public enum DocumentDestinationState
+{
+    /// <summary>Nothing was written; the destination is untouched.</summary>
+    NotStarted,
+
+    /// <summary>The complete output reached the destination.</summary>
+    Committed,
+
+    /// <summary>
+    /// Bytes reached a caller-owned stream and then the write stopped. The prefix
+    /// is not a valid document and discarding it is the caller's responsibility.
+    /// </summary>
+    PartialDestination,
+}

--- a/Broiler.Documents/Broiler.Documents/DocumentWriteOptions.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentWriteOptions.cs
@@ -7,7 +7,7 @@ namespace Broiler.Documents;
 /// <remarks>
 /// Open for derivation for the same reason as <see cref="DocumentReadOptions"/>:
 /// a codec carries its own immutable options through the shared
-/// <see cref="DocumentCodec.Write"/> signature (PDF roadmap §6.1).
+/// <see cref="DocumentCodec.Write(Model.RichTextDocument, System.IO.Stream, DocumentWriteOptions)"/> signature (PDF roadmap §6.1).
 /// </remarks>
 public class DocumentWriteOptions
 {
@@ -23,5 +23,10 @@ public class DocumentWriteOptions
     /// representation (for RTF, <c>\uN</c> with an ASCII fallback char) rather
     /// than emitted as raw bytes.
     /// </summary>
+    /// <remarks>
+    /// True is the only value the RTF writer implements, and the other codecs do
+    /// not consult it at all. A writer asked for the unimplemented value reports
+    /// it rather than quietly doing the opposite; see <c>RtfWriteOptions</c>.
+    /// </remarks>
     public bool AsciiOnly { get; }
 }

--- a/Broiler.Documents/Broiler.Documents/DocumentWriteResult.cs
+++ b/Broiler.Documents/Broiler.Documents/DocumentWriteResult.cs
@@ -6,17 +6,24 @@ using System.Linq;
 namespace Broiler.Documents;
 
 /// <summary>
-/// The outcome of writing a document: the number of bytes written to the
-/// destination plus any diagnostics (styles or constructs that could not be
+/// The outcome of writing a document: the number of bytes written, how far the
+/// destination got, and any diagnostics (styles or constructs that could not be
 /// represented in the target format).
 /// </summary>
 /// <remarks>
 /// Open for derivation for the same reason as <see cref="DocumentReadResult"/>;
-/// <c>PdfWriteResult</c> adds the result status and the destination commit state.
+/// <c>PdfWriteResult</c> adds the page count.
 /// </remarks>
 public class DocumentWriteResult
 {
-    public DocumentWriteResult(long bytesWritten, IEnumerable<DocumentDiagnostic>? diagnostics = null)
+    private static readonly ReadOnlyCollection<DocumentDiagnostic> EmptyDiagnostics =
+        Array.AsReadOnly(Array.Empty<DocumentDiagnostic>());
+
+    public DocumentWriteResult(
+        long bytesWritten,
+        IEnumerable<DocumentDiagnostic>? diagnostics = null,
+        DocumentResultStatus status = DocumentResultStatus.Success,
+        DocumentDestinationState destinationState = DocumentDestinationState.Committed)
     {
         if (bytesWritten < 0)
             throw new ArgumentOutOfRangeException(nameof(bytesWritten));
@@ -25,12 +32,55 @@ public class DocumentWriteResult
         Diagnostics = diagnostics is null
             ? EmptyDiagnostics
             : Array.AsReadOnly(diagnostics.ToArray());
+        Status = status;
+        DestinationState = destinationState;
     }
-
-    private static readonly ReadOnlyCollection<DocumentDiagnostic> EmptyDiagnostics =
-        Array.AsReadOnly(Array.Empty<DocumentDiagnostic>());
 
     public long BytesWritten { get; }
 
     public IReadOnlyList<DocumentDiagnostic> Diagnostics { get; }
+
+    public DocumentResultStatus Status { get; }
+
+    /// <summary>
+    /// How far the destination got. <see cref="DocumentResultStatus.Success"/>
+    /// requires <see cref="DocumentDestinationState.Committed"/>; a rejection
+    /// paired with <see cref="DocumentDestinationState.PartialDestination"/> tells
+    /// a caller-owned stream that an unusable prefix needs discarding.
+    /// </summary>
+    public DocumentDestinationState DestinationState { get; }
+
+    public bool HasErrors => Diagnostics.Any(static d => d.Severity == DocumentDiagnosticSeverity.Error);
+
+    /// <summary>
+    /// Derives a status from diagnostics, for a write that reached the
+    /// destination. See <see cref="DocumentReadResult.StatusFrom"/>.
+    /// </summary>
+    public static DocumentResultStatus StatusFrom(IEnumerable<DocumentDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        foreach (DocumentDiagnostic diagnostic in diagnostics)
+        {
+            if (diagnostic.Severity != DocumentDiagnosticSeverity.Info)
+                return DocumentResultStatus.Partial;
+        }
+
+        return DocumentResultStatus.Success;
+    }
+
+    /// <summary>A rejection that never touched the destination.</summary>
+    public static DocumentWriteResult Rejected(string code, string message) =>
+        new(
+            0,
+            [DocumentDiagnostic.Error(code, message)],
+            DocumentResultStatus.Rejected,
+            DocumentDestinationState.NotStarted);
+
+    /// <summary>The write-side counterpart of <see cref="DocumentReadResult.InvalidOptions"/>.</summary>
+    public static DocumentWriteResult InvalidOptions(string codecName, Type expected, Type actual) =>
+        Rejected(
+            DocumentDiagnosticCodes.OptionsInvalid,
+            $"The {codecName} codec requires {expected.Name} but was given {actual.Name}. " +
+            "Options of the wrong type are rejected rather than ignored, because silently " +
+            "falling back to defaults would apply settings the caller did not choose.");
 }

--- a/Broiler.Documents/README.md
+++ b/Broiler.Documents/README.md
@@ -57,6 +57,9 @@ Matching headless test projects live beside each runtime project.
 - [Markdown conformance](docs/markdown-conformance.md)
 - [PDF feature matrix](docs/pdf-feature-matrix.md) - the authority for what the
   PDF codec does today and what it may be described as.
+- [PDF construct inventory](docs/pdf-construct-inventory.md) - exactly which PDF
+  constructs the codec reads, writes, recognizes without interpreting, and
+  rejects, derived from the implementation.
 - [Formatting Codes grammar version 1](Broiler.Documents.FormatCodes/GRAMMAR.md)
 
 ## Records

--- a/Broiler.Documents/docs/pdf-construct-inventory.md
+++ b/Broiler.Documents/docs/pdf-construct-inventory.md
@@ -1,0 +1,196 @@
+# PDF Construct Inventory
+
+- **Status:** Active; regenerated whenever the codec's behavior changes
+- **Component:** `Broiler.Documents.Pdf`
+- **Updated:** 2026-08-25
+- **Purpose:** to scope the IP-001 qualified review by stating exactly which PDF
+  constructs the implementation reads, writes, recognizes without interpreting,
+  and rejects
+
+## 1. What this document is for
+
+The IP/licensing register's IP-001 row asks a qualified reviewer to determine
+whether Broiler's reader and writer fall within Adobe's ISO 32000-1 public
+patent licence — a question about *`Compliant Implementation`* and *`Essential
+Claim`* coverage, and therefore a question about a concrete artifact rather than
+an intention. Before the base slice was implemented that question had no
+definite subject. It now does, and this inventory is that subject written down.
+
+A reviewer should be able to work from this document alone to answer "what does
+this implementation actually do with the format?" without reading the code, and
+to spot-check any row against the named source file when they want to.
+
+**This is not a conformance claim.** It states behavior, not compliance. No entry
+here promotes anything in the [feature matrix](pdf-feature-matrix.md), which
+remains the sole authority on what Broiler may be *described* as supporting, and
+nothing here is `Supported` while its register row is pending.
+
+## 2. Provenance and the clause column
+
+Every behavioral row was derived from the implementation, not from memory or from
+any other PDF library: the operator list is the interpreter's dispatch switch,
+the key list is the set of dictionary keys the code actually consults, and the
+writer list is the set of names the serializer actually emits. The
+"Where" column names the file so a reviewer can verify any row directly.
+
+> **The clause column is provisional and must be verified against the licensed
+> standard text.** Lawful standards access for implementers is still an open
+> Phase 0 exit item ([status record](pdf-phase0-status.md)), so these references
+> are a best-effort starting point offered to save the reviewer time — they are
+> not themselves evidence, and a mismatch between this column and the standard
+> means this column is wrong. Consistent with the roadmap's standards-source
+> rule, clauses are cited and no standard prose, table, or diagram is reproduced
+> here.
+
+## 3. Reader — constructs interpreted
+
+These are the constructs the codec parses and acts on. This is the set the
+IP-001 determination has to cover on the reading side.
+
+| Construct | Clause (provisional) | Behavior | Where |
+|---|---|---|---|
+| Lexical conventions: whitespace, delimiters, `%` comments | 7.2 | Tokenized | `Syntax/PdfLexer.cs` |
+| Boolean, numeric, name (`#xx` escapes), null objects | 7.3.2, 7.3.3, 7.3.5, 7.3.9 | Parsed | `Syntax/PdfLexer.cs`, `Syntax/PdfObjectParser.cs` |
+| String objects, literal and hexadecimal forms | 7.3.4 | Parsed, escapes resolved; kept as bytes, not text | `Syntax/PdfLexer.cs` |
+| Array and dictionary objects | 7.3.6, 7.3.7 | Parsed on an explicit stack, depth- and entry-bounded | `Syntax/PdfObjectParser.cs` |
+| Stream objects and stream extent | 7.3.8 | Parsed; `/Length` honoured, with a bounded `endstream` search when it disagrees | `Structure/PdfObjectStore.cs` |
+| Indirect objects and references | 7.3.10 | Parsed; resolved lazily with cycle detection | `Syntax/PdfObjectParser.cs`, `Structure/PdfObjectStore.cs` |
+| `ASCIIHexDecode` | 7.4.2 | Decoded | `Filters/BuiltInFilters.cs` |
+| `ASCII85Decode` | 7.4.3 | Decoded | `Filters/BuiltInFilters.cs` |
+| `FlateDecode` | 7.4.4 | Decoded via the .NET runtime's DEFLATE (IP-023) | `Filters/BuiltInFilters.cs` |
+| PNG and TIFF predictors | 7.4.4.4 | Reversed | `Filters/PdfPredictor.cs` |
+| `RunLengthDecode` | 7.4.5 | Decoded | `Filters/BuiltInFilters.cs` |
+| Chained filters and `DecodeParms` | 7.4.1 | Applied in order, per-stage and aggregate budgets | `Filters/PdfFilterPipeline.cs` |
+| File header, including a header not at byte zero | 7.5.2 | Located; version parsed | `Structure/PdfObjectStore.cs` |
+| Classic cross-reference table and subsections | 7.5.4 | Parsed; free entries skipped | `Structure/PdfObjectStore.cs` |
+| File trailer, `startxref`, `/Root`, `/Size`, `/Info` | 7.5.5 | Parsed; trailers merged newest-first | `Structure/PdfObjectStore.cs` |
+| Incremental updates via `/Prev` | 7.5.6 | Chain walked newest-first; latest revision wins by construction | `Structure/PdfObjectStore.cs` |
+| Object streams (`/Type /ObjStm`) | 7.5.7 | Members resolved through the production filter pipeline | `Structure/PdfObjectStore.cs` |
+| Cross-reference streams (`/Type /XRef`), `/W`, `/Index` | 7.5.8 | Parsed; entry types 1 and 2 honoured | `Structure/PdfObjectStore.cs` |
+| Hybrid-reference files (`/XRefStm`) | 7.5.8 | Companion stream loaded ahead of its classic section | `Structure/PdfObjectStore.cs` |
+| Document catalog, `/Pages`, `/Lang`, `/Version` | 7.7.2 | Read | `PdfReader.cs`, `Structure/PdfVersion.cs` |
+| Page tree, `/Kids`, `/Count`, leaf detection | 7.7.3 | Walked iteratively with a visited set | `Structure/PdfPageTree.cs` |
+| Inherited page attributes: `/Resources`, `/MediaBox`, `/CropBox`, `/Rotate` | 7.7.3 | Inherited down the tree; `/UserUnit` carried | `Structure/PdfPageTree.cs` |
+| Extensions dictionary: prefix, `/BaseVersion`, `/ExtensionLevel` | 7.12 | Inventoried for diagnostics only; never enables behavior | `Structure/PdfVersion.cs` |
+| Content streams, single and as an array | 7.8.2 | Decoded and concatenated | `Text/PdfContentInterpreter.cs` |
+| Resource dictionaries: `/Font`, `/XObject`, `/Properties` | 7.8.3 | Resolved lazily | `Text/PdfContentInterpreter.cs` |
+| Text string types and the UTF-16 byte-order mark | 7.9.2 | Decoded; PDFDocEncoding otherwise | `Structure/PdfMetadataReader.cs` |
+| Date strings `D:YYYYMMDDHHmmSSOHH'mm'` | 7.9.4 | Parsed; a zone-less value keeps its missing offset | `Structure/PdfMetadataReader.cs` |
+| Graphics state: `q`, `Q`, `cm` | 8.4 | Interpreted; state stack bounded | `Text/PdfContentInterpreter.cs` |
+| Device colour operators: `g`, `rg`, `k`, `sc`, `scn`, `cs` | 8.6 | Interpreted; CMYK converted by the format's device relationship, with no colour-management claim | `Text/PdfContentInterpreter.cs` |
+| Form XObjects (`Do` on `/Subtype /Form`), `/Matrix`, `/Resources` | 8.10 | Executed under bounded recursion and a visited set | `Text/PdfContentInterpreter.cs` |
+| Text objects `BT`/`ET` | 9.4.1 | Interpreted | `Text/PdfContentInterpreter.cs` |
+| Text state: `Tf`, `Tc`, `Tw`, `Tz`, `TL`, `Ts`, `Tr` | 9.3 | Interpreted | `Text/PdfContentInterpreter.cs` |
+| Text positioning: `Td`, `TD`, `Tm`, `T*` | 9.4.2 | Interpreted | `Text/PdfContentInterpreter.cs` |
+| Text showing: `Tj`, `TJ`, `'`, `"` | 9.4.3 | Interpreted, including `TJ` numeric adjustments | `Text/PdfContentInterpreter.cs` |
+| Simple font dictionaries: `/BaseFont`, `/FirstChar`, `/Widths`, `/FontDescriptor` | 9.6 | Read | `Text/PdfFont.cs` |
+| Character encoding: `/Encoding` name or dictionary, `/BaseEncoding`, `/Differences` | 9.6.6 | Applied | `Text/PdfFont.cs`, `Text/PdfEncodings.cs` |
+| Standard, WinAnsi, MacRoman encodings | Annex D | Applied from Broiler-authored tables (IP-021) | `Text/PdfEncodings.cs` |
+| Font subset name prefixes | 9.6 | Stripped structurally, not by guessing at the family name | `Text/PdfFont.cs` |
+| Composite fonts: `/Type0`, `/DescendantFonts`, `/DW`, `/W`, `Identity-H`, `Identity-V` | 9.7 | Read | `Text/PdfFont.cs` |
+| Font descriptors: `/Flags`, `/ItalicAngle`, `/StemV`, `/FontWeight`, `/MissingWidth` | 9.8 | Read for weight and slant only | `Text/PdfFont.cs` |
+| `ToUnicode` CMaps: codespace ranges, `bfchar`, `bfrange`, bounded `usecmap` | 9.10.3 | Parsed; the preferred mapping route | `Text/PdfCMap.cs` |
+| Marked content `BDC`/`EMC` and `/ActualText` | 14.6, 14.9.4 | `ActualText` replaces the glyphs it encloses | `Text/PdfContentInterpreter.cs` |
+| Annotation dictionaries, `/Subtype /Link`, `/Rect` | 12.5.6.5 | Read | `Text/PdfLinkRegion.cs` |
+| URI actions (`/A` with `/S /URI`) | 12.6.4.7 | Admitted by the URI policy, then projected as a link | `Text/PdfLinkRegion.cs`, `PdfUriPolicy.cs` |
+| Document information dictionary | 14.3.3 | Projected to the normalized allowlist only | `Structure/PdfMetadataReader.cs` |
+
+**Recovery behavior.** When the declared cross-reference data cannot produce a
+catalog, the reader rebuilds the object map by scanning for `n g obj` headers and
+reports it (`pdf.xref.recovered`). This is the only recovery path, it never runs
+speculatively mid-parse, and it interprets no construct the table above omits.
+
+## 4. Reader — recognized but not interpreted
+
+These constructs are identified so the reader can name what it declined. **No
+data of these kinds is decoded, executed, fetched, or projected**, which is the
+distinction that matters for the register rows they belong to.
+
+| Construct | Clause (provisional) | Diagnostic | Register row |
+|---|---|---|---|
+| `LZWDecode` | 7.4.4 | `pdf.filter.lzw.unsupported` | IP-010 |
+| `CCITTFaxDecode` | 7.4.6 | `pdf.filter.ccitt.unsupported` | IP-009 |
+| `JBIG2Decode` | 7.4.7 | `pdf.filter.jbig2.unsupported` | IP-008 |
+| `DCTDecode` | 7.4.8 | `pdf.image.dct.tuple-unsupported` | IP-005, IP-006 |
+| `JPXDecode` | 7.4.9 | `pdf.filter.jpx.unsupported` | IP-007 |
+| `Crypt` filter | 7.4.10 | `pdf.filter.crypt.unsupported` | IP-015 |
+| Image XObjects and inline images (`BI`/`ID`/`EI`) | 8.9 | `pdf.image.not-composed` | IP-005 |
+| Embedded font programs (`/FontFile`, `/FontFile2`, `/FontFile3`) | 9.8 | `pdf.font.program-not-composed` | IP-012 |
+| Type 3 fonts | 9.6.4 | `pdf.font.type3-unsupported` | — |
+| `MacExpertEncoding` and symbolic built-in encodings | Annex D | `pdf.text.mapping-missing-or-uncertain` | IP-013 |
+| Predefined CMaps other than the Identity pair | 9.7.5 | `pdf.text.mapping-missing-or-uncertain` | IP-013 |
+| Metadata streams (XMP) | 14.3.2 | `document.metadata.raw-dropped` | IP-004 |
+| Path painting and shading operators | 8.5, 8.7 | `pdf.import.vector-artwork-dropped` | — |
+| JavaScript, Launch, GoToR, SubmitForm, ImportData actions | 12.6.4 | `pdf.active-content.removed` | — |
+| Embedded files, screen, movie, rich media, 3D annotations | 12.5.6, 7.11 | `pdf.active-content.removed` | — |
+| AcroForm `/SigFlags`, signature fields | 12.7, 12.8 | `pdf.signature.not-validated` | IP-016 |
+| Structure tree (`/StructTreeRoot`), tagged PDF | 14.7, 14.8 | Reported; structure not consumed | IP-017 |
+| Optional content, artifacts, invisible and clipping render modes | 8.11, 9.3.6 | `pdf.text.visibility-uncertain`; extracted without a visibility claim | — |
+| Unapplied `/Redact` annotations | 12.5.6 | `pdf.redaction.not-applied` (error severity) | — |
+| PDF 2.x version declarations | 7.5.2, 7.7.2 | `pdf.version.tolerated-not-supported` | IP-002 |
+| Developer extension declarations | 7.12 | `pdf.extension.unsupported` | IP-003 |
+
+## 5. Reader — constructs that reject the document
+
+| Construct | Clause (provisional) | Behavior |
+|---|---|---|
+| `/Encrypt` in any effective trailer or cross-reference stream dictionary | 7.6 | The document is rejected with `pdf.encryption.unsupported` **before any object stream, catalog, metadata, font, image, annotation, or content is resolved**. No decrypt-dependent object is ever interpreted, and no password or document content reaches a diagnostic. |
+
+## 6. Writer — constructs emitted
+
+The writer creates new files only. It never rewrites an input, saves
+incrementally, or carries a source document's objects, fonts, images,
+identifiers, or raw metadata forward.
+
+| Construct | Clause (provisional) | Emitted |
+|---|---|---|
+| `%PDF-1.7` header and binary comment | 7.5.2 | Always |
+| Indirect objects, dictionaries, arrays, names, numbers, literal strings | 7.3 | Always |
+| Stream objects with `/Length` | 7.3.8 | Content streams |
+| `FlateDecode` on content streams | 7.4.4 | By default; disableable |
+| Classic cross-reference table, trailer, `startxref`, `%%EOF` | 7.5.4, 7.5.5 | Always |
+| Trailer `/Size`, `/Root`, `/Info`, `/ID` | 7.5.5 | `/Info` only when the caller supplies metadata; `/ID` derived from content when not caller-set |
+| Document catalog, `/Lang` | 7.7.2 | `/Lang` only when supplied |
+| Page tree, page objects, `/MediaBox`, `/Parent`, `/Count` | 7.7.3 | Always |
+| Resource dictionary with `/Font` | 7.8.3 | Always |
+| Text objects, `Tf`, `Tm`, `Tj` | 9.3, 9.4 | Always |
+| Simple `/Type1` fonts by standard base name with `/Encoding /WinAnsiEncoding` | 9.6.2, 9.6.6 | Always; **no font program is ever embedded** |
+| Device RGB fill (`rg`) and filled rectangles (`re f`) | 8.5.3, 8.6.3 | Colour, highlights, underline and strikethrough |
+| Link annotations with `/A`, `/S /URI`, `/Border` | 12.5.6.5, 12.6.4.7 | Only for targets the URI policy re-admits at emission time |
+| Document information dictionary | 14.3.3 | Only the normalized allowlist the caller supplied |
+| Date strings | 7.9.4 | A zone-less value is written back without a zone |
+
+**Never emitted:** embedded or subset font programs, composite/Type 0 fonts,
+`ToUnicode` maps, raster images of any kind, any filter other than
+`FlateDecode`, encryption, incremental updates, linearization, `/Alt`, a
+structure tree, tagged semantics, XMP, or any profile conformance identifier.
+
+## 7. Inputs relied on that are not ISO 32000-1
+
+| Dependency | Use | Register row |
+|---|---|---|
+| The .NET runtime's DEFLATE/zlib implementation | `FlateDecode` and content-stream compression | IP-023, under IP-011 |
+| Unicode character identities | The authored encoding tables and glyph-name repertoire | IP-013, IP-021 |
+| RFC 3986 URI grammar | Link admission on read and write; no copied test vectors | IP-014 |
+| Broiler-authored letterform proportions | Writer line breaking; not any vendor's metrics | IP-022 |
+
+## 8. Questions this inventory puts to the reviewer
+
+1. Does the read set in §3 constitute a `Compliant Implementation` for the
+   purposes of the Adobe ISO 32000-1 public patent licence, and does that licence
+   reach it? If coverage is partial, which rows fall outside?
+2. Does the write set in §6 — a strict subset of §3's constructs — raise any
+   question §3 does not?
+3. Does the recognize-without-interpreting posture in §4 carry any exposure of
+   its own? The codec identifies these constructs by name in order to decline
+   them; it decodes nothing.
+4. Do the four non-ISO dependencies in §7 close as source/licence reviews, and
+   does IP-023 satisfy IP-011's implementation-provenance requirement?
+
+## 9. Keeping this true
+
+This document describes behavior, so it goes stale the moment behavior changes.
+Any change that adds, removes, or moves a construct between §3, §4, §5, and §6
+updates this file in the same commit, and any change that moves one *into* §3 or
+§6 must first clear its register row per
+[PDF extension points §5](pdf-extension-points.md#5-adding-a-technology-step-by-step).

--- a/Broiler.Documents/docs/pdf-extension-points.md
+++ b/Broiler.Documents/docs/pdf-extension-points.md
@@ -4,6 +4,7 @@
 - **Component:** `Broiler.Documents.Pdf`
 - **Updated:** 2026-08-25
 - **Companion documents:** [PDF support roadmap](pdf-support-roadmap.md),
+  [construct inventory](pdf-construct-inventory.md),
   [feature matrix](pdf-feature-matrix.md),
   [IP/licensing register](pdf-ip-licensing-register.md),
   [approved-source record](pdf-approved-sources.md)

--- a/Broiler.Documents/docs/pdf-phase0-status.md
+++ b/Broiler.Documents/docs/pdf-phase0-status.md
@@ -57,6 +57,7 @@ row clears.
 | 2026-08-25 | `dotnet test Broiler.Documents/Broiler.Documents.slnx -c Release` | Passed: 504 tests across nine projects; 0 failed, 0 skipped |
 | 2026-08-25 | `dotnet build Broiler.Documents/Broiler.Documents.Pdf/Broiler.Documents.Pdf.csproj -c Release` | Passed with 0 errors and 0 warnings under `TreatWarningsAsErrors` |
 | 2026-08-25 | Delivery guards: package is unpacked, references only Documents projects, is absent from every `src/` composition root, and no `.pdf` is committed | Passed |
+| 2026-08-25 | `.github/workflows/documents-pdf.yml` added; its exact build, test and console-runner commands rehearsed locally | Passed: 508 tests executed across 8 result files, plus 99, 10 and 18 from the Graphics and Media runners |
 
 ## External decisions required for Phase 0 exit
 

--- a/Broiler.Documents/docs/pdf-support-roadmap.md
+++ b/Broiler.Documents/docs/pdf-support-roadmap.md
@@ -262,7 +262,7 @@ Broiler.Documents.Pdf
 | Phase | Goal | Dependency | Estimated effort | State |
 |---|---|---|---:|---|
 | 0 | Reset authority, scope, IP/legal ADRs, cleanup | None | 3–4 engineer-weeks | Repository work done; external approvals outstanding |
-| 1 | Shared contracts, read-safe shared services, approved corpus, CI/license foundation | Phase 0 | 7–10 | Not started; the PDF package carries its own typed options, limits, results, and budgets in the meantime |
+| 1 | Shared contracts, read-safe shared services, approved corpus, CI/license foundation | Phase 0 | 7–10 | CI workflow and existing-component jobs created (`.github/workflows/documents-pdf.yml`); shared contracts, oracles, corpus, harness, and package/notice work outstanding. The PDF package carries its own typed options, limits, results, and budgets in the meantime |
 | 2 | PDF syntax and object store | Phase 1 | 4–6 | Implemented |
 | 3 | Streamed xrefs/object store, structure, filters, security detection | Phase 2 | 6–9 | Implemented for the filters this build owns; the rest detected and skipped |
 | 4 | Logical text/image/link import and minimum hostile-input gate | Phase 3 | 8–12 | Text, links and structure implemented; images and embedded font programs detected and skipped; hostile-input gate covered by in-suite truncation and mutation campaigns, not yet by coverage-guided fuzzing |
@@ -311,7 +311,9 @@ research, permissions, or commercial-license negotiation.
 Implementation status and external approvals are tracked separately in the
 [Phase 0 status record](pdf-phase0-status.md). The boundary between the
 implemented base and each not-yet-cleared technology is specified in
-[PDF extension points](pdf-extension-points.md). The current decision/evidence set
+[PDF extension points](pdf-extension-points.md), and the exact construct set the
+IP-001 review has to cover is enumerated in the
+[construct inventory](pdf-construct-inventory.md). The current decision/evidence set
 is indexed by the [ADR index](adr/README.md),
 [feature matrix](pdf-feature-matrix.md),
 [IP/licensing register](pdf-ip-licensing-register.md),
@@ -734,6 +736,13 @@ fixed-layout objects remain prohibited.
 - Create required `.github/workflows/documents-pdf.yml` Windows/Linux checks for
   pull requests and pushes affecting Documents, Graphics, Media, relevant
   CLI/Writer roots, solution generation, packaging scripts, or the workflow.
+  **Created 2026-08-25** for the Documents solution plus the Graphics and Media
+  image suites, on both platforms, with a guard that fails a run whose executed
+  test count collapses — three of those suites are console runners that
+  `dotnet test` would exit 0 on having run nothing. The CLI/Writer host paths and
+  jobs are deliberately absent until Phase 5 activates them, so the trigger
+  covers only what the job actually proves; no oracle is wired in, because each
+  needs its licence review and tool-manifest row first.
   They restore locked inputs, build/test `Broiler.Documents/Broiler.Documents.slnx`
   in Release, explicitly run the applicable Graphics and Media test projects/
   console runners, execute host integration plus architecture/package-content

--- a/Broiler.Documents/docs/pdf-support-roadmap.md
+++ b/Broiler.Documents/docs/pdf-support-roadmap.md
@@ -262,7 +262,7 @@ Broiler.Documents.Pdf
 | Phase | Goal | Dependency | Estimated effort | State |
 |---|---|---|---:|---|
 | 0 | Reset authority, scope, IP/legal ADRs, cleanup | None | 3–4 engineer-weeks | Repository work done; external approvals outstanding |
-| 1 | Shared contracts, read-safe shared services, approved corpus, CI/license foundation | Phase 0 | 7–10 | CI workflow and existing-component jobs created (`.github/workflows/documents-pdf.yml`); shared contracts, oracles, corpus, harness, and package/notice work outstanding. The PDF package carries its own typed options, limits, results, and budgets in the meantime |
+| 1 | Shared contracts, read-safe shared services, approved corpus, CI/license foundation | Phase 0 | 7–10 | §6.1 contracts landed (`DocumentInput`, request envelopes, shared result status and destination state, typed-option validation, async overloads, catalog selection-and-read) and the CI workflow created. §6.2 resource/metadata context, §6.4 model review, §6.5 Graphics/Media prerequisites, and the §6.6 oracle/corpus/harness work are outstanding |
 | 2 | PDF syntax and object store | Phase 1 | 4–6 | Implemented |
 | 3 | Streamed xrefs/object store, structure, filters, security detection | Phase 2 | 6–9 | Implemented for the filters this build owns; the rest detected and skipped |
 | 4 | Logical text/image/link import and minimum hostile-input gate | Phase 3 | 8–12 | Text, links and structure implemented; images and embedded font programs detected and skipped; hostile-input gate covered by in-suite truncation and mutation campaigns, not yet by coverage-guided fuzzing |
@@ -475,11 +475,33 @@ is indexed by the [ADR index](adr/README.md),
 
 ### 6.1 `Broiler.Documents` request, option, input, and result contracts
 
+> **Landed 2026-08-25.** `DocumentInput`, `DocumentReadRequest`/`DocumentWriteRequest`,
+> the shared `DocumentResultStatus`/`DocumentDestinationState`, typed-option
+> validation, the async overloads, and `DocumentCodecCatalog.SelectAndRead` are
+> implemented, and every codec reports a status. Two bullets below were amended by
+> what the implementation found; both amendments are marked in place. Not yet
+> done: the conversion/resource context (§6.2), which is where the write
+> request's resource-manifest and commit-policy members belong, and a
+> spooling-capable `DocumentInput` — the type is memory-only by design until a
+> host supplies a spooling policy of its own.
+
 - Adopt non-sealed format-option bases with codec-specific immutable options.
   Move Windows-1252/default-code-page, object-decoding, ASCII-only output, group
   depth, and `\bin` payload settings into `RtfReadOptions`, `RtfWriteOptions`, and
   `RtfLimits`; base options/limits contain only behavior genuinely shared by
-  multiple codecs. `PdfReadOptions`/`PdfWriteOptions` compose `PdfLimits`. Where
+  multiple codecs.
+  **Amended 2026-08-25 by implementation.** Group depth and the `\bin` payload
+  limit are *not* RTF-specific: DOCX enforces `MaxGroupDepth` for style-inheritance
+  depth and `MaxBinBytes` for part size, so both already have the second consumer
+  the containment rule requires and correctly stay on `DocumentLimits` — moving
+  them would have forced DOCX to duplicate them. `RtfLimits` is therefore
+  unnecessary and was not created. Of the remaining three settings only the
+  default code page had any consumer: object-decoding and ASCII-only output had
+  none at all, which made them a public contract implying behavior no codec
+  implemented. `RtfReadOptions`/`RtfWriteOptions` now name the RTF-specific
+  settings, the base members document what they actually do, and a codec asked
+  for the unimplemented behavior reports `document.capability.not-composed`
+  instead of silently doing something else. `PdfReadOptions`/`PdfWriteOptions` compose `PdfLimits`. Where
   common and format-specific budgets overlap, the effective value is the
   stricter remaining budget. A codec validates the concrete option type before
   touching input or output. A mismatched option object produces a structured
@@ -491,6 +513,11 @@ is indexed by the [ADR index](adr/README.md),
   caller-selected metadata, resource manifest/context, cancellation, and output
   commit policy. Preserve existing overloads as documented compatibility
   adapters until the repository's normal deprecation policy permits removal.
+  **Amended 2026-08-25 by implementation:** the metadata, resource-manifest, and
+  commit-policy members wait on the §6.2 conversion context that defines them, so
+  the write request carries document, destination, typed options, and
+  cancellation today. Cancellation moved off `PdfReadOptions`/`PdfWriteOptions`
+  onto the request, giving it the single owner this bullet requires.
   Cross-format values have exactly one owner on the request; format options may
   not duplicate or override them. A future accidental duplicate/conflict is an
   invalid-options rejection rather than a precedence rule.

--- a/Broiler.Documents/docs/roadmap.md
+++ b/Broiler.Documents/docs/roadmap.md
@@ -6,12 +6,17 @@ residual work is tracked here.
 
 ## API contract cleanup
 
-- Resolve `DocumentReadOptions.DecodeEmbeddedObjects` before the public API is
-  frozen. The option exists, but the RTF reader currently skips `\pict` and
-  object destinations regardless of its value. Either implement a bounded,
-  caller-composed image-import path or remove/replace the option so the public
-  contract cannot imply behavior that does not exist.
-- Re-review ADR 0004 and the read/write option surface after that decision.
+- `DocumentReadOptions.DecodeEmbeddedObjects` and `DocumentWriteOptions.AsciiOnly`
+  no longer imply behavior that does not exist. Both are documented as what they
+  actually are, and a codec asked for the unimplemented behavior reports
+  `document.capability.not-composed` rather than quietly doing something else —
+  the RTF reader escalates its embedded-object note to that code when, and only
+  when, the caller asked for decoding *and* the document really contains a
+  picture or object. Removing the members outright still waits on the
+  repository's deprecation policy, and the bounded caller-composed image-import
+  path is Phase 1 §6.2 work.
+- Re-review ADR 0004 and the read/write option surface once the §6.2 resource
+  context lands.
 - Freeze public names and XML documentation after a consumer review.
 
 ## Format fidelity
@@ -53,11 +58,15 @@ Residual work owned here:
   read-preview and write-preview gates pass. Implementation is not a capability
   claim, and no feature-matrix entry may reach `Supported` while its
   IP/licensing row is pending.
-- The Phase 1 shared contracts — request/result envelopes, `DocumentInput`, the
-  conversion and resource context, and `Broiler.Documents.Pagination` — are not
-  built. The PDF package carries its own typed options, limits, results, and
-  internal pagination in the meantime, and those move to their shared owners when
-  Phase 1 lands rather than being promoted piecemeal.
+- The Phase 1 §6.1 contracts are built: `DocumentInput` (replayable probing over
+  non-seekable sources, bounded memory-only materialization, explicit ownership),
+  the read/write request envelopes, the shared result status and destination
+  state, typed-option validation, async overloads, and one catalog
+  selection-and-read path. The conversion and resource context (§6.2), the model
+  unit review (§6.4), the Graphics font inspector and Media image services (§6.5),
+  and `Broiler.Documents.Pagination` remain outstanding; the PDF writer paginates
+  internally against a replaceable metrics provider until the shared paginator
+  exists.
 - Coverage-guided fuzzing and the pinned oracle, corpus and performance
   infrastructure remain outstanding; the current suite covers bounded truncation
   and mutation campaigns only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- A required `Documents And PDF` CI workflow — the first pull-request-triggered
+  workflow in the repository. Every other one is `workflow_dispatch` or
+  tag-push, so the Documents solution had no CI at all and its suites were only
+  ever a local result. It builds and tests the solution on Windows and Linux and
+  runs the Graphics and Media image suites, which are console runners rather
+  than xunit projects: `dotnet test` exits 0 against them having run nothing, so
+  they are invoked with `dotnet run` where the exit code is the failure count.
+  The xunit half is checked against a floor on executed tests, because a run that
+  silently executes almost nothing should fail rather than report success. No
+  independent oracle is wired in — qpdf, PDFium, Poppler, MuPDF and veraPDF each
+  need a licence review and a tool-manifest row first — and the CLI/Writer host
+  jobs activate at the roadmap's Phase 5/7 boundaries along with the paths that
+  would trigger them.
+- A [PDF construct inventory](Broiler.Documents/docs/pdf-construct-inventory.md):
+  exactly which PDF constructs the codec reads, writes, recognizes without
+  interpreting, and rejects, each with the file that implements it. It exists to
+  scope the IP-001 qualified review, which asks whether a *concrete
+  implementation* falls within Adobe's ISO 32000-1 patent licence — a question
+  that had no definite subject until the base slice existed and now does. It
+  cites clauses without reproducing standard text, and marks the clause column
+  provisional, since lawful standards access is still an open Phase 0 item.
+
 - `Broiler.Documents.Pdf`, a base PDF codec: logical text import from ISO 32000-1
   files and a deterministic PDF 1.7 writer. It is not a published capability —
   the package is not packed and is registered in no application — and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- The Phase 1 §6.1 document contracts in `Broiler.Documents`.
+
+  `DocumentInput` is the load-bearing one. Choosing a codec means reading a
+  prefix and then reading the document means reading that prefix again — a
+  rewind on a file, and impossible on a pipe or a browser upload, where the
+  usual fix is to buffer the whole source before probing and so turn a bounded
+  read into an unbounded one. `DocumentInput` holds the probed prefix and
+  replays it ahead of the rest, so a non-seekable source is probed and read
+  exactly once. Ownership is explicit (a caller's stream is not closed unless it
+  says so), and materialization is memory-only and always bounded: nothing opens
+  a temporary file or consults a temp directory, which keeps it usable in a
+  memory-only WebAssembly host and keeps document bytes out of any location with
+  no agreed retention policy.
+
+  `DocumentReadRequest`/`DocumentWriteRequest` carry the input, typed options,
+  limits and cancellation with exactly one owner per value — cancellation moved
+  off the PDF options onto the request for that reason. `DocumentCodec` gains
+  request and async entry points; the stream methods stay, and are what a codec
+  implements, so every existing codec keeps working through the new contract
+  unchanged. No adapter uses `.Result` or `.Wait()` in either direction.
+
+  `DocumentResultStatus` and `DocumentDestinationState` moved out of the PDF
+  package onto the shared results, where they were always format-neutral, and
+  every codec now reports them. Status and severity answer different questions:
+  a read can carry a dozen warnings and be complete, or carry none and be
+  missing a page, so hosts branch on the status rather than on a diagnostic
+  count. `DocumentCodecCatalog.SelectAndRead` is the one path that probes and
+  reads through the same replayable input, and diagnostics can now carry an
+  optional source location.
+
 - A required `Documents And PDF` CI workflow — the first pull-request-triggered
   workflow in the repository. Every other one is `workflow_dispatch` or
   tag-push, so the Documents solution had no CI at all and its suites were only
@@ -287,6 +317,26 @@ are versioned in lockstep during the preview.
     from a single-page evaluation, and `click-to-load` never settles.
 
 ### Changed
+
+- A codec handed another codec's option type now returns a structured
+  `document.options.invalid` rejection instead of silently ignoring it and
+  applying its own defaults — settings the caller never chose. The plain shared
+  option type is still always accepted.
+- `DocumentReadOptions.DecodeEmbeddedObjects` and `DocumentWriteOptions.AsciiOnly`
+  stop implying behavior that does not exist. Neither had a single consumer:
+  the RTF reader skipped pictures and objects whichever way the first was set,
+  and the writer always escaped non-ASCII whatever the second said. Both are now
+  documented as what they are, and a codec asked for the unimplemented behavior
+  reports `document.capability.not-composed` — the RTF reader escalating its
+  embedded-object note to that code only when the caller asked for decoding
+  *and* the document actually contains one. `RtfReadOptions`/`RtfWriteOptions`
+  name the RTF-specific settings.
+
+  `MaxGroupDepth` and `MaxBinBytes` were expected to move to an `RtfLimits`
+  alongside them and did not: DOCX enforces both — style-inheritance depth and
+  part size — so they already have the second consumer the containment rule
+  wants and belong where they are. Moving them would have forced DOCX to
+  duplicate them.
 
 - `DocumentReadOptions`, `DocumentWriteOptions`, `DocumentReadResult` and
   `DocumentWriteResult` are no longer sealed, so a codec can carry typed options


### PR DESCRIPTION
Three follow-ups to the base PDF codec, chosen because none of them adds a standards implementation, a third-party component, or a capability claim — so none touches a pending IP-register row.

539 tests pass across the Documents solution (31 new); the CLI and Writer consumers build unchanged.

## 1. `.github/workflows/documents-pdf.yml`

The repository's first `pull_request`-triggered workflow. Every other one is `workflow_dispatch` or tag-push, so the Documents solution had no CI at all and the PDF codec merged on a local test result. It builds and tests the solution on Windows and Linux and runs the Graphics suite.

Worth knowing: that suite is an `OutputType=Exe` console runner, not an xunit project, and **`dotnet test` exits 0 against it having run nothing** — verified locally. That is exactly the no-op job the roadmap warns can never satisfy a later gate, and it is why §6.6 says "test projects/console runners". It is invoked with `dotnet run`, where `Main` returns the failure count. The xunit half is checked against a floor on executed tests, set well under the current total so adding tests does not break CI.

Three omissions are deliberate and commented in the file:

- **No independent oracle.** qpdf, PDFium, Poppler, MuPDF and veraPDF each need a licence review, a pinned build, and a `tests/pdf/tools/manifest.json` row first — Poppler is GPL, MuPDF is AGPL with a named compliance path, PDFium needs a full dependency SBOM. A CI image is an easy place to acquire an obligation nobody recorded.
- **No host-integration job.** Those activate at the Phase 5/7 boundaries together with the paths that would trigger them, so the trigger covers only what the job actually proves.
- **No `Broiler.Media` gate.** The scope is the Documents solution and its dependency closure, which today is `Broiler.Graphics` and nothing else — `Broiler.Documents.Model` references it for value types such as `BColor`. Nothing under `Broiler.Documents` references `Broiler.Media`, so a Media failure would say nothing about Documents. Images reach the PDF codec at a later roadmap phase; the Media paths and suites belong here then.

This PR is the workflow's own first run, and it earned its keep immediately: the first attempt was red on Windows in `Broiler.Media.Image.Managed.Tests`, on the lossy VP8 WebP path, which has no managed decoder and delegates to the Windows Imaging Component. The WIC WebP decoder ships as a Store extension the hosted Windows image does not carry, so that leg was red or green depending on the runner image rather than on the code. That is what prompted the scoping above — gating Documents on it would have made every future Documents pull request hostage to an optional OS component.

That leaves a real defect in `Broiler.Media`, out of scope here and worth its own change: `WebpWicDecoder.Decode` classifies "this host has no WebP codec" as a `FormatException`, a data-corruption verdict, when the same file already reports the missing-component case as `NotSupportedException` for `WINCODEC_ERR_COMPONENTNOTFOUND` and for non-Windows hosts. Anyone running that suite on Windows Server or a stripped Windows install gets a red suite for an absent optional component.

## 2. `Broiler.Documents/docs/pdf-construct-inventory.md`

Exactly which PDF constructs the codec interprets, recognizes without interpreting, rejects, and emits — with the file behind each row. Derived from the implementation: the operator list is the interpreter's dispatch switch, the key list is what the code actually consults, the writer list is what the serializer actually emits.

It exists to scope the IP-001 review, which asks whether a *concrete implementation* falls within Adobe's ISO 32000-1 patent licence — a question that had no definite subject until the base slice existed and now does. It cites clauses without reproducing standard text.

The clause column is marked **provisional and unverified**: lawful standards access is still an open Phase 0 exit item, so the references are offered to save the reviewer time, and a mismatch means the column is wrong. Presenting unverified cross-references as evidence in a document whose job is to inform a legal review would have been worse than omitting them.

## 3. The Phase 1 §6.1 document contracts

**`DocumentInput`** is the load-bearing piece. Selecting a codec means reading a prefix, and then reading the document means reading that prefix again — a rewind on a file, impossible on a pipe or a browser upload, where the usual fix is to buffer the whole source before probing and so turn a bounded read into an unbounded one. It holds the probed prefix and replays it ahead of the rest, so a non-seekable source is probed and read exactly once. Ownership is explicit, and materialization is memory-only and always bounded: nothing opens a temporary file or consults a temp directory, which keeps it usable in a memory-only WebAssembly host and keeps document bytes out of any location with no agreed retention policy.

**Request envelopes** carry input, typed options, limits and cancellation with one owner per value — cancellation moved off the PDF options onto the request for exactly that reason. `DocumentCodec` gains request and async entry points; the stream methods stay and remain what a codec *implements*, so every existing codec serves the new contract unchanged. No adapter uses `.Result` or `.Wait()` in either direction.

**`DocumentResultStatus`/`DocumentDestinationState`** move out of the PDF package onto the shared results, where they were always format-neutral, and every codec now reports them — the second-consumer test the containment rule asks for. The PDF-local copies are gone rather than left to shadow the base, which would have let a host holding a `DocumentReadResult` read `Success` off a rejected read.

`DocumentCodecCatalog.SelectAndRead` is the single path that probes and reads through one replayable input, and diagnostics can now carry an optional source location.

### Two findings that changed the plan

**The roadmap was wrong about `RtfLimits`.** §6.1 says to move group depth and the `\bin` payload limit into it. But DOCX enforces `MaxGroupDepth` for style-inheritance depth and `MaxBinBytes` for part size — both already have the second consumer the containment rule requires, so they belong on the shared limits, and moving them would have forced DOCX to duplicate them. `RtfLimits` is unnecessary and was not created. The roadmap bullet is amended in place rather than quietly diverged from.

**Two options were implying behavior that does not exist.** Of the remaining settings only the default code page had any consumer: nothing read `DecodeEmbeddedObjects`, and the RTF writer always escaped non-ASCII whatever `AsciiOnly` said. That is the defect the component roadmap flagged. Both are now documented as what they are, and a codec asked for the unimplemented behavior reports `document.capability.not-composed` — the RTF reader escalating its embedded-object note only when the caller asked for decoding *and* the document actually contains a picture. The members are not deleted: that is a public API break and the maintainers' call.

## Still outstanding in Phase 1

§6.2 conversion/resource context (where the write request's metadata and commit-policy members belong), §6.4 model units, §6.5 Graphics/Media prerequisites — that one is **not** IP-free, it touches IP-012 and IP-005 — and §6.6's oracles, corpus and fuzz harness.

## Unchanged

The PDF package stays `IsPackable=false` and registered in no application; the delivery guards fail the build if either changes. Nothing in the feature matrix moved to `Supported`, because every applicable register row is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oqQ6o6Gnfv7TW9wzK7DmV