### PR TITLE
Enable PDF opening in Windows and Linux Writer heads

### DIFF
--- a/.github/workflows/documents-pdf.yml
+++ b/.github/workflows/documents-pdf.yml
@@ -21,11 +21,13 @@ name: Documents And PDF
 #     Adding one is a separate change; adding one *casually* is how a CI image
 #     acquires an obligation nobody recorded.
 #
-#   * No host-integration job. CLI, Writer, packaging, trimming, and AOT jobs
+#   * No host-integration job yet. CLI, packaging, trimming, and AOT jobs
 #     activate at the roadmap's Phase 5/7 boundaries, together with the paths
-#     that would trigger them. The PDF package is currently registered in no
-#     application at all — Broiler.Documents.Tests/PdfDeliveryGuardTests.cs
-#     fails the build if that changes — so a host job today would gate nothing.
+#     that would trigger them. The Windows and Linux Writer heads now register
+#     the codec for opening (roadmap §10.1), and the shape of that registration
+#     is enforced by Broiler.Documents.Tests/PdfDeliveryGuardTests.cs, which runs
+#     in this workflow — hence the src/Broiler.Writer*/** trigger paths below. The
+#     Writer's own behavioural cover lives with the Writer tests.
 #
 # Scope: the Documents solution and its dependency closure, which today is
 # Broiler.Graphics and nothing else — Broiler.Documents.Model references it for
@@ -50,6 +52,11 @@ on:
     paths:
       - 'Broiler.Documents/**'
       - 'Broiler.Graphics/**'
+      # The Writer heads, because PdfDeliveryGuardTests polices them: it reads
+      # every composition root under src/ to prove PDF is registered only where a
+      # head asks for it. A guard whose subject can change without running the
+      # guard is not a guard.
+      - 'src/Broiler.Writer*/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - '.github/workflows/documents-pdf.yml'
@@ -59,6 +66,11 @@ on:
     paths:
       - 'Broiler.Documents/**'
       - 'Broiler.Graphics/**'
+      # The Writer heads, because PdfDeliveryGuardTests polices them: it reads
+      # every composition root under src/ to prove PDF is registered only where a
+      # head asks for it. A guard whose subject can change without running the
+      # guard is not a guard.
+      - 'src/Broiler.Writer*/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - '.github/workflows/documents-pdf.yml'

--- a/Broiler.Documents/Broiler.Documents.Pdf/PdfDocumentCodec.cs
+++ b/Broiler.Documents/Broiler.Documents.Pdf/PdfDocumentCodec.cs
@@ -37,10 +37,14 @@ namespace Broiler.Documents.Pdf;
 /// service graph does.
 /// </para>
 /// <para>
-/// <b>Delivery state.</b> The package is not published and is not registered in
-/// any application catalog. Advertising a PDF capability to users waits on the
-/// preview gates in the PDF support roadmap and on the clearance rows in the
-/// IP/licensing register.
+/// <b>Delivery state.</b> The package is not published. It is registered — for
+/// opening only — by the Windows and Linux Writer composition roots, which is the
+/// read-preview integration candidate the roadmap allows so integration checks
+/// can run; no other application registers it, no head registers it for saving,
+/// and the shared Writer core does not reference it, so no head acquires it
+/// transitively. Advertising a PDF capability to users still waits on the preview
+/// gates in the PDF support roadmap and on the clearance rows in the IP/licensing
+/// register.
 /// </para>
 /// </remarks>
 public sealed class PdfDocumentCodec : DocumentCodec

--- a/Broiler.Documents/Broiler.Documents.Tests/PdfDeliveryGuardTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Tests/PdfDeliveryGuardTests.cs
@@ -3,17 +3,57 @@ using System.Text.RegularExpressions;
 namespace Broiler.Documents.Tests;
 
 /// <summary>
-/// Guards the PDF delivery boundary described in the PDF support roadmap §4.1.
+/// Guards the PDF delivery boundary described in the PDF support roadmap §4.1
+/// and the registration rule in §10.1.
 /// </summary>
 /// <remarks>
-/// The codec exists and is tested, but it is not a published capability: the
-/// package is not packed, and no application composition root registers it. These
-/// tests fail the build if that changes without the preview gates and the
-/// clearance rows that must come with it, so "we shipped PDF by accident" is not
-/// a thing that can happen quietly.
+/// <para>
+/// The codec is not a published capability: the package is not packed, and it
+/// reaches an application only where a composition root names it. It is now
+/// registered — for opening only — by the Windows and Linux Writer heads, which
+/// is the read-preview integration §10.1 describes. Everywhere else the old rule
+/// stands unchanged, and these tests fail the build if it slips, so "we shipped
+/// PDF by accident" is still not a thing that can happen quietly.
+/// </para>
+/// <para>
+/// The rule that matters most here is the one about transitivity. A codec must
+/// arrive in a head because that head asked for it, never because it is a
+/// transitive reference of something shared: putting it in
+/// <c>Broiler.Writer.Core</c> would hand it to the Android and WebAssembly
+/// Writers too, whose package-size, memory, trimming and AOT gates it has not
+/// passed.
+/// </para>
 /// </remarks>
 public sealed class PdfDeliveryGuardTests
 {
+    /// <summary>
+    /// The only files in <c>src</c> that may name the PDF codec: the two desktop
+    /// composition roots that register it, their project files, and the Writer
+    /// tests that cover the registration.
+    /// </summary>
+    private static readonly string[] RegistrationSites =
+    [
+        "src/Broiler.Writer.Windows/Program.cs",
+        "src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj",
+        "src/Broiler.Writer.Linux/Program.cs",
+        "src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj",
+        "src/Broiler.Writer.FormatCodes.Tests/WriterPdfFormatTests.cs",
+        "src/Broiler.Writer.FormatCodes.Tests/Broiler.Writer.FormatCodes.Tests.csproj",
+    ];
+
+    /// <summary>
+    /// Projects that must never name the PDF codec, called out by name because
+    /// what each one would enable is different. The shared Writer core would
+    /// enable it in every head at once; the Android and WebAssembly heads have
+    /// their own outstanding gates.
+    /// </summary>
+    private static readonly string[] ProjectsThatMustNotCarryPdf =
+    [
+        "src/Broiler.Writer",
+        "src/Broiler.Writer.Android",
+        "src/Broiler.Writer.WebAssembly",
+    ];
+
     [Fact(Timeout = 600000)]
     public void The_Pdf_Package_Is_Not_Packable_Before_Its_Release_Gates_Pass()
     {
@@ -45,28 +85,72 @@ public sealed class PdfDeliveryGuardTests
     }
 
     [Fact(Timeout = 600000)]
-    public void No_Application_Composition_Root_Registers_The_Pdf_Codec()
+    public void Only_The_Enabled_Heads_Name_The_Pdf_Codec()
     {
         string root = FindRepositoryRoot();
-        var violations = new List<string>();
 
-        foreach (string file in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories)
-                     .Where(path => !IsBuildOutput(path)))
-        {
-            string source = File.ReadAllText(file);
-            if (source.Contains("PdfDocumentCodec", StringComparison.Ordinal) ||
-                source.Contains("Broiler.Documents.Pdf", StringComparison.Ordinal))
-                violations.Add(Path.GetRelativePath(root, file));
-        }
-
-        foreach (string project in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.csproj", SearchOption.AllDirectories))
-        {
-            if (File.ReadAllText(project).Contains("Broiler.Documents.Pdf", StringComparison.OrdinalIgnoreCase))
-                violations.Add(Path.GetRelativePath(root, project));
-        }
+        string[] violations = NamesPdf(root, "*.cs")
+            .Concat(NamesPdf(root, "*.csproj"))
+            .Where(path => !RegistrationSites.Contains(path, StringComparer.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
 
         Assert.Empty(violations);
     }
+
+    [Fact(Timeout = 600000)]
+    public void The_Shared_Writer_Core_And_The_Mobile_Heads_Cannot_Acquire_Pdf()
+    {
+        string root = FindRepositoryRoot();
+        string[] carriers = NamesPdf(root, "*.cs")
+            .Concat(NamesPdf(root, "*.csproj"))
+            .Where(path => ProjectsThatMustNotCarryPdf.Any(
+                project => path.StartsWith(project + "/", StringComparison.Ordinal)))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        // Stated separately from the allow-list test because the consequence is
+        // different: a reference here is not one head enabling a codec, it is
+        // every head that references the shared core acquiring it silently.
+        Assert.Empty(carriers);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void No_Head_Registers_The_Pdf_Codec_For_Saving()
+    {
+        string root = FindRepositoryRoot();
+
+        // The writer exists and passes its own unit tests, but PDF export has its
+        // own release gate. Every registration must therefore enable opening only,
+        // which is what keeps the capability out of the Save dialog, the save
+        // dispatch, and the extension a user can type into the Save box.
+        foreach (string site in RegistrationSites.Where(path => path.EndsWith("Program.cs", StringComparison.Ordinal)))
+        {
+            string source = File.ReadAllText(Path.Combine(root, site.Replace('/', Path.DirectorySeparatorChar)));
+            foreach (Match match in Regex.Matches(source, @"new\s+WriterDocumentFormat\((?<arguments>[^;]*?)\)\s*\)"))
+            {
+                string arguments = match.Groups["arguments"].Value;
+                if (!arguments.Contains("PdfDocumentCodec", StringComparison.Ordinal))
+                    continue;
+
+                Assert.Contains("WriterFormatCapabilities.Open", arguments, StringComparison.Ordinal);
+                Assert.DoesNotContain("WriterFormatCapabilities.Save", arguments, StringComparison.Ordinal);
+                Assert.DoesNotContain("WriterFormatCapabilities.OpenAndSave", arguments, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    /// <summary>Repo-relative paths under <c>src</c> whose text names the PDF codec.</summary>
+    private static IEnumerable<string> NamesPdf(string root, string pattern) =>
+        Directory.EnumerateFiles(Path.Combine(root, "src"), pattern, SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path =>
+            {
+                string source = File.ReadAllText(path);
+                return source.Contains("PdfDocumentCodec", StringComparison.Ordinal) ||
+                    source.Contains("Broiler.Documents.Pdf", StringComparison.OrdinalIgnoreCase);
+            })
+            .Select(path => Path.GetRelativePath(root, path).Replace('\\', '/'));
 
     [Fact(Timeout = 600000)]
     public void No_Pdf_Fixture_Is_Committed_Outside_The_Rights_Aware_Corpus()

--- a/Broiler.Documents/docs/adr/0012-pdf-base-implementation-and-composed-extensions.md
+++ b/Broiler.Documents/docs/adr/0012-pdf-base-implementation-and-composed-extensions.md
@@ -57,10 +57,12 @@ letterform proportions (register rows IP-021 and IP-022). Adobe's Standard 14
 metric files are not used, and output must never be described as using any
 vendor's metrics.
 
-**Implementation is not a claim.** The package is `IsPackable=false` and is
-registered in no application catalog, enforced by tests. Nothing in the feature
-matrix may reach `Supported` while its register row is pending, regardless of how
-complete the code is.
+**Implementation is not a claim.** The package is `IsPackable=false`, and its
+registration is confined to the composition roots that have been opened to it —
+at the time of writing none, and since the roadmap §10.1 read-preview candidate
+the Windows and Linux Writer heads, for opening only — enforced by tests.
+Nothing in the feature matrix may reach `Supported` while its register row is
+pending, regardless of how complete the code is.
 
 **The order for adding a technology is fixed**: the register row clears, the
 sources are recorded, the implementation goes behind the interface in its

--- a/Broiler.Documents/docs/pdf-phase0-status.md
+++ b/Broiler.Documents/docs/pdf-phase0-status.md
@@ -39,8 +39,10 @@ built deliberately inside the Phase 0 constraints rather than after them:
   [PDF extension points](pdf-extension-points.md));
 - no fixture is committed — every test PDF is generated in code — so the corpus
   manifest remains empty and no artifact needs a rights decision; and
-- the package is `IsPackable=false` and registered in no application, enforced by
-  `PdfDeliveryGuardTests`, so nothing is published or advertised.
+- the package is `IsPackable=false`, and its registration is confined to the
+  composition roots explicitly opened to it — none at Phase 0; since the §10.1
+  read-preview candidate, the Windows and Linux Writer heads, for opening only —
+  enforced by `PdfDeliveryGuardTests`, so nothing is published or advertised.
 
 Implementation is therefore not a claim. Nothing below becomes checked because
 code exists, and no feature-matrix entry may reach `Supported` until its register

--- a/Broiler.Documents/docs/pdf-support-roadmap.md
+++ b/Broiler.Documents/docs/pdf-support-roadmap.md
@@ -185,11 +185,12 @@ is authoritative for that boundary.
   today; its writer paginates internally against a replaceable metrics provider
   rather than pre-empting the shared paginator's design.
 
-**Not advertised.** The package is `IsPackable=false`, absent from every
-application catalog and composition root, and guarded by tests that fail the
-build if either changes. Phase 5 and Phase 7 remain the publication boundaries,
-and no feature-matrix entry may reach `Supported` while its register row is
-pending.
+**Not advertised.** The package is `IsPackable=false` and reaches an application
+only through the Windows and Linux Writer composition roots, for opening, as the
+§10.1 read-preview candidate; every other catalog and composition root is still
+closed to it, and tests fail the build if any of that changes. Phase 5 and Phase 7
+remain the publication boundaries, and no feature-matrix entry may reach
+`Supported` while its register row is pending.
 
 ## 3. Component ownership
 
@@ -266,7 +267,7 @@ Broiler.Documents.Pdf
 | 2 | PDF syntax and object store | Phase 1 | 4–6 | Implemented |
 | 3 | Streamed xrefs/object store, structure, filters, security detection | Phase 2 | 6–9 | Implemented for the filters this build owns; the rest detected and skipped |
 | 4 | Logical text/image/link import and minimum hostile-input gate | Phase 3 | 8–12 | Text, links and structure implemented; images and embedded font programs detected and skipped; hostile-input gate covered by in-suite truncation and mutation campaigns, not yet by coverage-guided fuzzing |
-| 5 | Read-preview integration | Phase 4 and Phase 1 unit/UI gate | 3–5 | Not started; the package is unregistered by design |
+| 5 | Read-preview integration | Phase 4 and Phase 1 unit/UI gate | 3–5 | Writer integration candidate landed: catalogs are injected from composition roots, the Windows and Linux Writer heads register the codec for opening, and the desktop open path runs through `SelectAndRead`/`DocumentInput`. CLI integration, conversion context, partial-read confirmation, and the §10.2 exit-gate evidence are outstanding; the package stays unpacked and unpublished |
 | 6 | Shared pagination/font/export foundation | Phase 1; parallel with 2–5 | 10–16 | Not started; the writer paginates internally against a replaceable metrics provider |
 | 7 | Deterministic PDF writer and output integration | Core: Phases 3 and 6; write-preview publication: Phase 5 also | 7–12 | Writer core implemented for the standard-font subset; integration and publication not started |
 | 8 | Hardening, packaging, legal and stable-release evidence | Phases 5 and 7 | 6–10 | Not started |
@@ -282,17 +283,21 @@ research, permissions, or commercial-license negotiation.
 ### 4.1 Delivery milestones and publication state
 
 - Phases 2–4 produce an internal parser/importer. The PDF project remains
-  `IsPackable=false`,
-  absent from application catalogs, and excluded from release artifacts. **This
-  is the state today**, enforced by `PdfDeliveryGuardTests`: the guards fail the
-  build if the project becomes packable, gains a third-party or non-Documents
-  reference, is referenced or registered anywhere under `src/`, or if a `.pdf`
+  `IsPackable=false` and excluded from release artifacts, enforced by
+  `PdfDeliveryGuardTests`: the guards fail the build if the project becomes
+  packable, gains a third-party or non-Documents reference, or if a `.pdf`
   fixture is committed outside the rights-aware corpus.
 - Phase 5 is the read-preview boundary. After the Phase 4 reader-core gate, a
   test-only candidate may expose `CanRead=true` and register PDF in open/import
   paths so integration checks can run. Publish that prerelease capability only
   after the complete Phase 5 gate passes on the candidate; `CanWrite` and every
-  PDF destination/save filter remain disabled.
+  PDF destination/save filter remain disabled. **This is the state today**: the
+  Windows and Linux Writer heads register the codec for opening, and the same
+  guards enforce the shape of that registration — only those two composition
+  roots (and the tests covering them) may name the codec, the shared
+  `Broiler.Writer.Core` and the Android and WebAssembly heads may not acquire it
+  even transitively, and no head may register it for saving. The package is not
+  packed and the capability is not published.
 - Phase 7 is the write-preview boundary. After its writer-core readiness subgate,
   a test-only candidate may enable `CanWrite`, CLI PDF destinations, and selected
   Writer save filters so integration gates can execute. Those capabilities are
@@ -1217,6 +1222,20 @@ the selected registrations below. Only that candidate is used for host/package
 tests; the capability is published only after the complete Phase 5 exit gate.
 
 ### 10.1 Deliverables
+
+The Writer half of this list has landed as the integration candidate: catalog
+construction moved to `WriterDocumentFormats`, which each composition root
+builds; the Windows and Linux heads register `PdfDocumentCodec` for opening; the
+desktop open path runs through `DocumentCodecCatalog.SelectAndRead` over a
+`DocumentInput` rather than `File.ReadAllBytes` plus a separate probe; `.pdf` is
+in the open filters and in no save filter; and a rejected read — or one that
+recovered no text at all — leaves the open document in place and says why.
+
+Outstanding: the CLI and `BrowserWriterDemo` migrations, `DocumentConversionContext`,
+explicit confirmation before a partial read replaces the open document (today it
+is committed and the status line reports it as partial rather than clean), host
+cancellation reaching probing and materialization, the composed managed JPEG
+service, the support-wording review, and every §10.2 exit-gate item.
 
 - Move catalog construction out of shared Writer internals and inject catalogs
   and codec services from each platform composition root. Register

--- a/Broiler.Linux.Writer.slnx
+++ b/Broiler.Linux.Writer.slnx
@@ -13,6 +13,7 @@
     <Project Path="Broiler.Documents/Broiler.Documents.Html/Broiler.Documents.Html.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Markdown/Broiler.Documents.Markdown.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Model/Broiler.Documents.Model.csproj" />
+    <Project Path="Broiler.Documents/Broiler.Documents.Pdf/Broiler.Documents.Pdf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Rtf/Broiler.Documents.Rtf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents/Broiler.Documents.csproj" />
   </Folder>

--- a/Broiler.Tests.slnx
+++ b/Broiler.Tests.slnx
@@ -26,6 +26,7 @@
     <Project Path="Broiler.Documents/Broiler.Documents.Html/Broiler.Documents.Html.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Markdown/Broiler.Documents.Markdown.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Model/Broiler.Documents.Model.csproj" />
+    <Project Path="Broiler.Documents/Broiler.Documents.Pdf/Broiler.Documents.Pdf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Rtf/Broiler.Documents.Rtf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents/Broiler.Documents.csproj" />
   </Folder>

--- a/Broiler.Windows.Writer.slnx
+++ b/Broiler.Windows.Writer.slnx
@@ -13,6 +13,7 @@
     <Project Path="Broiler.Documents/Broiler.Documents.Html/Broiler.Documents.Html.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Markdown/Broiler.Documents.Markdown.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Model/Broiler.Documents.Model.csproj" />
+    <Project Path="Broiler.Documents/Broiler.Documents.Pdf/Broiler.Documents.Pdf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents.Rtf/Broiler.Documents.Rtf.csproj" />
     <Project Path="Broiler.Documents/Broiler.Documents/Broiler.Documents.csproj" />
   </Folder>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- The PDF read-preview integration candidate: Broiler Writer can open PDFs on
+  Windows and Linux.
+
+  The Writer used to hard-code its codec catalog and its two file-dialog filter
+  arrays, so every head got exactly the same formats and adding one to the shared
+  core added it everywhere — including the Android and WebAssembly Writers, whose
+  package-size, memory, trimming and AOT gates PDF has not passed. Composition
+  roots now build a `WriterDocumentFormats` instead: `CreateDefault()` is the RTF,
+  DOCX, HTML and Markdown set every head has always had, and the Windows and Linux
+  heads add `PdfDocumentCodec` to their own. Nothing else changes for the heads
+  that do not ask for it, and `PdfDeliveryGuardTests` fails the build if the codec
+  is named anywhere but those two roots.
+
+  Registration carries a capability, separately from what the codec implements.
+  PDF is registered for opening only: its writer exists and passes its own tests,
+  but PDF export has its own release gate, so there is no PDF save filter and the
+  save dispatch — which reads the same set the filters come from — has no PDF
+  entry, whether the user picks the format or types the extension.
+
+  The desktop open path moved onto `DocumentCodecCatalog.SelectAndRead` over a
+  `DocumentInput`, so probing and reading observe the same bytes without a second
+  buffer, and the read's own limits decide how much of a file enters memory rather
+  than `File.ReadAllBytes` materializing it first and measuring after. Two reads
+  that used to replace the open document no longer can: a rejected one, which
+  carries a placeholder rather than content, and one that recovered no text at all
+  and knows it is incomplete — a scanned PDF with no text layer is that shape,
+  where "empty" is a report about the reader rather than about the file. Both
+  leave the editor alone and say why in the status bar. A partial read that did
+  recover text is committed and reported as partial, never as a clean open.
+
 - The Phase 1 §6.1 document contracts in `Broiler.Documents`.
 
   `DocumentInput` is the load-bearing one. Choosing a codec means reading a
@@ -63,7 +93,9 @@ are versioned in lockstep during the preview.
 
 - `Broiler.Documents.Pdf`, a base PDF codec: logical text import from ISO 32000-1
   files and a deterministic PDF 1.7 writer. It is not a published capability —
-  the package is not packed and is registered in no application — and the
+  the package is not packed, and the only applications registering it are the
+  Windows and Linux Writer heads, for opening, as the read-preview integration
+  candidate described above — and the
   [feature matrix](Broiler.Documents/docs/pdf-feature-matrix.md) remains the
   authority for what it may be described as.
 

--- a/src/Broiler.Writer.FormatCodes.Tests/Broiler.Writer.FormatCodes.Tests.csproj
+++ b/src/Broiler.Writer.FormatCodes.Tests/Broiler.Writer.FormatCodes.Tests.csproj
@@ -18,6 +18,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer.FormatCodes\Broiler.Writer.FormatCodes.csproj" />
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
+    <!-- Referenced so the tests can compose PDF the way the desktop heads do, and
+         assert that the shared default format set still does not carry it. -->
+    <ProjectReference Include="..\..\Broiler.Documents\Broiler.Documents.Pdf\Broiler.Documents.Pdf.csproj" />
     <ProjectReference Include="..\..\Broiler.UI\src\Implementations\Standard\Text\Broiler.UI.RichEdit.Standard\Broiler.UI.RichEdit.Standard.csproj" />
     <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
   </ItemGroup>

--- a/src/Broiler.Writer.FormatCodes.Tests/WriterPdfFormatTests.cs
+++ b/src/Broiler.Writer.FormatCodes.Tests/WriterPdfFormatTests.cs
@@ -1,0 +1,205 @@
+using System.Text;
+using Broiler.Documents;
+using Broiler.Documents.Model;
+using Broiler.Documents.Pdf;
+using Broiler.Graphics;
+using Broiler.UI.FileDialog;
+
+namespace Broiler.Writer.FormatCodes.Tests;
+
+/// <summary>
+/// Cover for wiring <c>Broiler.Documents.Pdf</c> into the Writer: PDF reaches a
+/// head only when that head registers it, it is offered for opening and not for
+/// saving, and a read the codec refuses does not cost the user the document they
+/// had open.
+/// </summary>
+public sealed class WriterPdfFormatTests
+{
+    [Fact(Timeout = 600000)]
+    public void The_Shared_Default_Formats_Do_Not_Carry_Pdf()
+    {
+        // The guard behind "Android and WebAssembly cannot acquire PDF
+        // transitively": those heads take the default set, so PDF appearing in it
+        // would enable it everywhere at once.
+        WriterDocumentFormats formats = WriterDocumentFormats.CreateDefault();
+
+        Assert.DoesNotContain(formats.Formats, format => format.MatchesExtension(".pdf"));
+        Assert.Null(formats.FindForSave(".pdf"));
+        Assert.DoesNotContain(formats.CreateOpenFilters(), FilterMentionsPdf);
+        Assert.DoesNotContain(formats.CreateSaveFilters(), FilterMentionsPdf);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Registering_Pdf_Offers_It_For_Opening_Only()
+    {
+        WriterDocumentFormats formats = DesktopFormats();
+
+        Assert.Contains(formats.CreateOpenFilters(), FilterMentionsPdf);
+        Assert.DoesNotContain(formats.CreateSaveFilters(), FilterMentionsPdf);
+
+        // The save dispatch reads the same set the filters come from, so a typed
+        // ".pdf" filename cannot reach the writer either.
+        Assert.Null(formats.FindForSave(".pdf"));
+        Assert.DoesNotContain(".pdf", formats.DescribeSaveExtensions());
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Writer_Composed_Without_A_Format_Set_Gets_The_Default_One()
+    {
+        using WriterApp bare = CreateApp();
+        Assert.DoesNotContain(bare.DocumentFormats.Formats, format => format.MatchesExtension(".pdf"));
+
+        using WriterApp desktop = CreateApp(DesktopFormats());
+        Assert.Contains(desktop.DocumentFormats.Formats, format => format.MatchesExtension(".pdf"));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Registering_A_Format_For_Saving_Needs_A_Codec_That_Writes()
+    {
+        // PdfDocumentCodec does implement writing, so this is the check that the
+        // capability is a host decision rather than a codec one: it is refused
+        // only where the host declines to enable it, not by the type system.
+        var format = new WriterDocumentFormat(
+            new PdfDocumentCodec(), "PDF", WriterFormatCapabilities.OpenAndSave);
+        Assert.True(format.CanSave);
+
+        Assert.Throws<ArgumentException>(() => new WriterDocumentFormats(
+        [
+            new WriterDocumentFormat(new PdfDocumentCodec(), "PDF", WriterFormatCapabilities.Open),
+            new WriterDocumentFormat(new PdfDocumentCodec(), "PDF again", WriterFormatCapabilities.Open),
+        ]));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Opens_A_Pdf_Through_The_Registered_Codec()
+    {
+        using WriterApp app = CreateApp(DesktopFormats());
+
+        using var stream = new MemoryStream(WritePdf("Quarterly report", "Prepared by the Writer."), writable: false);
+        Assert.True(app.LoadDocument(stream, "report.pdf"));
+
+        string text = app.Document.PlainText;
+        Assert.Contains("Quarterly report", text, StringComparison.Ordinal);
+        Assert.Contains("Prepared by the Writer.", text, StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Head_That_Did_Not_Register_Pdf_Refuses_One()
+    {
+        using WriterApp app = CreateApp();
+        string before = app.Document.PlainText;
+
+        using var stream = new MemoryStream(WritePdf("Quarterly report"), writable: false);
+        Assert.False(app.LoadDocument(stream, "report.pdf"));
+
+        Assert.Equal(before, app.Document.PlainText);
+        Assert.Contains("Could not open report.pdf", app.LastAction, StringComparison.Ordinal);
+        Assert.Contains("No composed codec recognized the source", app.LastAction, StringComparison.Ordinal);
+        Assert.Contains("The open document is unchanged.", app.LastAction, StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Rejected_Read_Leaves_The_Open_Document_Alone()
+    {
+        using WriterApp app = CreateApp(DesktopFormats());
+        string before = app.Document.PlainText;
+        Assert.NotEqual(string.Empty, before);
+
+        // A PDF header and then nothing a reader can use: the codec recognizes the
+        // file and rejects it, which must not cost the user the open document.
+        byte[] bytes = Encoding.ASCII.GetBytes("%PDF-1.7\n% not actually a PDF body\n");
+        using var stream = new MemoryStream(bytes, writable: false);
+        Assert.False(app.LoadDocument(stream, "broken.pdf"));
+
+        Assert.Equal(before, app.Document.PlainText);
+        Assert.Contains("Could not open broken.pdf", app.LastAction, StringComparison.Ordinal);
+        Assert.Contains("The open document is unchanged.", app.LastAction, StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Partial_Read_That_Recovered_No_Text_Is_Not_Committed()
+    {
+        // The shape a scanned PDF produces: the file parsed, every page carried
+        // image data and no text layer, and the reader says so. Committing that
+        // would replace the open document with a report about the reader.
+        Assert.False(WriterApp.MayReplaceDocument(new DocumentReadResult(
+            RichTextDocument.Empty,
+            [DocumentDiagnostic.Warning(PdfDiagnosticCodes.TextOcrRequired, "no extractable text")],
+            DocumentResultStatus.Partial)));
+
+        // A partial read that did recover text is committed; the status line is
+        // what says it was partial.
+        Assert.True(WriterApp.MayReplaceDocument(new DocumentReadResult(
+            RichTextDocument.FromPlainText("page one"),
+            [DocumentDiagnostic.Warning(PdfDiagnosticCodes.TextOcrRequired, "page two needs OCR")],
+            DocumentResultStatus.Partial)));
+
+        // An empty file that read cleanly is still an empty file, not a failure.
+        Assert.True(WriterApp.MayReplaceDocument(new DocumentReadResult(RichTextDocument.Empty)));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Partial_Open_Is_Never_Reported_As_A_Clean_One()
+    {
+        string status = WriterApp.DescribeOpen(
+            "report.pdf",
+            new DocumentReadResult(
+                RichTextDocument.FromPlainText("page one"),
+                [DocumentDiagnostic.Warning(PdfDiagnosticCodes.TextOcrRequired, "page two needs OCR")],
+                DocumentResultStatus.Partial));
+
+        Assert.Equal("Opened report.pdf with 1 note(s); parts of it were skipped or approximated", status);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Saving_As_Pdf_Is_Refused_Even_Where_Pdf_Opens()
+    {
+        using WriterApp app = CreateApp(DesktopFormats());
+
+        using var destination = new MemoryStream();
+        Assert.False(app.WriteDocument(destination, "report.pdf"));
+
+        Assert.Equal(0, destination.Length);
+        Assert.Contains("Unsupported save format '.pdf'", app.LastAction, StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 600000)]
+    public void The_Formats_Still_Save_Every_Format_They_Advertise()
+    {
+        using WriterApp app = CreateApp(DesktopFormats());
+
+        foreach (string extension in new[] { ".rtf", ".docx", ".html", ".md" })
+        {
+            using var destination = new MemoryStream();
+            Assert.True(app.WriteDocument(destination, "document" + extension));
+            Assert.True(destination.Length > 0, extension + " produced no bytes");
+        }
+    }
+
+    /// <summary>What the Windows and Linux heads compose.</summary>
+    private static WriterDocumentFormats DesktopFormats() =>
+        WriterDocumentFormats.CreateDefault().With(
+            new WriterDocumentFormat(new PdfDocumentCodec(), "PDF", WriterFormatCapabilities.Open));
+
+    private static bool FilterMentionsPdf(UiFileDialogFilter filter) =>
+        filter.Pattern.Contains("*.pdf", StringComparison.OrdinalIgnoreCase);
+
+    private static byte[] WritePdf(params string[] paragraphs)
+    {
+        RichTextDocument document = RichTextDocument.FromPlainText(string.Join("\n", paragraphs));
+        using var buffer = new MemoryStream();
+        DocumentWriteResult result = new PdfDocumentCodec().Write(document, buffer);
+        Assert.Equal(DocumentResultStatus.Success, result.Status);
+        return buffer.ToArray();
+    }
+
+    private static WriterApp CreateApp(WriterDocumentFormats? formats = null)
+    {
+        var host = new WriterUiHost(
+            () => new BSize(1200, 800),
+            () => 1,
+            () => { },
+            _ => { });
+        return new WriterApp(host, () => { }, documentFormats: formats);
+    }
+}

--- a/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
+++ b/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
@@ -23,6 +23,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
+    <!-- The PDF codec is referenced by the heads that register it, never by the
+         shared Writer core: a head must not acquire it transitively (PDF roadmap §10.1). -->
+    <ProjectReference Include="..\..\Broiler.Documents\Broiler.Documents.Pdf\Broiler.Documents.Pdf.csproj" />
     <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Linux\Broiler.Graphics.Linux.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Linux.OpenGL\Broiler.Graphics.Linux.OpenGL.csproj" />

--- a/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
+++ b/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
@@ -17,9 +17,13 @@ internal static class LinuxWriterRunner
     private static readonly TimeSpan OffscreenPollInterval = TimeSpan.FromMilliseconds(1);
     private static readonly BRenderOptions RenderOptions = new(Antialias: true, VSync: true, SubpixelText: true);
 
-    public static async Task<int> RunAsync(LinuxWriterOptions options, CancellationToken cancellationToken)
+    public static async Task<int> RunAsync(
+        LinuxWriterOptions options,
+        WriterDocumentFormats documentFormats,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(documentFormats);
 
         Console.WriteLine("Broiler Writer");
         Console.WriteLine();
@@ -63,7 +67,7 @@ internal static class LinuxWriterRunner
             () => clipboard is not null && clipboard.TryGetText(out string text) ? text : null,
             text => clipboard?.SetText(text),
             getRenderer: () => renderer);
-        using WriterApp app = new(host, () => closeRequested = true);
+        using WriterApp app = new(host, () => closeRequested = true, documentFormats: documentFormats);
 
         await using LinuxInputCoordinator input = new(canUseEvdev, Console.WriteLine, externalPointer: x11Window is not null);
         await input.InitializeAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Broiler.Writer.Linux/Program.cs
+++ b/src/Broiler.Writer.Linux/Program.cs
@@ -37,7 +37,9 @@ internal static class Program
 
         try
         {
-            return await LinuxWriterRunner.RunAsync(options, shutdown.Token).ConfigureAwait(false);
+            return await LinuxWriterRunner
+                .RunAsync(options, CreateDocumentFormats(), shutdown.Token)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (shutdown.IsCancellationRequested)
         {
@@ -49,4 +51,30 @@ internal static class Program
             return 1;
         }
     }
+
+    /// <summary>
+    /// The document formats this head offers: the shared four, plus PDF for
+    /// opening.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// PDF is registered here rather than in <c>Broiler.Writer.Core</c>
+    /// deliberately. Putting it in the shared core would hand it to every head
+    /// that references the core — including the Android and WebAssembly Writers,
+    /// whose package-size, memory, trimming and AOT gates it has not passed — and
+    /// a codec must not reach a head by being someone else's transitive reference
+    /// (PDF roadmap §10.1). Each head that wants it says so, here.
+    /// </para>
+    /// <para>
+    /// Opening only. <c>PdfDocumentCodec</c> implements writing, but PDF export
+    /// has its own release gate that has not been passed, so this head offers no
+    /// PDF save filter and its save dispatch has no PDF entry.
+    /// </para>
+    /// </remarks>
+    private static WriterDocumentFormats CreateDocumentFormats() =>
+        WriterDocumentFormats.CreateDefault().With(
+            new WriterDocumentFormat(
+                new Broiler.Documents.Pdf.PdfDocumentCodec(),
+                "PDF",
+                WriterFormatCapabilities.Open));
 }

--- a/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
+++ b/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
@@ -25,6 +25,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
+    <!-- The PDF codec is referenced by the heads that register it, never by the
+         shared Writer core: a head must not acquire it transitively (PDF roadmap §10.1). -->
+    <ProjectReference Include="..\..\Broiler.Documents\Broiler.Documents.Pdf\Broiler.Documents.Pdf.csproj" />
     <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
   </ItemGroup>

--- a/src/Broiler.Writer.Windows/Program.cs
+++ b/src/Broiler.Writer.Windows/Program.cs
@@ -21,7 +21,7 @@ internal static class Program
 
         try
         {
-            using var window = new WriterWindow();
+            using var window = new WriterWindow(CreateDocumentFormats());
             return window.Run();
         }
         catch (Exception ex)
@@ -30,6 +30,32 @@ internal static class Program
             return 1;
         }
     }
+
+    /// <summary>
+    /// The document formats this head offers: the shared four, plus PDF for
+    /// opening.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// PDF is registered here rather than in <c>Broiler.Writer.Core</c>
+    /// deliberately. Putting it in the shared core would hand it to every head
+    /// that references the core — including the Android and WebAssembly Writers,
+    /// whose package-size, memory, trimming and AOT gates it has not passed — and
+    /// a codec must not reach a head by being someone else's transitive reference
+    /// (PDF roadmap §10.1). Each head that wants it says so, here.
+    /// </para>
+    /// <para>
+    /// Opening only. <c>PdfDocumentCodec</c> implements writing, but PDF export
+    /// has its own release gate that has not been passed, so this head offers no
+    /// PDF save filter and its save dispatch has no PDF entry.
+    /// </para>
+    /// </remarks>
+    private static WriterDocumentFormats CreateDocumentFormats() =>
+        WriterDocumentFormats.CreateDefault().With(
+            new WriterDocumentFormat(
+                new Broiler.Documents.Pdf.PdfDocumentCodec(),
+                "PDF",
+                WriterFormatCapabilities.Open));
 
     private const uint MbOk = 0x00000000;
     private const uint MbIconError = 0x00000010;

--- a/src/Broiler.Writer.Windows/WriterWindow.cs
+++ b/src/Broiler.Writer.Windows/WriterWindow.cs
@@ -25,7 +25,7 @@ internal sealed class WriterWindow : Direct2DWindow
     private readonly StandardLegacyGraphicsInputAdapter _legacyInput = new("broiler-writer");
 #pragma warning restore CS0618
 
-    public WriterWindow()
+    public WriterWindow(WriterDocumentFormats documentFormats)
         : base(new BWindowOptions
         {
             Title = "Broiler Writer",
@@ -43,7 +43,7 @@ internal sealed class WriterWindow : Direct2DWindow
             ReadClipboardText,
             WriteClipboardText,
             getRenderer: () => Renderer);
-        _app = new WriterApp(_host, CloseNativeWindow);
+        _app = new WriterApp(_host, CloseNativeWindow, documentFormats: documentFormats);
     }
 
     protected override void OnCreated() => _clipboard = new WindowsClipboard(NativeHandle);

--- a/src/Broiler.Writer/WriterApp.cs
+++ b/src/Broiler.Writer/WriterApp.cs
@@ -3,12 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Broiler.Documents;
-using Broiler.Documents.Docx;
 using Broiler.Documents.FormatCodes;
-using Broiler.Documents.Html;
-using Broiler.Documents.Markdown;
 using Broiler.Documents.Model;
-using Broiler.Documents.Rtf;
 using Broiler.Graphics;
 using Broiler.Input.Keyboard;
 using Broiler.UI;
@@ -53,13 +49,10 @@ internal sealed class WriterApp : IDisposable
     private readonly StandardToolbar _toolbar;
     private readonly StandardLabel _title;
     private readonly StandardLabel _status;
-    private readonly DocumentCodecCatalog _documentCatalog = new(new DocumentCodec[]
-    {
-        new RtfDocumentCodec(),
-        new DocxDocumentCodec(),
-        new HtmlDocumentCodec(),
-        new MarkdownDocumentCodec(),
-    });
+    private readonly WriterDocumentFormats _documentFormats;
+    private readonly DocumentCodecCatalog _documentCatalog;
+    private readonly UiFileDialogFilter[] _openDocumentFileFilters;
+    private readonly UiFileDialogFilter[] _saveDocumentFileFilters;
     private readonly List<(UiMenuItem Item, RichEditCommand Command)> _richEditMenuItems = [];
     private readonly List<(StandardButton Button, RichEditCommand Command)> _toolbarActionButtons = [];
     private readonly List<(StandardToggleButton Button, RichEditCommand Command)> _toolbarToggleButtons = [];
@@ -71,24 +64,8 @@ internal sealed class WriterApp : IDisposable
     private string _lastAction = "Ready";
     private IReadOnlyList<DocumentDiagnostic> _lastReadDiagnostics = Array.Empty<DocumentDiagnostic>();
 
-    private const string DefaultDocumentExtension = ".rtf";
     private static readonly BSize FileDialogPreferredSize = new(740, 430);
     private static readonly BSize FontDialogPreferredSize = new(520, 322);
-    private static readonly UiFileDialogFilter[] OpenDocumentFileFilters =
-    [
-        new("All supported documents", "*.rtf;*.docx;*.html;*.htm;*.md;*.markdown", DefaultDocumentExtension),
-        new("Rich Text Format (*.rtf)", "*.rtf", ".rtf"),
-        new("Word Document (*.docx)", "*.docx", ".docx"),
-        new("HTML (*.html, *.htm)", "*.html;*.htm", ".html"),
-        new("Markdown (*.md, *.markdown)", "*.md;*.markdown", ".md"),
-    ];
-    private static readonly UiFileDialogFilter[] SaveDocumentFileFilters =
-    [
-        new("Rich Text Format (*.rtf)", "*.rtf", ".rtf"),
-        new("Word Document (*.docx)", "*.docx", ".docx"),
-        new("HTML (*.html)", "*.html;*.htm", ".html"),
-        new("Markdown (*.md)", "*.md;*.markdown", ".md"),
-    ];
     private static readonly UiFileDialogFilter[] OpenPictureFileFilters =
     [
         new("Images", "*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.webp", ".png"),
@@ -101,18 +78,30 @@ internal sealed class WriterApp : IDisposable
     /// <summary>The widest a freshly inserted picture is placed at, in editor units.</summary>
     private const double MaxInsertedPictureWidth = 420;
 
+    /// <param name="documentFormats">
+    /// The formats this Writer offers. Null composes
+    /// <see cref="WriterDocumentFormats.CreateDefault"/> — the RTF, DOCX, HTML and
+    /// Markdown set every head has always had. A head that carries more (the
+    /// desktop heads register the PDF codec for opening) passes its own set here,
+    /// which is what keeps that codec out of the heads that did not ask for it.
+    /// </param>
     public WriterApp(
         WriterUiHost host,
         Action requestClose,
         Action? requestOpenDocument = null,
         Action<string, bool>? requestSaveDocument = null,
-        bool compactMode = false)
+        bool compactMode = false,
+        WriterDocumentFormats? documentFormats = null)
     {
         _host = host ?? throw new ArgumentNullException(nameof(host));
         _requestClose = requestClose ?? throw new ArgumentNullException(nameof(requestClose));
         _requestOpenDocument = requestOpenDocument;
         _requestSaveDocument = requestSaveDocument;
         _compactMode = compactMode;
+        _documentFormats = documentFormats ?? WriterDocumentFormats.CreateDefault();
+        _documentCatalog = _documentFormats.CreateOpenCatalog();
+        _openDocumentFileFilters = _documentFormats.CreateOpenFilters();
+        _saveDocumentFileFilters = _documentFormats.CreateSaveFilters();
         _session = new StandardUiSessionBuilder()
             .WithDispatcher(new ImmediateUiDispatcher())
             .Build(_host);
@@ -231,6 +220,12 @@ internal sealed class WriterApp : IDisposable
     /// </summary>
     internal IReadOnlyList<DocumentDiagnostic> LastReadDiagnostics => _lastReadDiagnostics;
 
+    /// <summary>The formats this Writer was composed with.</summary>
+    internal WriterDocumentFormats DocumentFormats => _documentFormats;
+
+    /// <summary>The most recent status-bar line, which is where a refused open is reported.</summary>
+    internal string LastAction => _lastAction;
+
     public BRenderList RenderFrame() => _session.RenderFrame();
 
     public void Dispatch(UiInputEvent input)
@@ -254,13 +249,21 @@ internal sealed class WriterApp : IDisposable
 
         try
         {
-            using var copy = new MemoryStream();
-            stream.CopyTo(copy);
-            DocumentReadResult result = ReadDocument(displayName, copy.ToArray());
+            // The input replays the probed prefix ahead of the rest, so a stream
+            // the host cannot rewind is still probed and read exactly once.
+            using DocumentInput input = DocumentInput.FromStream(stream);
+            DocumentCodecSelection selection = ReadDocument(displayName, input);
+            if (!MayReplaceDocument(selection.Result))
+            {
+                _lastAction = DescribeRefusedOpen(Path.GetFileName(displayName), selection);
+                RefreshUi();
+                return false;
+            }
+
             _currentDocumentPath = displayName;
             _title.Text = Path.GetFileName(displayName);
-            _lastAction = DescribeOpen(Path.GetFileName(displayName), result);
-            _editor.Document = result.Document;
+            _lastAction = DescribeOpen(Path.GetFileName(displayName), selection.Result);
+            _editor.Document = selection.Result.Document;
             _editor.Selection = RichTextRange.Caret(_editor.Document.Start);
             _session.SetFocus(_editor);
             RefreshUi();
@@ -645,7 +648,7 @@ internal sealed class WriterApp : IDisposable
             FileName = _currentDocumentPath is null ? string.Empty : Path.GetFileName(_currentDocumentPath),
             PreferredSize = FileDialogPreferredSize,
         };
-        dialog.SetFileTypeFilters(OpenDocumentFileFilters);
+        dialog.SetFileTypeFilters(_openDocumentFileFilters);
         dialog.ResultCompleted += (_, e) =>
         {
             if (e.Result.Kind == UiDialogResultKind.Accepted && !string.IsNullOrWhiteSpace(e.Result.Value))
@@ -698,8 +701,8 @@ internal sealed class WriterApp : IDisposable
             PreferredSize = FileDialogPreferredSize,
         };
         dialog.SetFileTypeFilters(
-            SaveDocumentFileFilters,
-            GetFileTypeFilterIndex(SaveDocumentFileFilters, _currentDocumentPath));
+            _saveDocumentFileFilters,
+            GetFileTypeFilterIndex(_saveDocumentFileFilters, _currentDocumentPath));
         dialog.ResultCompleted += (_, e) =>
         {
             if (e.Result.Kind == UiDialogResultKind.Accepted && !string.IsNullOrWhiteSpace(e.Result.Value))
@@ -716,13 +719,25 @@ internal sealed class WriterApp : IDisposable
         try
         {
             string fullPath = ResolveDocumentPath(path);
-            byte[] bytes = File.ReadAllBytes(fullPath);
-            DocumentReadResult result = ReadDocument(fullPath, bytes);
+
+            // Streamed rather than File.ReadAllBytes: the read's own limits decide
+            // how much of a file is allowed into memory, so an oversized document
+            // is refused instead of being materialized and then measured.
+            using FileStream file = File.OpenRead(fullPath);
+            using DocumentInput input = DocumentInput.FromStream(file);
+            DocumentCodecSelection selection = ReadDocument(fullPath, input);
+            if (!MayReplaceDocument(selection.Result))
+            {
+                _lastAction = DescribeRefusedOpen(Path.GetFileName(fullPath), selection);
+                RefreshUi();
+                return;
+            }
+
             _currentDocumentPath = fullPath;
             _lastDirectory = Path.GetDirectoryName(fullPath) ?? _lastDirectory;
             _title.Text = Path.GetFileName(fullPath);
-            _lastAction = DescribeOpen(Path.GetFileName(fullPath), result);
-            _editor.Document = result.Document;
+            _lastAction = DescribeOpen(Path.GetFileName(fullPath), selection.Result);
+            _editor.Document = selection.Result.Document;
             _editor.Selection = RichTextRange.Caret(_editor.Document.Start);
             _session.SetFocus(_editor);
         }
@@ -977,24 +992,61 @@ internal sealed class WriterApp : IDisposable
     private string ResolveDocumentPath(string path)
     {
         string fullPath = Path.GetFullPath(path);
-        return Path.HasExtension(fullPath) ? fullPath : fullPath + DefaultDocumentExtension;
+        return Path.HasExtension(fullPath) ? fullPath : fullPath + _documentFormats.DefaultExtension;
     }
 
-    private DocumentReadResult ReadDocument(string fullPath, byte[] bytes)
+    /// <summary>
+    /// Selects a codec for <paramref name="input"/> and reads it through the one
+    /// authoritative catalog path, so the bytes the probe saw are the bytes the
+    /// codec reads and a source is never buffered twice to make that true.
+    /// </summary>
+    private DocumentCodecSelection ReadDocument(string fullPath, DocumentInput input)
     {
-        using var probeStream = new MemoryStream(bytes, writable: false);
-        DocumentCodecMatch? match = _documentCatalog.Select(
-            probeStream,
-            new DocumentSourceHints(fileName: fullPath));
+        DocumentCodecSelection selection = _documentCatalog.SelectAndRead(
+            input,
+            hints: new DocumentSourceHints(fileName: fullPath));
 
-        if (match is null || !match.Codec.CanRead)
-            throw new NotSupportedException("No readable document codec recognized '" + Path.GetExtension(fullPath) + "'.");
+        _lastReadDiagnostics = selection.Result.Diagnostics;
+        LogReadDiagnostics(selection.Codec?.Name ?? "no codec", fullPath, selection.Result);
+        return selection;
+    }
 
-        using var readStream = new MemoryStream(bytes, writable: false);
-        DocumentReadResult result = match.Codec.Read(readStream);
-        _lastReadDiagnostics = result.Diagnostics;
-        LogReadDiagnostics(match.Codec.Name, fullPath, result);
-        return result;
+    /// <summary>
+    /// Whether a read may replace what is in the editor.
+    /// </summary>
+    /// <remarks>
+    /// Two reads must never land in the editor. A <see cref="DocumentResultStatus.Rejected"/>
+    /// one carries a placeholder rather than content, and committing it would
+    /// throw away the open document in exchange for nothing. So would a read that
+    /// recovered no text at all and knows it is incomplete — a scanned PDF with no
+    /// text layer is the shape that produces it — where "empty" is a report about
+    /// the reader, not about the file. A read that produced text is committed even
+    /// when it is <see cref="DocumentResultStatus.Partial"/>; the status line says
+    /// so rather than passing it off as a clean open.
+    /// </remarks>
+    internal static bool MayReplaceDocument(DocumentReadResult result) =>
+        result.IsUsable &&
+        (result.Document.PlainText.Length > 0 || result.Status == DocumentResultStatus.Success);
+
+    /// <summary>Why a read was refused, for the status bar.</summary>
+    internal static string DescribeRefusedOpen(string fileName, DocumentCodecSelection selection)
+    {
+        string reason = FirstProblem(selection.Result) ?? (selection.Codec is null
+            ? "no registered format recognized it"
+            : "the " + selection.Codec.Name + " reader recovered no content from it");
+
+        return "Could not open " + fileName + ": " + reason.TrimEnd('.') + ". The open document is unchanged.";
+    }
+
+    private static string? FirstProblem(DocumentReadResult result)
+    {
+        foreach (DocumentDiagnostic diagnostic in result.Diagnostics)
+        {
+            if (diagnostic.Severity != DocumentDiagnosticSeverity.Info)
+                return diagnostic.Message;
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1038,27 +1090,36 @@ internal sealed class WriterApp : IDisposable
                 notes++;
         }
 
-        return notes == 0
-            ? text
-            : text + " with " + notes.ToString(CultureInfo.InvariantCulture) + " note(s)";
+        if (notes > 0)
+            text += " with " + notes.ToString(CultureInfo.InvariantCulture) + " note(s)";
+
+        // A partial read is a different outcome from a clean one, not a clean one
+        // with footnotes, so it is never reported as undifferentiated success.
+        return result.Status == DocumentResultStatus.Partial
+            ? text + "; parts of it were skipped or approximated"
+            : text;
     }
 
-    private static DocumentWriteResult WriteDocument(
+    /// <summary>
+    /// Writes through the codec the host registered for the target extension.
+    /// A format registered for opening only has no entry here, so a save cannot
+    /// reach a writer the host did not enable — not through the Save dialog,
+    /// whose filters come from the same set, and not through a typed filename
+    /// either.
+    /// </summary>
+    private DocumentWriteResult WriteDocument(
         string fullPath,
         RichTextDocument document,
         out byte[] bytes)
     {
-        string extension = Path.GetExtension(fullPath).ToLowerInvariant();
-        using var stream = new MemoryStream();
-        DocumentWriteResult result = extension switch
-        {
-            ".rtf" => RtfWriter.Write(document, stream),
-            ".docx" => DocxWriter.Write(document, stream),
-            ".html" or ".htm" => HtmlWriter.Write(document, stream),
-            ".md" or ".markdown" => MarkdownWriter.Write(document, stream),
-            _ => throw new NotSupportedException("Unsupported save format '" + extension + "'. Use .rtf, .docx, .html, or .md."),
-        };
+        string extension = Path.GetExtension(fullPath);
+        WriterDocumentFormat format = _documentFormats.FindForSave(extension) ??
+            throw new NotSupportedException(
+                "Unsupported save format '" + extension + "'. Use " +
+                _documentFormats.DescribeSaveExtensions() + ".");
 
+        using var stream = new MemoryStream();
+        DocumentWriteResult result = format.Codec.Write(document, stream);
         bytes = stream.ToArray();
         return result;
     }

--- a/src/Broiler.Writer/WriterDocumentFormat.cs
+++ b/src/Broiler.Writer/WriterDocumentFormat.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Broiler.Documents;
+using Broiler.UI.FileDialog;
+
+namespace Broiler.Writer;
+
+/// <summary>What a composition root lets the Writer do with one document format.</summary>
+/// <remarks>
+/// A codec's own <see cref="DocumentCodec.CanRead"/>/<see cref="DocumentCodec.CanWrite"/>
+/// say what it implements; this says what the host chose to offer. The two are
+/// deliberately separate — a codec whose writer exists but has not cleared its
+/// release gate is registered for opening only, and no save filter, save
+/// destination, or save dispatch can reach it.
+/// </remarks>
+[Flags]
+public enum WriterFormatCapabilities
+{
+    /// <summary>Registered but offered for nothing. Useful only in tests.</summary>
+    None = 0,
+
+    /// <summary>The format appears in the Open dialog and can be selected for reading.</summary>
+    Open = 1 << 0,
+
+    /// <summary>The format appears in the Save dialog and can be written.</summary>
+    Save = 1 << 1,
+
+    /// <summary>Both.</summary>
+    OpenAndSave = Open | Save,
+}
+
+/// <summary>
+/// One document codec as a host composed it: the codec, the name the file
+/// dialogs show, and the capabilities the host enabled.
+/// </summary>
+public sealed class WriterDocumentFormat
+{
+    public WriterDocumentFormat(
+        DocumentCodec codec,
+        string displayName,
+        WriterFormatCapabilities capabilities = WriterFormatCapabilities.OpenAndSave)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ArgumentException("A document format needs a display name.", nameof(displayName));
+        if (codec.Descriptor.FileExtensions.Count == 0)
+            throw new ArgumentException(
+                $"The {codec.Descriptor.Name} codec declares no file extension, so the Writer cannot offer it in a file dialog.",
+                nameof(codec));
+
+        // A host can offer less than a codec implements, never more: enabling a
+        // capability the codec does not have would produce a filter the dispatch
+        // then has to refuse.
+        if ((capabilities & WriterFormatCapabilities.Open) != 0 && !codec.CanRead)
+            throw new ArgumentException(
+                $"The {codec.Descriptor.Name} codec does not implement reading, so it cannot be registered for opening.",
+                nameof(capabilities));
+        if ((capabilities & WriterFormatCapabilities.Save) != 0 && !codec.CanWrite)
+            throw new ArgumentException(
+                $"The {codec.Descriptor.Name} codec does not implement writing, so it cannot be registered for saving.",
+                nameof(capabilities));
+
+        Codec = codec;
+        DisplayName = displayName.Trim();
+        Capabilities = capabilities;
+    }
+
+    public DocumentCodec Codec { get; }
+
+    /// <summary>The format name a file dialog shows, without the pattern suffix.</summary>
+    public string DisplayName { get; }
+
+    public WriterFormatCapabilities Capabilities { get; }
+
+    public bool CanOpen => (Capabilities & WriterFormatCapabilities.Open) != 0;
+
+    public bool CanSave => (Capabilities & WriterFormatCapabilities.Save) != 0;
+
+    public IReadOnlyList<string> FileExtensions => Codec.Descriptor.FileExtensions;
+
+    /// <summary>The extension a name without one is completed with.</summary>
+    public string DefaultExtension => FileExtensions[0];
+
+    /// <summary>The dialog pattern, e.g. <c>*.html;*.htm</c>.</summary>
+    public string FilterPattern => string.Join(";", Patterns());
+
+    /// <summary>The dialog label, e.g. <c>HTML (*.html, *.htm)</c>.</summary>
+    public string FilterName => DisplayName + " (" + string.Join(", ", Patterns()) + ")";
+
+    public UiFileDialogFilter CreateFilter() => new(FilterName, FilterPattern, DefaultExtension);
+
+    public bool MatchesExtension(string? extension) => Codec.Descriptor.MatchesExtension(extension);
+
+    private IEnumerable<string> Patterns()
+    {
+        foreach (string extension in FileExtensions)
+            yield return "*" + extension;
+    }
+}

--- a/src/Broiler.Writer/WriterDocumentFormats.cs
+++ b/src/Broiler.Writer/WriterDocumentFormats.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Broiler.Documents;
+using Broiler.Documents.Docx;
+using Broiler.Documents.Html;
+using Broiler.Documents.Markdown;
+using Broiler.Documents.Rtf;
+using Broiler.UI.FileDialog;
+
+namespace Broiler.Writer;
+
+/// <summary>
+/// The document formats one Writer instance offers, composed by the host rather
+/// than discovered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Writer used to hard-code its codec catalog and its two filter arrays, so
+/// every head — desktop, Android, WebAssembly — got exactly the same formats and
+/// adding one to the shared core added it everywhere. Composition roots build
+/// this instead: <see cref="CreateDefault"/> is the four formats every head has
+/// always had, and anything beyond that is registered by the head that wants it
+/// and reaches no other (PDF roadmap §10.1).
+/// </para>
+/// <para>
+/// The instance is not shared between Writer instances: <see cref="CreateDefault"/>
+/// builds fresh codecs each call, so two Writers in one process never reach the
+/// same codec object.
+/// </para>
+/// </remarks>
+public sealed class WriterDocumentFormats
+{
+    private readonly ReadOnlyCollection<WriterDocumentFormat> _formats;
+
+    public WriterDocumentFormats(IEnumerable<WriterDocumentFormat> formats)
+    {
+        ArgumentNullException.ThrowIfNull(formats);
+
+        WriterDocumentFormat[] array = formats.ToArray();
+        var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (WriterDocumentFormat format in array)
+        {
+            if (format is null)
+                throw new ArgumentException("The format collection contains a null entry.", nameof(formats));
+
+            // Two formats claiming one extension make the save dispatch ambiguous
+            // and the open filters misleading, so it is refused at composition
+            // rather than resolved by registration order at runtime.
+            foreach (string extension in format.FileExtensions)
+            {
+                if (!extensions.Add(extension))
+                    throw new ArgumentException(
+                        $"Two registered formats both claim '{extension}'; the second is {format.DisplayName}.",
+                        nameof(formats));
+            }
+        }
+
+        _formats = Array.AsReadOnly(array);
+    }
+
+    /// <summary>
+    /// The formats every Writer head has carried: RTF, DOCX, HTML and Markdown,
+    /// all readable and writable. Each call composes its own codec instances.
+    /// </summary>
+    public static WriterDocumentFormats CreateDefault() => new(
+    [
+        new WriterDocumentFormat(new RtfDocumentCodec(), "Rich Text Format"),
+        new WriterDocumentFormat(new DocxDocumentCodec(), "Word Document"),
+        new WriterDocumentFormat(new HtmlDocumentCodec(), "HTML"),
+        new WriterDocumentFormat(new MarkdownDocumentCodec(), "Markdown"),
+    ]);
+
+    public IReadOnlyList<WriterDocumentFormat> Formats => _formats;
+
+    /// <summary>This set plus <paramref name="additional"/>, leaving this one unchanged.</summary>
+    public WriterDocumentFormats With(params WriterDocumentFormat[] additional)
+    {
+        ArgumentNullException.ThrowIfNull(additional);
+        return new WriterDocumentFormats(_formats.Concat(additional));
+    }
+
+    /// <summary>
+    /// A catalog over the codecs enabled for opening. A codec registered for
+    /// saving only is absent, so it cannot be selected by a content probe either.
+    /// </summary>
+    public DocumentCodecCatalog CreateOpenCatalog() =>
+        new(_formats.Where(static format => format.CanOpen).Select(static format => format.Codec));
+
+    /// <summary>The format that writes <paramref name="extension"/>, or null when none does.</summary>
+    public WriterDocumentFormat? FindForSave(string? extension) =>
+        _formats.FirstOrDefault(format => format.CanSave && format.MatchesExtension(extension));
+
+    /// <summary>The extension a document name without one is completed with.</summary>
+    public string DefaultExtension =>
+        _formats.FirstOrDefault(static format => format.CanSave)?.DefaultExtension ??
+        _formats.FirstOrDefault()?.DefaultExtension ??
+        ".rtf";
+
+    /// <summary>
+    /// The Open dialog filters: an aggregate of everything openable, then one
+    /// filter per format.
+    /// </summary>
+    public UiFileDialogFilter[] CreateOpenFilters()
+    {
+        WriterDocumentFormat[] openable = _formats.Where(static format => format.CanOpen).ToArray();
+        if (openable.Length == 0)
+            return [];
+
+        var filters = new List<UiFileDialogFilter>(openable.Length + 1)
+        {
+            new(
+                "All supported documents",
+                string.Join(";", openable.Select(static format => format.FilterPattern)),
+                DefaultExtension),
+        };
+        filters.AddRange(openable.Select(static format => format.CreateFilter()));
+        return filters.ToArray();
+    }
+
+    /// <summary>The Save dialog filters, one per format enabled for saving.</summary>
+    public UiFileDialogFilter[] CreateSaveFilters() =>
+        _formats.Where(static format => format.CanSave).Select(static format => format.CreateFilter()).ToArray();
+
+    /// <summary>
+    /// The extensions a save can name, for the message a save to anything else
+    /// fails with. A format registered for opening only is deliberately absent.
+    /// </summary>
+    public string DescribeSaveExtensions()
+    {
+        string[] extensions = _formats
+            .Where(static format => format.CanSave)
+            .Select(static format => format.DefaultExtension)
+            .ToArray();
+
+        return extensions.Length switch
+        {
+            0 => "no format is registered for saving",
+            1 => extensions[0],
+            _ => string.Join(", ", extensions[..^1]) + ", or " + extensions[^1],
+        };
+    }
+}


### PR DESCRIPTION
Implement the read-preview integration candidate for PDF support (roadmap §10.1) by making document formats composable rather than hard-coded, allowing the Windows and Linux Writer heads to register the PDF codec for opening while keeping it out of other heads and the shared core.

## Summary

The Writer previously hard-coded its codec catalog and file-dialog filters, so every head received the same formats. This change extracts format composition into `WriterDocumentFormats` and `WriterDocumentFormat` classes, allowing each head to declare which codecs it offers and with what capabilities (open, save, or both). The Windows and Linux heads now register `PdfDocumentCodec` for opening only; other heads and the shared core remain unchanged.

## Key changes

- **New composition types** (`WriterDocumentFormat`, `WriterDocumentFormats`): Codecs are now registered with a display name and capability flags, separate from what the codec itself implements. A codec can be offered for opening only even if it implements writing, enabling PDF to be opened while its export gate remains closed.

- **Injected format sets**: `WriterApp` now accepts an optional `WriterDocumentFormats` parameter. Null defaults to `CreateDefault()` (RTF, DOCX, HTML, Markdown), preserving behavior for heads that do not pass one. Windows and Linux heads pass their own set that includes PDF for opening.

- **Streamed document reading**: The open path now uses `DocumentCodecCatalog.SelectAndRead` over `DocumentInput` instead of `File.ReadAllBytes`, so probing and reading observe the same bytes without buffering twice, and the read's own limits decide memory usage rather than materializing the entire file first.

- **Guarded delivery**: `PdfDeliveryGuardTests` now enforces that PDF is named only in the two desktop composition roots and their test coverage, never in the shared core or mobile heads. The test also verifies that every registration uses `WriterFormatCapabilities.Open` only.

- **Partial-read handling**: `WriterApp.MayReplaceDocument` refuses to commit reads that recovered no text (e.g., scanned PDFs with no text layer), preserving the open document instead of replacing it with a diagnostic report.

## Implementation details

- Format registration is validated at composition time: duplicate extensions are rejected, and a capability cannot be enabled if the codec does not implement it.
- The save dispatch reads the same format set the filters come from, so typing `.pdf` into the Save box has no effect even where PDF opens.
- Each `WriterApp` instance gets its own codec instances via `CreateDefault()`, so two Writers in one process never share codec state.
- The Windows and Linux `Program.cs` files each define `CreateDocumentFormats()` to compose their format set, with detailed comments explaining why PDF is registered there rather than in the shared core.

https://claude.ai/code/session_01F4gU3jrBqW9b7ttwQHxkPK