### PR TITLE
Drop the redundant (KeyString) casts at FastAddValue/FastAddProperty call sites

### DIFF
--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -1387,7 +1387,7 @@ public class CaptureService
         var classes = new List<string>();
 
         classList.FastAddValue(
-            (KeyString)"add",
+            "add",
             new JSFunction((in Arguments a) =>
             {
                 for (var i = 0; i < a.Length; i++)
@@ -1400,7 +1400,7 @@ public class CaptureService
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue(
-            (KeyString)"remove",
+            "remove",
             new JSFunction((in Arguments a) =>
             {
                 for (var i = 0; i < a.Length; i++)
@@ -1410,7 +1410,7 @@ public class CaptureService
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue(
-            (KeyString)"contains",
+            "contains",
             new JSFunction((in Arguments a) =>
             {
                 if (a.Length == 0) return JSBoolean.False;
@@ -1419,12 +1419,12 @@ public class CaptureService
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         docElement.FastAddValue(
-            (KeyString)"classList",
+            "classList",
             classList,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         document.FastAddValue(
-            (KeyString)"documentElement",
+            "documentElement",
             docElement,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -1433,7 +1433,7 @@ public class CaptureService
         // window stub with localStorage and matchMedia
         var window = new JSObject();
         window.FastAddValue(
-            (KeyString)"document",
+            "document",
             document,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -1446,11 +1446,11 @@ public class CaptureService
         var sessionStorage = Broiler.HtmlBridge.Dom.Features.WebStorageBinding.BuildStorage();
 
         window.FastAddValue(
-            (KeyString)"localStorage",
+            "localStorage",
             localStorage,
             JSPropertyAttributes.EnumerableConfigurableValue);
         window.FastAddValue(
-            (KeyString)"sessionStorage",
+            "sessionStorage",
             sessionStorage,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -1459,16 +1459,16 @@ public class CaptureService
 
         // window.matchMedia(query) — stub returning { matches: false }
         window.FastAddValue(
-            (KeyString)"matchMedia",
+            "matchMedia",
             new JSFunction((in Arguments a) =>
             {
                 var result = new JSObject();
                 result.FastAddValue(
-                    (KeyString)"matches",
+                    "matches",
                     JSBoolean.False,
                     JSPropertyAttributes.EnumerableConfigurableValue);
                 result.FastAddValue(
-                    (KeyString)"media",
+                    "media",
                     a.Length > 0 ? new JSString(a[0]?.ToString() ?? string.Empty) : new JSString(string.Empty),
                     JSPropertyAttributes.EnumerableConfigurableValue);
                 return result;
@@ -1543,7 +1543,7 @@ public class CaptureService
             var weakRef = new WeakReference<JSValue>(target);
 
             var instance = new JSObject();
-            instance.FastAddValue((KeyString)"deref", new JSFunction((in Arguments _) =>
+            instance.FastAddValue("deref", new JSFunction((in Arguments _) =>
             {
                 return weakRef.TryGetTarget(out var t) ? t : JSUndefined.Value;
             }, "deref", 0), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -1571,12 +1571,12 @@ public class CaptureService
         {
             var instance = new JSObject();
 
-            instance.FastAddValue((KeyString)"register", new JSFunction((in Arguments _) =>
+            instance.FastAddValue("register", new JSFunction((in Arguments _) =>
             {
                 return JSUndefined.Value;
             }, "register", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-            instance.FastAddValue((KeyString)"unregister", new JSFunction((in Arguments _) =>
+            instance.FastAddValue("unregister", new JSFunction((in Arguments _) =>
             {
                 return JSBoolean.False;
             }, "unregister", 1), JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.DialogHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.DialogHost.cs
@@ -71,9 +71,9 @@ public sealed partial class DomBridge : IDialogHost
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("fullscreenchange"),
+            evt.FastAddValue("type", new JSString("fullscreenchange"),
                 JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.True,
+            evt.FastAddValue("bubbles", JSBoolean.True,
                 JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(target, evt);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ElementInternalsHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ElementInternalsHost.cs
@@ -57,9 +57,9 @@ public sealed partial class DomBridge : IElementInternalsHost
     void IElementInternalsHost.DispatchInvalidEvent(DomElement element)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("invalid"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("invalid"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
         DispatchEventOnElement(element, evt);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ScriptInsertionHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ScriptInsertionHost.cs
@@ -44,8 +44,8 @@ public sealed partial class DomBridge : Dom.Runtime.IScriptInsertionHost
             // addEventListener registration — all three land on the one dispatch path.
             ToJSObject(target);
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString(type), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString(type), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(target, evt);
         }
         catch (Exception ex)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.SubDocumentGlobals.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.SubDocumentGlobals.cs
@@ -93,7 +93,7 @@ public sealed partial class DomBridge
                 if (value is null || value.IsUndefined)
                     continue;
 
-                subWindow.FastAddValue((KeyString)name,
+                subWindow.FastAddValue(name,
                     value is JSFunction declared ? BindToFrameContext(declared, subWindow, name) : value,
                     JSPropertyAttributes.EnumerableConfigurableValue);
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.SubDocument.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.SubDocument.cs
@@ -77,11 +77,11 @@ public sealed partial class DomBridge
         }
 
         var transition = new JSObject();
-        transition.FastAddValue((KeyString)"ready", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
-        transition.FastAddValue((KeyString)"finished", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
-        transition.FastAddValue((KeyString)"updateCallbackDone", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
-        transition.FastAddValue((KeyString)"types", new JavaScript.BuiltIns.Array.JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
-        transition.FastAddValue((KeyString)"skipTransition",
+        transition.FastAddValue("ready", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("finished", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("updateCallbackDone", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("types", new JavaScript.BuiltIns.Array.JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("skipTransition",
             new DomFunction((in _) =>
             {
                 _subDocumentViewTransitionOldMarkup.Remove(docRoot);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -197,23 +197,23 @@ public sealed partial class DomBridge
     private JSObject BuildViewTransitionObject(ViewTransitionState state)
     {
         var transition = new JSObject();
-        transition.FastAddValue((KeyString)"ready", ReadyThenable(state), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("ready", ReadyThenable(state), JSPropertyAttributes.EnumerableConfigurableValue);
         // `finished` resolving means the transition is over: the ::view-transition tree has been
         // removed and the DOM is back to its plain final state. A reftest that screenshots from
         // finished (rather than ready) therefore expects the final DOM, not the pseudo tree — so
         // realizing this thenable clears the active transition, and the serialize-time bake becomes
         // a no-op (WPT element-stops-grouping-after-animation).
-        transition.FastAddValue((KeyString)"finished", FinishedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
-        transition.FastAddValue((KeyString)"updateCallbackDone", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("finished", FinishedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("updateCallbackDone", ResolvedThenable(), JSPropertyAttributes.EnumerableConfigurableValue);
 
         var typesArray = new JavaScript.BuiltIns.Array.JSArray();
         foreach (var type in state.Types)
             typesArray.Add(new JavaScript.BuiltIns.String.JSString(type));
-        transition.FastAddValue((KeyString)"types", typesArray, JSPropertyAttributes.EnumerableConfigurableValue);
+        transition.FastAddValue("types", typesArray, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // skipTransition() ends the transition without animating; the still is already the final
         // state here, so it is a no-op beyond clearing the active state.
-        transition.FastAddValue((KeyString)"skipTransition",
+        transition.FastAddValue("skipTransition",
             new DomFunction((in _) => { _activeViewTransition = null; return JSUndefined.Value; }, "skipTransition", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -240,9 +240,9 @@ public sealed partial class DomBridge
             }
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"finally",
+        thenable.FastAddValue("then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("finally",
             new DomFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;
@@ -293,9 +293,9 @@ public sealed partial class DomBridge
             Run(args.Length > 0 ? args[0] as JSFunction : null);
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"finally",
+        thenable.FastAddValue("then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("finally",
             new DomFunction((in a) => { Run(a.Length > 0 ? a[0] as JSFunction : null); return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;
@@ -364,9 +364,9 @@ public sealed partial class DomBridge
             RunAndMaybeFinish(args.Length > 0 ? args[0] as JSFunction : null);
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"finally",
+        thenable.FastAddValue("then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("finally",
             new DomFunction((in a) => { RunAndMaybeFinish(a.Length > 0 ? a[0] as JSFunction : null); return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
@@ -47,8 +47,8 @@ public sealed partial class DomBridge
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("readystatechange"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString("readystatechange"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(_document, evt);
         }
         catch (Exception ex)
@@ -117,8 +117,8 @@ public sealed partial class DomBridge
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("load"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString("load"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(element, evt);
         }
         catch (Exception ex)
@@ -269,8 +269,8 @@ public sealed partial class DomBridge
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("DOMContentLoaded"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString("DOMContentLoaded"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(_document, evt);
         }
         catch (Exception ex)
@@ -293,8 +293,8 @@ public sealed partial class DomBridge
     private JSBoolean DispatchWindowEvent(string eventType, bool bubbles = false)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString(eventType), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", bubbles ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString(eventType), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", bubbles ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
         return DispatchWindowEvent(evt);
     }
 
@@ -304,10 +304,10 @@ public sealed partial class DomBridge
             return JSBoolean.True;
 
         var eventType = evt[(KeyString)"type"]?.ToString() ?? "unknown";
-        evt.FastAddValue((KeyString)"target", _windowJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", _windowJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
         evt[(KeyString)"srcElement"] = _windowJSObject;
-        evt.FastAddValue((KeyString)"currentTarget", _windowJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", _windowJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         var immediateStopped = false;
         var prevented = evt[(KeyString)"defaultPrevented"] is JSValue defaultPreventedValue &&
@@ -315,26 +315,26 @@ public sealed partial class DomBridge
         var currentListenerPassive = false;
         var legacyCancelBubble = false;
         evt[(KeyString)"defaultPrevented"] = prevented ? JSBoolean.True : JSBoolean.False;
-        evt.FastAddValue((KeyString)"stopPropagation",
+        evt.FastAddValue("stopPropagation",
             new DomFunction((in _) => JsCallbackStopPropagation001Core(ref legacyCancelBubble, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"stopImmediatePropagation",
+        evt.FastAddValue("stopImmediatePropagation",
             new DomFunction((in _) => JsCallbackStopImmediatePropagation002Core(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"preventDefault",
+        evt.FastAddValue("preventDefault",
             new DomFunction((in _) => JsCallbackPreventDefault003Core(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddProperty(
-            (KeyString)"cancelBubble",
+            "cancelBubble",
             new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
             new DomFunction((in setArgs) => JsCallbackSetCancelBubble005Core(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         evt.FastAddProperty(
-            (KeyString)"returnValue",
+            "returnValue",
             new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
             new DomFunction((in setArgs) => JsCallbackSetReturnValue007Core(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
-        evt.FastAddValue((KeyString)"composedPath",
+        evt.FastAddValue("composedPath",
             new DomFunction((in _) => new JSArray(_windowJSObject), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CharacterDataInterface.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CharacterDataInterface.cs
@@ -297,13 +297,13 @@ public sealed partial class DomBridge
     /// the member changes.
     /// </remarks>
     private static void AddPrototypeMethod(JSObject proto, string name, int length, JSFunctionDelegate body) =>
-        proto.FastAddValue((KeyString)name, new DomFunction(body, name, length),
+        proto.FastAddValue(name, new DomFunction(body, name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
     /// <summary>Adds a WebIDL attribute to an interface prototype, read-only unless a setter is given.</summary>
     private static void AddPrototypeAccessor(JSObject proto, string name,
         JSFunctionDelegate getter, JSFunctionDelegate? setter = null) =>
-        proto.FastAddProperty((KeyString)name,
+        proto.FastAddProperty(name,
             new DomFunction(getter, "get " + name),
             setter is null ? null : new DomFunction(setter, "set " + name),
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
@@ -55,24 +55,24 @@ public sealed partial class DomBridge
         static void MarkRulesMutated() => BridgeRuntimeStateEpoch.Bump();
 
         // ownerNode is null for a constructed sheet; href is null (no source URL).
-        sheet.FastAddProperty((KeyString)"ownerNode", NullFunction("get ownerNode"),
+        sheet.FastAddProperty("ownerNode", NullFunction("get ownerNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        sheet.FastAddProperty((KeyString)"href", NullFunction("get href"),
+        sheet.FastAddProperty("href", NullFunction("get href"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // disabled — a script flag on the sheet; a disabled adopted sheet does not apply.
         var disabled = false;
-        sheet.FastAddProperty((KeyString)"disabled",
+        sheet.FastAddProperty("disabled",
             new DomFunction((in _) => disabled ? JSBoolean.True : JSBoolean.False, "get disabled"),
             new DomFunction((in a) => { disabled = a.Length > 0 && a[0].BooleanValue; return JSUndefined.Value; }, "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var liveCssRules = new JSObject();
         var lastSyncedRuleCount = 0;
-        liveCssRules.FastAddProperty((KeyString)"length",
+        liveCssRules.FastAddProperty("length",
             new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        liveCssRules.FastAddValue((KeyString)"item",
+        liveCssRules.FastAddValue("item",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -88,13 +88,13 @@ public sealed partial class DomBridge
             lastSyncedRuleCount = current.Count;
         }
 
-        sheet.FastAddProperty((KeyString)"cssRules",
+        sheet.FastAddProperty("cssRules",
             new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        sheet.FastAddValue((KeyString)"insertRule",
+        sheet.FastAddValue("insertRule",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        sheet.FastAddValue((KeyString)"deleteRule",
+        sheet.FastAddValue("deleteRule",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -112,10 +112,10 @@ public sealed partial class DomBridge
             SyncLiveCssRulesIndices();
         }
 
-        sheet.FastAddValue((KeyString)"replaceSync",
+        sheet.FastAddValue("replaceSync",
             new DomFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return JSUndefined.Value; }, "replaceSync", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        sheet.FastAddValue((KeyString)"replace",
+        sheet.FastAddValue("replace",
             new DomFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return ResolvedThenableWith(sheet); }, "replace", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -136,9 +136,9 @@ public sealed partial class DomBridge
             }
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"finally",
+        thenable.FastAddValue("then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue("finally",
             new DomFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -772,9 +772,9 @@ public sealed partial class DomBridge
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type",
+            evt.FastAddValue("type",
                 new JSString(loaded ? "load" : "error"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(element, evt);
         }
         catch (Exception ex)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -114,14 +114,14 @@ public sealed partial class DomBridge
         // HTMLLabelElement — htmlFor property (maps to 'for' content attribute)
         if (tag == "label")
         {
-            obj.FastAddProperty((KeyString)"htmlFor", new DomFunction((in _) => TryGetAttribute(element, "for", out var f) ? new JSString(f) : new JSString(string.Empty), "get htmlFor"),
+            obj.FastAddProperty("htmlFor", new DomFunction((in _) => TryGetAttribute(element, "for", out var f) ? new JSString(f) : new JSString(string.Empty), "get htmlFor"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHtmlFor(element, in a), "set htmlFor"), JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // HTMLMetaElement — httpEquiv property (maps to 'http-equiv' content attribute)
         if (tag == "meta")
         {
-            obj.FastAddProperty((KeyString)"httpEquiv", new DomFunction((in _) => TryGetAttribute(element, "http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty), "get httpEquiv"),
+            obj.FastAddProperty("httpEquiv", new DomFunction((in _) => TryGetAttribute(element, "http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty), "get httpEquiv"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHttpEquiv(element, in a), "set httpEquiv"), JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -131,13 +131,13 @@ public sealed partial class DomBridge
             // data get (reflected URL) + type get/set are in ElementReflectionBinding (P3.49); the data
             // setter, contentDocument getter and getSVGDocument() are sub-document-coupled and live in the
             // ObjectElementBinding feature module (Phase 3 P3.52).
-            obj.FastAddProperty((KeyString)"data",
+            obj.FastAddProperty("data",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetData(this, element, in _), "get data"),
                 new DomFunction((in a) => Dom.Features.ObjectElementBinding.SetData(this, element, in a), "set data"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // type property (MIME type of the resource)
-            obj.FastAddProperty((KeyString)"type",
+            obj.FastAddProperty("type",
                 new DomFunction((in _) => TryGetAttribute(element, "type", out var t) ? new JSString(t) : new JSString(string.Empty), "get type"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetType(element, in a), "set type"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -145,12 +145,12 @@ public sealed partial class DomBridge
             // contentDocument for <object> element (with same-origin check)
             // Returns null when the resource fails to load (HTTP 404, file not found, etc.)
             // which signals that the fallback content (child nodes) should be visible.
-            obj.FastAddProperty((KeyString)"contentDocument",
+            obj.FastAddProperty("contentDocument",
                 new DomFunction((in _) => Dom.Features.ObjectElementBinding.GetContentDocument(this, element, in _), "get contentDocument"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // getSVGDocument() for <object> element
-            obj.FastAddValue((KeyString)"getSVGDocument",
+            obj.FastAddValue("getSVGDocument",
                 new DomFunction((in _) => Dom.Features.ObjectElementBinding.GetSvgDocument(this, element, in _), "getSVGDocument", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -158,7 +158,7 @@ public sealed partial class DomBridge
         // HTMLAnchorElement — href property with URI resolution
         if (tag == "a")
         {
-            obj.FastAddProperty((KeyString)"href",
+            obj.FastAddProperty("href",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -171,14 +171,14 @@ public sealed partial class DomBridge
             foreach (var attrName in new[] { "shape", "coords", "alt", "target" })
             {
                 var captured = attrName; // capture for closure
-                obj.FastAddProperty((KeyString)captured,
+                obj.FastAddProperty(captured,
                     new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + captured),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + captured),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
             }
 
             // href — with URI resolution like <a>
-            obj.FastAddProperty((KeyString)"href",
+            obj.FastAddProperty("href",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -194,7 +194,7 @@ public sealed partial class DomBridge
             // Writing a live <link>'s href points it at a new sheet, which is a fresh fetch and so a
             // fresh load event (HTML §4.2.4) — the shape UIEvent.load.stylesheet waits on.
             var isLink = tag == "link";
-            obj.FastAddProperty((KeyString)"href",
+            obj.FastAddProperty("href",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
                 new DomFunction((in a) =>
                 {
@@ -215,7 +215,7 @@ public sealed partial class DomBridge
             {
                 var captured = attrName; // capture for closure
                 var firesLoad = captured == "rel";
-                obj.FastAddProperty((KeyString)idlName,
+                obj.FastAddProperty(idlName,
                     new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
                     new DomFunction((in a) =>
                     {
@@ -237,7 +237,7 @@ public sealed partial class DomBridge
         // waitForWhichBrowser poll). Exactly the shape of the <link>.href gap fixed above.
         if (tag == "script")
         {
-            obj.FastAddProperty((KeyString)"src",
+            obj.FastAddProperty("src",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetSrc(this, element, in _), "get src"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetSrc(element, in a), "set src"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -245,7 +245,7 @@ public sealed partial class DomBridge
             foreach (var (idlName, attrName) in ScriptReflectedAttributes)
             {
                 var captured = attrName; // capture for closure
-                obj.FastAddProperty((KeyString)idlName,
+                obj.FastAddProperty(idlName,
                     new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + idlName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -254,7 +254,7 @@ public sealed partial class DomBridge
             foreach (var (idlName, attrName) in ScriptReflectedBooleans)
             {
                 var captured = attrName; // capture for closure
-                obj.FastAddProperty((KeyString)idlName,
+                obj.FastAddProperty(idlName,
                     new DomFunction((in _) => HasAttr(element, captured) ? JSBoolean.True : JSBoolean.False, "get " + idlName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedBoolean(captured, element, in a), "set " + idlName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -264,7 +264,7 @@ public sealed partial class DomBridge
             // loader idiom, for an inline script built in JS rather than fetched. textContent is
             // already installed on every element and does the same thing; this aliases it so
             // `s.text = code` is not silently a plain JS property either.
-            obj.FastAddProperty((KeyString)"text",
+            obj.FastAddProperty("text",
                 new DomFunction((in _) => GetNodeTextValue(element), "get text"),
                 new DomFunction((in a) => { SetElementTextContent(element, a.Length > 0 ? a[0].ToString() : string.Empty); return JSUndefined.Value; }, "set text"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -278,7 +278,7 @@ public sealed partial class DomBridge
             foreach (var dim in new[] { "height", "width" })
             {
                 var dimName = dim;
-                obj.FastAddProperty((KeyString)dimName,
+                obj.FastAddProperty(dimName,
                     new DomFunction((in _) => Dom.Features.ComputedStyleBinding.GetUsedDimension(this, dimName, element, in _), "get " + dimName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -291,7 +291,7 @@ public sealed partial class DomBridge
             // mw.util.parseImageUrl(), whose first act is url.match(...) — "Cannot get property match
             // of undefined". That throw took MultimediaViewerBootstrap.processThumbs down and, with
             // it, the rest of the single load.php bundle queued behind it.
-            obj.FastAddProperty((KeyString)"src",
+            obj.FastAddProperty("src",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetSrc(this, element, in _), "get src"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetSrc(element, in a), "set src"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -301,12 +301,12 @@ public sealed partial class DomBridge
             // the resolved src, and the empty string when there is no src at all. That is the pair of
             // answers the `img.currentSrc || img.src` idiom is written against (mmv.bootstrap's
             // processThumb reads exactly that, then calls .includes() on the result).
-            obj.FastAddProperty((KeyString)"currentSrc",
+            obj.FastAddProperty("currentSrc",
                 new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetCurrentSrc(this, element, in _), "get currentSrc"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // .isMap — the one boolean in the interface: present or absent, never the string "false".
-            obj.FastAddProperty((KeyString)"isMap",
+            obj.FastAddProperty("isMap",
                 new DomFunction((in _) => HasAttr(element, "ismap") ? JSBoolean.True : JSBoolean.False, "get isMap"),
                 new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedBoolean("ismap", element, in a), "set isMap"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -318,7 +318,7 @@ public sealed partial class DomBridge
             foreach (var (idlName, attrName) in ImageReflectedAttributes)
             {
                 var captured = attrName; // capture for closure
-                obj.FastAddProperty((KeyString)idlName,
+                obj.FastAddProperty(idlName,
                     new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + idlName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -335,7 +335,7 @@ public sealed partial class DomBridge
             foreach (var dim in new[] { "height", "width" })
             {
                 var dimName = dim;
-                obj.FastAddProperty((KeyString)dimName,
+                obj.FastAddProperty(dimName,
                     new DomFunction((in _) => new JSString(
                         TryGetAttribute(element, dimName, out var v) ? v : string.Empty), "get " + dimName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/EventTargetInterface.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/EventTargetInterface.cs
@@ -95,7 +95,7 @@ public sealed partial class DomBridge
     private void RouteEventTargetMethod(JSObject proto, string name, int length, JSFunction? engineMethod,
         NodeEventTargetOperation onNode, WindowEventTargetOperation onWindow)
     {
-        proto.FastAddValue((KeyString)name, new DomFunction((in Arguments a) =>
+        proto.FastAddValue(name, new DomFunction((in Arguments a) =>
         {
             if (a.This is JSObject receiver)
             {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlElementInterface.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlElementInterface.cs
@@ -147,7 +147,7 @@ public sealed partial class DomBridge
             var eventName = name;
             var member = "on" + eventName;
 
-            target.FastAddProperty((KeyString)member,
+            target.FastAddProperty(member,
                 new DomFunction((in Arguments a) =>
                     Dom.Features.EventHandlerReflectorBinding.GetOn(this, element(in a, member), eventName, in a), "get " + member),
                 new DomFunction((in Arguments a) =>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.NonElementNodes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.NonElementNodes.cs
@@ -52,15 +52,15 @@ public sealed partial class DomBridge
         // in a browser. A wrapper minted before the realm carried it installs its own.
         if (!_eventTargetRoutingReady)
         {
-            obj.FastAddValue((KeyString)"addEventListener",
+            obj.FastAddValue("addEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"removeEventListener",
+            obj.FastAddValue("removeEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"dispatchEvent",
+            obj.FastAddValue("dispatchEvent",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -76,158 +76,158 @@ public sealed partial class DomBridge
     private void PopulateCharacterDataMembersOnInstance(JSObject obj, DomNode node)
     {
         // -- Node identity --
-        obj.FastAddProperty((KeyString)"nodeType",
+        obj.FastAddProperty("nodeType",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"nodeName",
+        obj.FastAddProperty("nodeName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"localName",
+        obj.FastAddProperty("localName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(node, in a), "get localName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"prefix",
+        obj.FastAddProperty("prefix",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(node, in a), "get prefix"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"namespaceURI",
+        obj.FastAddProperty("namespaceURI",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(node, in a), "get namespaceURI"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Character data --
-        obj.FastAddProperty((KeyString)"nodeValue",
+        obj.FastAddProperty("nodeValue",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(node, in a), "get nodeValue"),
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set nodeValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"textContent",
+        obj.FastAddProperty("textContent",
             new DomFunction((in _) => GetNodeTextValue(node), "get textContent"),
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set textContent"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"data",
+        obj.FastAddProperty("data",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetData(node, in a), "get data"),
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, node, in a), "set data"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"length",
+        obj.FastAddProperty("length",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(node, in a), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // splitText is Text-only (not on Comment).
         if (IsText(node))
         {
-            obj.FastAddValue((KeyString)"splitText",
+            obj.FastAddValue("splitText",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, node, in a), "splitText", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
-        obj.FastAddValue((KeyString)"substringData",
+        obj.FastAddValue("substringData",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(this, node, in a), "substringData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"appendData",
+        obj.FastAddValue("appendData",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, node, in a), "appendData", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"deleteData",
+        obj.FastAddValue("deleteData",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, node, in a), "deleteData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"insertData",
+        obj.FastAddValue("insertData",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, node, in a), "insertData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"replaceData",
+        obj.FastAddValue("replaceData",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, node, in a), "replaceData", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Tree navigation --
-        obj.FastAddProperty((KeyString)"parentNode",
+        obj.FastAddProperty("parentNode",
             new DomFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"parentElement",
+        obj.FastAddProperty("parentElement",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"isConnected",
+        obj.FastAddProperty("isConnected",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"childNodes",
+        obj.FastAddProperty("childNodes",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"firstChild",
+        obj.FastAddProperty("firstChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"lastChild",
+        obj.FastAddProperty("lastChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"nextSibling",
+        obj.FastAddProperty("nextSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"previousSibling",
+        obj.FastAddProperty("previousSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"ownerDocument",
+        obj.FastAddProperty("ownerDocument",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddValue((KeyString)"hasChildNodes",
+        obj.FastAddValue("hasChildNodes",
             new DomFunction((in a) => node.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
-        obj.FastAddValue((KeyString)"cloneNode",
+        obj.FastAddValue("cloneNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"contains",
+        obj.FastAddValue("contains",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"compareDocumentPosition",
+        obj.FastAddValue("compareDocumentPosition",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"isSameNode",
+        obj.FastAddValue("isSameNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"isEqualNode",
+        obj.FastAddValue("isEqualNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"getRootNode",
+        obj.FastAddValue("getRootNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"normalize",
+        obj.FastAddValue("normalize",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ChildNode mixin --
-        obj.FastAddValue((KeyString)"remove",
+        obj.FastAddValue("remove",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"before",
+        obj.FastAddValue("before",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"after",
+        obj.FastAddValue("after",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"replaceWith",
+        obj.FastAddValue("replaceWith",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -250,107 +250,107 @@ public sealed partial class DomBridge
         DomNode node = doctype;
 
         // -- Node identity --
-        obj.FastAddProperty((KeyString)"nodeType",
+        obj.FastAddProperty("nodeType",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"nodeName",
+        obj.FastAddProperty("nodeName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"nodeValue",
+        obj.FastAddProperty("nodeValue",
             new DomFunction((in _) => JSNull.Value, "get nodeValue"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"textContent",
+        obj.FastAddProperty("textContent",
             new DomFunction((in _) => JSNull.Value, "get textContent"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- DocumentType interface --
-        obj.FastAddProperty((KeyString)"name",
+        obj.FastAddProperty("name",
             new DomFunction((in _) => new JSString(doctype.Name), "get name"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"publicId",
+        obj.FastAddProperty("publicId",
             new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetPublicId(node, in _), "get publicId"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"systemId",
+        obj.FastAddProperty("systemId",
             new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetSystemId(node, in _), "get systemId"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"internalSubset",
+        obj.FastAddProperty("internalSubset",
             NullFunction("get internalSubset"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Tree navigation --
-        obj.FastAddProperty((KeyString)"parentNode",
+        obj.FastAddProperty("parentNode",
             new DomFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"parentElement",
+        obj.FastAddProperty("parentElement",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"previousSibling",
+        obj.FastAddProperty("previousSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"nextSibling",
+        obj.FastAddProperty("nextSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"ownerDocument",
+        obj.FastAddProperty("ownerDocument",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"isConnected",
+        obj.FastAddProperty("isConnected",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddValue((KeyString)"hasChildNodes",
+        obj.FastAddValue("hasChildNodes",
             new DomFunction((in a) => JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
-        obj.FastAddValue((KeyString)"cloneNode",
+        obj.FastAddValue("cloneNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"isEqualNode",
+        obj.FastAddValue("isEqualNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"isSameNode",
+        obj.FastAddValue("isSameNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"contains",
+        obj.FastAddValue("contains",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"compareDocumentPosition",
+        obj.FastAddValue("compareDocumentPosition",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"getRootNode",
+        obj.FastAddValue("getRootNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ChildNode mixin --
-        obj.FastAddValue((KeyString)"remove",
+        obj.FastAddValue("remove",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"before",
+        obj.FastAddValue("before",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"after",
+        obj.FastAddValue("after",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"replaceWith",
+        obj.FastAddValue("replaceWith",
             new DomFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -359,15 +359,15 @@ public sealed partial class DomBridge
         // in a browser. A wrapper minted before the realm carried it installs its own.
         if (!_eventTargetRoutingReady)
         {
-            obj.FastAddValue((KeyString)"addEventListener",
+            obj.FastAddValue("addEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"removeEventListener",
+            obj.FastAddValue("removeEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"dispatchEvent",
+            obj.FastAddValue("dispatchEvent",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -393,57 +393,57 @@ public sealed partial class DomBridge
         DomNode node = fragment;
 
         // -- Node identity --
-        obj.FastAddProperty((KeyString)"nodeType",
+        obj.FastAddProperty("nodeType",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"nodeName",
+        obj.FastAddProperty("nodeName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"nodeValue",
+        obj.FastAddProperty("nodeValue",
             new DomFunction((in _) => JSNull.Value, "get nodeValue"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"ownerDocument",
+        obj.FastAddProperty("ownerDocument",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Tree navigation --
-        obj.FastAddProperty((KeyString)"parentNode",
+        obj.FastAddProperty("parentNode",
             new DomFunction((in _) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"parentElement",
+        obj.FastAddProperty("parentElement",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"childNodes",
+        obj.FastAddProperty("childNodes",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"firstChild",
+        obj.FastAddProperty("firstChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"lastChild",
+        obj.FastAddProperty("lastChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"isConnected",
+        obj.FastAddProperty("isConnected",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddValue((KeyString)"hasChildNodes",
+        obj.FastAddValue("hasChildNodes",
             new DomFunction((in a) => fragment.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ParentNode mixin (element views) --
-        obj.FastAddProperty((KeyString)"children",
+        obj.FastAddProperty("children",
             new DomFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"childElementCount",
+        obj.FastAddProperty("childElementCount",
             new DomFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c))), "get childElementCount"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"firstElementChild",
+        obj.FastAddProperty("firstElementChild",
             new DomFunction((in _) =>
             {
                 var first = ChildElements(fragment).FirstOrDefault(c => !IsText(c));
                 return first != null ? ToJSObject(first) : JSNull.Value;
             }, "get firstElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        obj.FastAddProperty((KeyString)"lastElementChild",
+        obj.FastAddProperty("lastElementChild",
             new DomFunction((in _) =>
             {
                 var last = ChildElements(fragment).LastOrDefault(c => !IsText(c));
@@ -452,7 +452,7 @@ public sealed partial class DomBridge
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- textContent (get/set) --
-        obj.FastAddProperty((KeyString)"textContent",
+        obj.FastAddProperty("textContent",
             new DomFunction((in _) => GetNodeTextValue(node), "get textContent"),
             new DomFunction((in a) =>
             {
@@ -465,7 +465,7 @@ public sealed partial class DomBridge
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Child manipulation --
-        obj.FastAddValue((KeyString)"appendChild",
+        obj.FastAddValue("appendChild",
             new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject childObj)
@@ -479,7 +479,7 @@ public sealed partial class DomBridge
                 return a[0];
             }, "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"insertBefore",
+        obj.FastAddValue("insertBefore",
             new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject newChildObj)
@@ -506,7 +506,7 @@ public sealed partial class DomBridge
                 return a[0];
             }, "insertBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"removeChild",
+        obj.FastAddValue("removeChild",
             new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject childObj)
@@ -523,7 +523,7 @@ public sealed partial class DomBridge
                 return a[0];
             }, "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"replaceChild",
+        obj.FastAddValue("replaceChild",
             new DomFunction((in a) =>
             {
                 if (a.Length < 2 || a[0] is not JSObject newObj || a[1] is not JSObject oldObj)
@@ -540,7 +540,7 @@ public sealed partial class DomBridge
                 return a[1];
             }, "replaceChild", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"append",
+        obj.FastAddValue("append",
             new DomFunction((in a) =>
             {
                 if (a.Length == 0)
@@ -552,7 +552,7 @@ public sealed partial class DomBridge
                 return JSUndefined.Value;
             }, "append", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"prepend",
+        obj.FastAddValue("prepend",
             new DomFunction((in a) =>
             {
                 if (a.Length == 0)
@@ -566,44 +566,44 @@ public sealed partial class DomBridge
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Query --
-        obj.FastAddValue((KeyString)"querySelector",
+        obj.FastAddValue("querySelector",
             new DomFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, false, bridge), "querySelector", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"querySelectorAll",
+        obj.FastAddValue("querySelectorAll",
             new DomFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, true, bridge), "querySelectorAll", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
-        obj.FastAddValue((KeyString)"cloneNode",
+        obj.FastAddValue("cloneNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"isEqualNode",
+        obj.FastAddValue("isEqualNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"isSameNode",
+        obj.FastAddValue("isSameNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"contains",
+        obj.FastAddValue("contains",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"compareDocumentPosition",
+        obj.FastAddValue("compareDocumentPosition",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"getRootNode",
+        obj.FastAddValue("getRootNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"normalize",
+        obj.FastAddValue("normalize",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- EventTarget --
-        obj.FastAddValue((KeyString)"addEventListener",
+        obj.FastAddValue("addEventListener",
             new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"removeEventListener",
+        obj.FastAddValue("removeEventListener",
             new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"dispatchEvent",
+        obj.FastAddValue("dispatchEvent",
             new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -118,20 +118,20 @@ public sealed partial class DomBridge
             PopulateElementNodeMembersOnInstance(obj, element);
 
         // data (read/write) — for text nodes and comment nodes (alias for nodeValue/textContent)
-        obj.FastAddProperty((KeyString)"data",
+        obj.FastAddProperty("data",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetData(element, in a), "get data"),
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, element, in a), "set data"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // length (read-only) — character count for text/comment nodes, child count for elements
-        obj.FastAddProperty((KeyString)"length",
+        obj.FastAddProperty("length",
             new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(element, in a), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // splitText(offset) — splits a text node at the given character offset
         if (IsText(element))
         {
-            obj.FastAddValue((KeyString)"splitText",
+            obj.FastAddValue("splitText",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, element, in a), "splitText", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -139,23 +139,23 @@ public sealed partial class DomBridge
         // substringData(offset, count) — for text/comment CharacterData nodes
         if (IsText(element) || IsComment(element))
         {
-            obj.FastAddValue((KeyString)"substringData",
+            obj.FastAddValue("substringData",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(this, element, in a), "substringData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"appendData",
+            obj.FastAddValue("appendData",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, element, in a), "appendData", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"deleteData",
+            obj.FastAddValue("deleteData",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, element, in a), "deleteData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"insertData",
+            obj.FastAddValue("insertData",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, element, in a), "insertData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"replaceData",
+            obj.FastAddValue("replaceData",
                 new DomFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, element, in a), "replaceData", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -164,17 +164,17 @@ public sealed partial class DomBridge
         // §4.9 pairs setAttributeNode with setAttributeNodeNS but gives removeAttributeNode no
         // namespace-qualified sibling (an Attr already knows its namespace), so no browser has one and
         // putting it on Element.prototype would give that prototype a member a browser's has not got.
-        obj.FastAddValue((KeyString)"removeAttributeNodeNS",
+        obj.FastAddValue("removeAttributeNodeNS",
             new DomFunction((in a) => _attributes.RemoveAttributeNodeNS(element, obj, in a), "removeAttributeNodeNS", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // insertBefore(newChild, refChild)
-        obj.FastAddValue((KeyString)"insertBefore",
+        obj.FastAddValue("insertBefore",
             new DomFunction((in a) => Dom.Features.TreeMutationBinding.InsertBefore(this, element, in a), "insertBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // moveBefore(node, refChild) — the atomic, state-preserving sibling of insertBefore.
-        obj.FastAddValue((KeyString)"moveBefore",
+        obj.FastAddValue("moveBefore",
             new DomFunction((in a) => Dom.Features.TreeMutationBinding.MoveBefore(this, element, in a), "moveBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -186,23 +186,23 @@ public sealed partial class DomBridge
         // component script threw. See GetTemplateContent for what this fragment is and is not.
         if (string.Equals(element.TagName, "template", StringComparison.OrdinalIgnoreCase))
         {
-            obj.FastAddProperty((KeyString)"content",
+            obj.FastAddProperty("content",
                 new DomFunction((in a) => ToJSObject(GetTemplateContent(element)), "get content"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // appendChild(child)
-        obj.FastAddValue((KeyString)"appendChild",
+        obj.FastAddValue("appendChild",
             new DomFunction((in a) => Dom.Features.TreeMutationBinding.AppendChild(this, element, in a), "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeChild(child)
-        obj.FastAddValue((KeyString)"removeChild",
+        obj.FastAddValue("removeChild",
             new DomFunction((in a) => Dom.Features.TreeMutationBinding.RemoveChild(this, element, in a), "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // replaceChild(newChild, oldChild)
-        obj.FastAddValue((KeyString)"replaceChild",
+        obj.FastAddValue("replaceChild",
             new DomFunction((in a) => Dom.Features.TreeMutationBinding.ReplaceChild(this, element, in a), "replaceChild", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -213,15 +213,15 @@ public sealed partial class DomBridge
         // in a browser. A wrapper minted before the realm carried it installs its own.
         if (!_eventTargetRoutingReady)
         {
-            obj.FastAddValue((KeyString)"addEventListener",
+            obj.FastAddValue("addEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, element, in a), "addEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"removeEventListener",
+            obj.FastAddValue("removeEventListener",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, element, in a), "removeEventListener", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"dispatchEvent",
+            obj.FastAddValue("dispatchEvent",
                 new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, element, in a), "dispatchEvent", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -241,18 +241,18 @@ public sealed partial class DomBridge
         _formControl.Install(obj, element);
 
         // checkValidity() — form validation (Phase 3 P3.9: FormBinding owns the validity check)
-        obj.FastAddValue((KeyString)"checkValidity",
+        obj.FastAddValue("checkValidity",
             new DomFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "checkValidity", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // reportValidity() — form validation
-        obj.FastAddValue((KeyString)"reportValidity",
+        obj.FastAddValue("reportValidity",
             new DomFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "reportValidity", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // submit() — for form elements (Phase 3 P3.61: co-located FormSubmitBinding feature module,
         // reached through IFormSubmitHost; DomBridge.FormSubmitHost.cs).
-        obj.FastAddValue((KeyString)"submit",
+        obj.FastAddValue("submit",
             new DomFunction((in a) => Dom.Features.FormSubmitBinding.Submit(this, element, obj, in a), "submit", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -285,116 +285,116 @@ public sealed partial class DomBridge
     private void PopulateElementNodeMembersOnInstance(JSObject obj, DomElement element)
     {
         // parentNode (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"parentNode",
+        obj.FastAddProperty("parentNode",
             new DomFunction((in a) => element.ParentNode != null ? ToJSObject(element.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"isConnected",
+        obj.FastAddProperty("isConnected",
             new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, element, in _), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // childNodes (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"childNodes",
+        obj.FastAddProperty("childNodes",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, element, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstChild (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"firstChild",
+        obj.FastAddProperty("firstChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, element, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastChild (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"lastChild",
+        obj.FastAddProperty("lastChild",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, element, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nextSibling (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"nextSibling",
+        obj.FastAddProperty("nextSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, element, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // previousSibling (read-only, dynamic)
-        obj.FastAddProperty((KeyString)"previousSibling",
+        obj.FastAddProperty("previousSibling",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, element, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeType (read-only)
-        obj.FastAddProperty((KeyString)"nodeType",
+        obj.FastAddProperty("nodeType",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(element, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeName (read-only)
-        obj.FastAddProperty((KeyString)"nodeName",
+        obj.FastAddProperty("nodeName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(element, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // localName (read-only) — null for non-element nodes; local part of tag name for elements
-        obj.FastAddProperty((KeyString)"localName",
+        obj.FastAddProperty("localName",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(element, in a), "get localName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // prefix (read-only) — namespace prefix or null
-        obj.FastAddProperty((KeyString)"prefix",
+        obj.FastAddProperty("prefix",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(element, in a), "get prefix"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // namespaceURI (read-only) — returns namespace URI for elements created via createElementNS
-        obj.FastAddProperty((KeyString)"namespaceURI",
+        obj.FastAddProperty("namespaceURI",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(element, in a), "get namespaceURI"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeValue (read/write) — null for elements, text content for text/comment nodes
-        obj.FastAddProperty((KeyString)"nodeValue",
+        obj.FastAddProperty("nodeValue",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(element, in a), "get nodeValue"),
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, element, in a), "set nodeValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // ownerDocument (read-only) — returns the Document node (nodeType=9)
-        obj.FastAddProperty((KeyString)"ownerDocument",
+        obj.FastAddProperty("ownerDocument",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, element, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // parentElement (read-only, dynamic) — like parentNode but returns null for non-element parents
-        obj.FastAddProperty((KeyString)"parentElement",
+        obj.FastAddProperty("parentElement",
             new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, element, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hasChildNodes()
-        obj.FastAddValue((KeyString)"hasChildNodes",
+        obj.FastAddValue("hasChildNodes",
             new DomFunction((in a) => element.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // contains(otherNode) — returns true if otherNode is a descendant
-        obj.FastAddValue((KeyString)"contains",
+        obj.FastAddValue("contains",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, element, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // compareDocumentPosition(otherNode)
-        obj.FastAddValue((KeyString)"compareDocumentPosition",
+        obj.FastAddValue("compareDocumentPosition",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, element, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // isSameNode(otherNode)
-        obj.FastAddValue((KeyString)"isSameNode",
+        obj.FastAddValue("isSameNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, element, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // normalize()
-        obj.FastAddValue((KeyString)"normalize",
+        obj.FastAddValue("normalize",
             new DomFunction((in _) => Dom.Features.NodeRelationshipsBinding.Normalize(this, element, in _), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // isEqualNode(otherNode)
-        obj.FastAddValue((KeyString)"isEqualNode",
+        obj.FastAddValue("isEqualNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, element, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"getRootNode",
+        obj.FastAddValue("getRootNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, element, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // cloneNode(deep)
-        obj.FastAddValue((KeyString)"cloneNode",
+        obj.FastAddValue("cloneNode",
             new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, element, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
@@ -340,8 +340,8 @@ public sealed partial class DomBridge
     private void DispatchElementEvent(DomElement element, string eventType)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString(eventType), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString(eventType), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
         DispatchEventOnElement(element, evt);
     }
 
@@ -467,9 +467,9 @@ public sealed partial class DomBridge
             return;
 
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("scroll"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"target", _visualViewportJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"currentTarget", _visualViewportJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("scroll"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", _visualViewportJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", _visualViewportJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
 
         foreach (var listener in _eventTargets.VisualViewportScrollListeners.ToList())
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -104,22 +104,22 @@ public sealed partial class DomBridge
         // resolve it once here (stable CWT identity for this element/bridge) and hand it to the callbacks.
         var animationState = AnimationStateFor(element);
         animation.FastAddProperty(
-            (KeyString)"currentTime",
+            "currentTime",
             new DomFunction((in _) => Dom.Features.AnimationObjectBinding.GetCurrentTime(animationState, in _), "get currentTime"),
             new DomFunction((in a) => Dom.Features.AnimationObjectBinding.SetCurrentTime(animationState, in a), "set currentTime"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var ready = new JSObject();
         ready.FastAddValue(
-            (KeyString)"then",
+            "then",
             new DomFunction((in a) => Dom.Features.AnimationObjectBinding.Then(ready, in a), "then", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         ready.FastAddValue(
-            (KeyString)"catch",
+            "catch",
             new DomFunction((in _) => ready, "catch", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        animation.FastAddValue((KeyString)"ready", ready, JSPropertyAttributes.EnumerableConfigurableValue);
+        animation.FastAddValue("ready", ready, JSPropertyAttributes.EnumerableConfigurableValue);
         return animation;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/CustomElements.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/CustomElements.cs
@@ -42,19 +42,19 @@ public sealed partial class DomBridge
     private void RegisterCustomElements(JSContext context, JSObject window)
     {
         var registry = new JSObject();
-        registry.FastAddValue((KeyString)"define",
+        registry.FastAddValue("define",
             new DomFunction((in a) => CustomElements.Define(in a), "define", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        registry.FastAddValue((KeyString)"get",
+        registry.FastAddValue("get",
             new DomFunction((in a) => CustomElements.Get(in a), "get", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        registry.FastAddValue((KeyString)"getName",
+        registry.FastAddValue("getName",
             new DomFunction((in a) => CustomElements.GetName(in a), "getName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        registry.FastAddValue((KeyString)"whenDefined",
+        registry.FastAddValue("whenDefined",
             new DomFunction((in a) => CustomElements.WhenDefined(in a), "whenDefined", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        registry.FastAddValue((KeyString)"upgrade",
+        registry.FastAddValue("upgrade",
             new DomFunction((in a) => CustomElements.Upgrade(in a), "upgrade", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -119,7 +119,7 @@ public sealed partial class DomBridge
             })();
             """);
 
-        window.FastAddValue((KeyString)"customElements", registry, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("customElements", registry, JSPropertyAttributes.EnumerableConfigurableValue);
         SubscribeCustomElementReactions();
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -28,29 +28,29 @@ public sealed partial class DomBridge
         // Deferring the mint to the first read is what makes the fallback unreachable for it rather
         // than compensated for afterwards. It also stops a re-parse handing back the previous
         // document's wrapper: the registry is cleared, and the value property was not.
-        document.FastAddProperty((KeyString)"documentElement",
+        document.FastAddProperty("documentElement",
             new JSFunction((in _) => ToJSObject(DocumentElement), "get documentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.scrollingElement (getter — returns document.documentElement
         // in standards mode, or document.body in quirks mode; we always use
         // standards mode so it's always the <html> element).
-        document.FastAddProperty((KeyString)"scrollingElement", new JSFunction((in _) => ToJSObject(DocumentElement), "get scrollingElement"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("scrollingElement", new JSFunction((in _) => ToJSObject(DocumentElement), "get scrollingElement"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // Fullscreen §document API. `fullscreenElement` is a getter over the per-element fullscreen
         // flag rather than a stored reference, so it stays correct when the element is exited or
         // detached. `fullscreenEnabled` is constant here: the runner has no user-permission model
         // and nothing in the corpus needs it to be false.
-        document.FastAddProperty((KeyString)"fullscreenElement",
+        document.FastAddProperty("fullscreenElement",
             new JSFunction((in _) => FindFullscreenElement() is { } el ? ToJSObject(el) : JSNull.Value, "get fullscreenElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddProperty((KeyString)"webkitFullscreenElement",
+        document.FastAddProperty("webkitFullscreenElement",
             new JSFunction((in _) => FindFullscreenElement() is { } el ? ToJSObject(el) : JSNull.Value, "get webkitFullscreenElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddValue((KeyString)"fullscreenEnabled", JavaScript.BuiltIns.Boolean.JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"exitFullscreen",
+        document.FastAddValue("fullscreenEnabled", JavaScript.BuiltIns.Boolean.JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("exitFullscreen",
             new JSFunction((in _) => _dialogs.ExitFullscreen(), "exitFullscreen", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"webkitExitFullscreen",
+        document.FastAddValue("webkitExitFullscreen",
             new JSFunction((in _) => _dialogs.ExitFullscreen(), "webkitExitFullscreen", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // HTML §3.1.7 document.readyState: "loading" while parsing, "interactive" once parsing is
@@ -66,63 +66,63 @@ public sealed partial class DomBridge
         // www.mediawiki.org none of the skin's JavaScript ran, and the appearance panel it moves
         // into the header stayed in the page column, displacing the whole article.
         document.FastAddProperty(
-            (KeyString)"readyState",
+            "readyState",
             new JSFunction((in _) => new JSString(_documentReadyState), "get readyState"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document structural accessors — body/head/title, co-located in the DocumentStructureBinding
         // feature module (Phase 3).
-        document.FastAddProperty((KeyString)"body", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetBody(this, in a), "get body"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddProperty((KeyString)"head", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetHead(this, in a), "get head"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddProperty((KeyString)"title", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetTitle(this, in a), "get title"), new JSFunction((in a) => Dom.Features.DocumentStructureBinding.SetTitle(this, in a), "set title"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("body", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetBody(this, in a), "get body"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("head", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetHead(this, in a), "get head"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("title", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetTitle(this, in a), "get title"), new JSFunction((in a) => Dom.Features.DocumentStructureBinding.SetTitle(this, in a), "set title"), JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document element-query methods — getElementById/getElementsByTagName/getElementsByClassName/
         // getElementsByName/querySelector/querySelectorAll, co-located in the DocumentQueryBinding
         // feature module (Phase 3).
-        document.FastAddValue((KeyString)"getElementById", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementById(this, in a), "getElementById", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"getElementsByTagName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByTagName(this, in a), "getElementsByTagName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"getElementsByClassName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByClassName(this, in a), "getElementsByClassName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"getElementsByName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByName(this, in a), "getElementsByName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"querySelector", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelector(this, in a), "querySelector", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"querySelectorAll", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelectorAll(this, in a), "querySelectorAll", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("getElementById", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementById(this, in a), "getElementById", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("getElementsByTagName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByTagName(this, in a), "getElementsByTagName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("getElementsByClassName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByClassName(this, in a), "getElementsByClassName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("getElementsByName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByName(this, in a), "getElementsByName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("querySelector", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelector(this, in a), "querySelector", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("querySelectorAll", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelectorAll(this, in a), "querySelectorAll", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         // document.elementFromPoint / elementsFromPoint (hit-testing), co-located in the HitTestBinding
         // feature module (Phase 3).
-        document.FastAddValue((KeyString)"elementFromPoint", new JSFunction((in a) => Dom.Features.HitTestBinding.ElementFromPoint(this, in a), "elementFromPoint", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"elementsFromPoint", new JSFunction((in a) => Dom.Features.HitTestBinding.ElementsFromPoint(this, in a), "elementsFromPoint", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("elementFromPoint", new JSFunction((in a) => Dom.Features.HitTestBinding.ElementFromPoint(this, in a), "elementFromPoint", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("elementsFromPoint", new JSFunction((in a) => Dom.Features.HitTestBinding.ElementsFromPoint(this, in a), "elementsFromPoint", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.getAnimations() — minimal Web Animations API support used by WPT.
-        document.FastAddValue((KeyString)"getAnimations", new JSFunction((in _) => BuildAnimationList(null), "getAnimations", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("getAnimations", new JSFunction((in _) => BuildAnimationList(null), "getAnimations", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document node factories — createElement/createTextNode/createAttribute/createDocumentFragment,
         // co-located in the DocumentFactoryBinding feature module (Phase 3).
-        document.FastAddValue((KeyString)"createElement", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateElement(this, context, in a), "createElement", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"createTextNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateTextNode(this, in a), "createTextNode", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"createAttribute", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateAttribute(this, context, in a), "createAttribute", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"createDocumentFragment", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateDocumentFragment(this, in a), "createDocumentFragment", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"importNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.ImportNode(this, context, in a), "importNode", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createElement", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateElement(this, context, in a), "createElement", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createTextNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateTextNode(this, in a), "createTextNode", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createAttribute", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateAttribute(this, context, in a), "createAttribute", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createDocumentFragment", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateDocumentFragment(this, in a), "createDocumentFragment", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("importNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.ImportNode(this, context, in a), "importNode", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         // adoptNode moves the node itself rather than copying it, which is the half importNode
         // cannot do and the one a custom element hears as adoptedCallback.
-        document.FastAddValue((KeyString)"adoptNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.AdoptNode(this, context, in a), "adoptNode", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("adoptNode", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.AdoptNode(this, context, in a), "adoptNode", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.createEvent(type) — DOM Events Level 3 (Phase 3: co-located LegacyEventBinding module)
-        document.FastAddValue((KeyString)"createEvent", new JSFunction(Dom.Features.LegacyEventBinding.Create, "createEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createEvent", new JSFunction(Dom.Features.LegacyEventBinding.Create, "createEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.startViewTransition(updateCallback | { update, types }) — CSS View Transitions
         // (see DomBridge.ViewTransition.cs). Runs the callback and returns a resolved ViewTransition;
         // the pseudo tree is baked at serialize time.
-        document.FastAddValue((KeyString)"startViewTransition", new JSFunction((in a) => StartViewTransition(in a), "startViewTransition", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("startViewTransition", new JSFunction((in a) => StartViewTransition(in a), "startViewTransition", 1), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     private void RegisterDocumentWriting(JSObject document)
     {
         // document.write(html) — parse and insert at the current script position (Phase 3:
         // co-located DocumentWriteBinding feature module).
-        document.FastAddValue((KeyString)"write", new JSFunction((in a) => Dom.Features.DocumentWriteBinding.Write(this, in a), "write", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("write", new JSFunction((in a) => Dom.Features.DocumentWriteBinding.Write(this, in a), "write", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.writeln(html) — same as write, with trailing newline
         var writeFn = (JSFunction)document[(KeyString)"write"];
-        document.FastAddValue((KeyString)"writeln", new JSFunction((in a) => Dom.Features.DocumentWriteBinding.Writeln(writeFn, in a), "writeln", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("writeln", new JSFunction((in a) => Dom.Features.DocumentWriteBinding.Writeln(writeFn, in a), "writeln", 1), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     private void RegisterDocumentNodeAndCollectionApis(JSContext context, JSObject document)
@@ -132,30 +132,30 @@ public sealed partial class DomBridge
         Dom.Features.NodeConstantsBinding.Install(document);
 
         // document.nodeType = DOCUMENT_NODE (9)
-        document.FastAddProperty((KeyString)"nodeType", new JSFunction((in _) => new JSNumber(9), "get nodeType"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("nodeType", new JSFunction((in _) => new JSNumber(9), "get nodeType"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.nodeName = "#document"
-        document.FastAddProperty((KeyString)"nodeName", new JSFunction((in _) => new JSString("#document"), "get nodeName"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("nodeName", new JSFunction((in _) => new JSString("#document"), "get nodeName"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.firstChild (getter — returns first child of document: DOCTYPE if present, else documentElement)
-        document.FastAddProperty((KeyString)"firstChild", new JSFunction((in _) => _document.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_document, 0)) : JSNull.Value, "get firstChild"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("firstChild", new JSFunction((in _) => _document.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_document, 0)) : JSNull.Value, "get firstChild"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.lastChild (getter — returns last child of document, typically documentElement)
-        document.FastAddProperty((KeyString)"lastChild", new JSFunction((in _) => _document.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_document, ^1)) : JSNull.Value, "get lastChild"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("lastChild", new JSFunction((in _) => _document.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_document, ^1)) : JSNull.Value, "get lastChild"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document-node mutation — childNodes/removeChild/appendChild/insertBefore, co-located in the
         // NodeMutationBinding feature module (Phase 3).
-        document.FastAddProperty((KeyString)"childNodes", new JSFunction((in a) => Dom.Features.NodeMutationBinding.GetChildNodes(this, in a), "get childNodes"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddValue((KeyString)"removeChild", new JSFunction((in a) => Dom.Features.NodeMutationBinding.RemoveChild(this, in a), "removeChild", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"appendChild", new JSFunction((in a) => Dom.Features.NodeMutationBinding.AppendChild(this, in a), "appendChild", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"insertBefore", new JSFunction((in a) => Dom.Features.NodeMutationBinding.InsertBefore(this, in a), "insertBefore", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddProperty("childNodes", new JSFunction((in a) => Dom.Features.NodeMutationBinding.GetChildNodes(this, in a), "get childNodes"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddValue("removeChild", new JSFunction((in a) => Dom.Features.NodeMutationBinding.RemoveChild(this, in a), "removeChild", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("appendChild", new JSFunction((in a) => Dom.Features.NodeMutationBinding.AppendChild(this, in a), "appendChild", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("insertBefore", new JSFunction((in a) => Dom.Features.NodeMutationBinding.InsertBefore(this, in a), "insertBefore", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Document includes the ParentNode mixin (DOM §4.2.6), so append/prepend/replaceChildren
         // exist on the document node just as they do on an element. Only the Node-level methods
         // above were bound, which made `document.append(x)` a TypeError mid-script.
-        document.FastAddValue((KeyString)"append", new JSFunction((in a) => Dom.Features.NodeMutationBinding.Append(this, in a), "append", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"prepend", new JSFunction((in a) => Dom.Features.NodeMutationBinding.Prepend(this, in a), "prepend", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        document.FastAddValue((KeyString)"replaceChildren", new JSFunction((in a) => Dom.Features.NodeMutationBinding.ReplaceChildren(this, in a), "replaceChildren", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("append", new JSFunction((in a) => Dom.Features.NodeMutationBinding.Append(this, in a), "append", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("prepend", new JSFunction((in a) => Dom.Features.NodeMutationBinding.Prepend(this, in a), "prepend", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("replaceChildren", new JSFunction((in a) => Dom.Features.NodeMutationBinding.ReplaceChildren(this, in a), "replaceChildren", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.forms/images/links/anchors/scripts/embeds/plugins/styleSheets — the live
         // collections, each built once and closed over so the identity a browser guarantees holds.
@@ -165,46 +165,46 @@ public sealed partial class DomBridge
         RegisterDocumentMetadata(document);
 
         // document.createElementNS(namespace, tagName)  — DocumentFactoryBinding (Phase 3)
-        document.FastAddValue((KeyString)"createElementNS", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateElementNS(this, context, in a), "createElementNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createElementNS", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateElementNS(this, context, in a), "createElementNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.createAttributeNS(namespace, qualifiedName)  — DocumentFactoryBinding (Phase 3)
-        document.FastAddValue((KeyString)"createAttributeNS", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateAttributeNS(this, context, in a), "createAttributeNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("createAttributeNS", new JSFunction((in a) => Dom.Features.DocumentFactoryBinding.CreateAttributeNS(this, context, in a), "createAttributeNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.currentScript — the <script> element being executed, null when none is. The
         // element the bridge already tracks for document.write's insertion point, read from the
         // property a loader script uses to find its own <src>.
-        document.FastAddProperty((KeyString)"currentScript", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetCurrentScript(this, in a), "get currentScript"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("currentScript", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetCurrentScript(this, in a), "get currentScript"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.adoptedStyleSheets — the live array of constructed stylesheets applied to the
         // document (CSSOM). Readable (supports .push) and assignable (= [sheet, …]).
-        document.FastAddProperty((KeyString)"adoptedStyleSheets",
+        document.FastAddProperty("adoptedStyleSheets",
             new JSFunction((in _) => AdoptedStyleSheetsArray(), "get adoptedStyleSheets"),
             new JSFunction((in a) => { SetAdoptedStyleSheets(a.Length > 0 ? a[0] : JSUndefined.Value); return JSUndefined.Value; }, "set adoptedStyleSheets"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.open() — for main document
-        document.FastAddValue((KeyString)"open", new JSFunction((in _) => document, "open", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("open", new JSFunction((in _) => document, "open", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.close() — for main document
-        document.FastAddValue((KeyString)"close", UndefinedFunction("close", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("close", UndefinedFunction("close", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.implementation — DOMImplementation
         var implementation = new JSObject();
 
         // implementation.hasFeature() — always returns true per spec
-        implementation.FastAddValue((KeyString)"hasFeature", TrueFunction("hasFeature", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        implementation.FastAddValue("hasFeature", TrueFunction("hasFeature", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.implementation factories — createDocumentType/createDocument/createHTMLDocument,
         // co-located in the DocumentLevelFactoryBinding feature module (Phase 3).
-        implementation.FastAddValue((KeyString)"createDocumentType", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateDocumentType(this, context, in a), "createDocumentType", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        implementation.FastAddValue("createDocumentType", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateDocumentType(this, context, in a), "createDocumentType", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // implementation.createDocument(namespace, qualifiedName, doctype)
-        implementation.FastAddValue((KeyString)"createDocument", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateDocument(this, context, in a), "createDocument", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        implementation.FastAddValue("createDocument", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateDocument(this, context, in a), "createDocument", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // implementation.createHTMLDocument(title)
-        implementation.FastAddValue((KeyString)"createHTMLDocument", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateHTMLDocument(this, in a), "createHTMLDocument", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        implementation.FastAddValue("createHTMLDocument", new JSFunction((in a) => Dom.Features.DocumentLevelFactoryBinding.CreateHTMLDocument(this, in a), "createHTMLDocument", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        document.FastAddValue((KeyString)"implementation", implementation, JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("implementation", implementation, JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     private void RegisterDocumentEventTargetAndMetadata(JSObject document)
@@ -216,48 +216,48 @@ public sealed partial class DomBridge
         // reaches exactly what these did (DomBridge.EventTargetInterface.cs).
         if (!_eventTargetRoutingReady)
         {
-            document.FastAddValue((KeyString)"addEventListener", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-            document.FastAddValue((KeyString)"removeEventListener", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-            document.FastAddValue((KeyString)"dispatchEvent", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            document.FastAddValue("addEventListener", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+            document.FastAddValue("removeEventListener", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+            document.FastAddValue("dispatchEvent", new JSFunction((in a) => Dom.Features.DocumentEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // document.contentType — returns the MIME type of the document
-        document.FastAddProperty((KeyString)"contentType", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetContentType(this, in a), "get contentType"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("contentType", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetContentType(this, in a), "get contentType"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.URL — returns the document URL
-        document.FastAddProperty((KeyString)"URL", new JSFunction((in _) => new JSString(_pageUrl), "get URL"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("URL", new JSFunction((in _) => new JSString(_pageUrl), "get URL"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.documentURI — same as document.URL
-        document.FastAddProperty((KeyString)"documentURI", new JSFunction((in _) => new JSString(_pageUrl), "get documentURI"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("documentURI", new JSFunction((in _) => new JSString(_pageUrl), "get documentURI"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.compatMode — "CSS1Compat" for standards mode, "BackCompat" for quirks
-        document.FastAddProperty((KeyString)"compatMode", new JSFunction((in _) => new JSString("CSS1Compat"), "get compatMode"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("compatMode", new JSFunction((in _) => new JSString("CSS1Compat"), "get compatMode"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.characterSet — always UTF-8
-        document.FastAddProperty((KeyString)"characterSet", new JSFunction((in _) => new JSString("UTF-8"), "get characterSet"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("characterSet", new JSFunction((in _) => new JSString("UTF-8"), "get characterSet"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.inputEncoding — alias for characterSet
-        document.FastAddProperty((KeyString)"inputEncoding", new JSFunction((in _) => new JSString("UTF-8"), "get inputEncoding"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("inputEncoding", new JSFunction((in _) => new JSString("UTF-8"), "get inputEncoding"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.charset — the other historical alias of characterSet (DOM §4.5). It reads the same
         // value as the two above; it was simply not registered, so the oldest of the three spellings —
         // and the one legacy encoding-sniffing code reaches for first — was the one that answered
         // `undefined`.
-        document.FastAddProperty((KeyString)"charset", new JSFunction((in _) => new JSString("UTF-8"), "get charset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("charset", new JSFunction((in _) => new JSString("UTF-8"), "get charset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.referrer — the URL of the page that linked here (HTML §3.1.5). A capture navigates
         // to its URL directly, with no referring document, and the empty string is precisely what the
         // specification (and a browser following a typed URL or a bookmark) reports for that: "If the
         // document has no referrer, return the empty string." Analytics and same-site-entry checks read
         // it unguarded, where `undefined` stringifies into a bogus referrer rather than reading as none.
-        document.FastAddProperty((KeyString)"referrer", new JSFunction((in _) => new JSString(string.Empty), "get referrer"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("referrer", new JSFunction((in _) => new JSString(string.Empty), "get referrer"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.domain — the origin's effective domain, i.e. this document's host.
-        document.FastAddProperty((KeyString)"domain", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetDocumentDomain(this, in a), "get domain"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("domain", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetDocumentDomain(this, in a), "get domain"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.lastModified — MM/DD/YYYY hh:mm:ss in local time; the current time when the source's
         // own modification date is unknown, which is the specification's stated fallback.
-        document.FastAddProperty((KeyString)"lastModified", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetLastModified(in a), "get lastModified"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("lastModified", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.GetLastModified(in a), "get lastModified"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.activeElement — the focused element, or, when nothing is focused, the body element:
         // HTML's algorithm ends "if candidate is null, set candidate to the body element", so `body` is
@@ -265,11 +265,11 @@ public sealed partial class DomBridge
         // always body. Returning it as a getter (not a stored reference) keeps it correct across
         // document mutation. Scripts commonly walk up from it — `document.activeElement.tagName`,
         // `.blur()` — which threw outright while the property was missing.
-        document.FastAddProperty((KeyString)"activeElement", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetBody(this, in a), "get activeElement"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("activeElement", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetBody(this, in a), "get activeElement"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.hasFocus() — true; see the binding for why a capture's one document is always the
         // focused one, matching visibilityState below.
-        document.FastAddValue((KeyString)"hasFocus", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.HasFocus(in a), "hasFocus", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("hasFocus", new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.HasFocus(in a), "hasFocus", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.hidden / document.visibilityState (Page Visibility, HTML §6.6). A capture
         // renders one document in one viewport and never backgrounds it, so the answer is always
@@ -279,8 +279,8 @@ public sealed partial class DomBridge
         // true for `false` and false for `undefined`. A missing property does not read as
         // "not hidden"; it reads as a third state no page has a branch for. See
         // docs/google-search-post-consent-challenge.md.
-        document.FastAddProperty((KeyString)"hidden", new JSFunction((in _) => JavaScript.BuiltIns.Boolean.JSBoolean.False, "get hidden"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        document.FastAddProperty((KeyString)"visibilityState", new JSFunction((in _) => new JSString("visible"), "get visibilityState"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("hidden", new JSFunction((in _) => JavaScript.BuiltIns.Boolean.JSBoolean.False, "get hidden"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty("visibilityState", new JSFunction((in _) => new JSString("visible"), "get visibilityState"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.onvisibilitychange — the event handler IDL attribute that completes the pair above,
         // null until a page assigns one. Its event never fires here, and that is the accurate outcome
@@ -289,6 +289,6 @@ public sealed partial class DomBridge
         // `'onvisibilitychange' in document` is the feature test pages use to decide whether the Page
         // Visibility API is available at all — answering false sent them to legacy focus/blur polling
         // even though `visibilityState` above answers correctly.
-        document.FastAddValue((KeyString)"onvisibilitychange", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("onvisibilitychange", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/DocumentSurface.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/DocumentSurface.cs
@@ -58,7 +58,7 @@ public sealed partial class DomBridge
 
         void Getter(string name, Func<JSValue> read) =>
             document.FastAddProperty(
-                (KeyString)name, new DomFunction((in _) => read(), $"get {name}"), null,
+                name, new DomFunction((in _) => read(), $"get {name}"), null,
                 JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 
@@ -77,7 +77,7 @@ public sealed partial class DomBridge
     private void RegisterDocumentMetadata(JSObject document)
     {
         document.FastAddProperty(
-            (KeyString)"doctype",
+            "doctype",
             new DomFunction((in _) => DocumentTypeNode() is { } doctype ? ToJSObject(doctype) : JSNull.Value, "get doctype"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -87,7 +87,7 @@ public sealed partial class DomBridge
         // the attribute still spelled "LTR", and an unknown value reads back as "" with the
         // attribute set to whatever was assigned.
         document.FastAddProperty(
-            (KeyString)"dir",
+            "dir",
             new DomFunction((in _) => new JSString(DocumentDirection()), "get dir"),
             new DomFunction((in a) =>
             {
@@ -100,7 +100,7 @@ public sealed partial class DomBridge
         // Assigning anything but "on"/"off" (ASCII case-insensitively) is ignored rather than
         // stored — `document.designMode = 'zzz'` leaves the previous value in place.
         document.FastAddProperty(
-            (KeyString)"designMode",
+            "designMode",
             new DomFunction((in _) => new JSString(_designMode), "get designMode"),
             new DomFunction((in a) =>
             {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
@@ -20,7 +20,7 @@ public sealed partial class DomBridge
         // here rather than in the JS asset. Order-independent of the pure-JS polyfills above.
         var cookieStore = "";
         document.FastAddProperty(
-            (KeyString)"cookie",
+            "cookie",
             new DomFunction((in _) => new JSString(cookieStore), "get cookie"),
             new DomFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetCookie(ref cookieStore, in a), "set cookie"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -30,7 +30,7 @@ public sealed partial class DomBridge
     {
         // window.crypto — the getRandomValues/randomUUID subset (Phase 3: co-located CryptoBinding module)
         var cryptoObj = Dom.Features.CryptoBinding.Build();
-        window.FastAddValue((KeyString)"crypto", cryptoObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("crypto", cryptoObj, JSPropertyAttributes.EnumerableConfigurableValue);
         context["crypto"] = cryptoObj;
 
         // window.CSS — the CSSOM namespace object (supports/escape). Host-driven rather than a
@@ -38,7 +38,7 @@ public sealed partial class DomBridge
         // evaluator; answering from the CSSOM instead would claim support for everything, since
         // Broiler's CSSOM stores declarations without validating them.
         var cssObj = Dom.Features.CssBinding.Build();
-        window.FastAddValue((KeyString)"CSS", cssObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("CSS", cssObj, JSPropertyAttributes.EnumerableConfigurableValue);
         context["CSS"] = cssObj;
 
         // DOMException constructor
@@ -96,13 +96,13 @@ public sealed partial class DomBridge
         // Notification — the interface, with its permission already settled at "denied" because
         // there is no surface to show one on (NotificationBinding).
         var notification = Dom.Features.NotificationBinding.Build();
-        window.FastAddValue((KeyString)"Notification", notification, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Notification", notification, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // MediaSource — the Media Source Extensions entry point, whose isTypeSupported answers for
         // the playback pipeline the HTML layer does not yet have (MediaCapabilityBinding, which also
         // installs canPlayType on the media elements themselves).
         var mediaSource = Dom.Features.MediaCapabilityBinding.BuildMediaSource(context);
-        window.FastAddValue((KeyString)"MediaSource", mediaSource, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("MediaSource", mediaSource, JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
@@ -145,15 +145,15 @@ public sealed partial class DomBridge
         // registration; they are registered here alongside the other window globals now that the fetch
         // networking surface is an isolated feature module.
         var messageChannelCtor = new JSFunction((in _) => _messaging.CreateMessageChannel(), "MessageChannel", 0);
-        window.FastAddValue((KeyString)"MessageChannel", messageChannelCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("MessageChannel", messageChannelCtor, JSPropertyAttributes.EnumerableConfigurableValue);
         context["MessageChannel"] = messageChannelCtor;
         // CSSStyleSheet constructor (constructable stylesheets / adoptedStyleSheets — CSSOM).
         var cssStyleSheetCtor = new JSFunction((in a) => CreateConstructedStyleSheet(in a), "CSSStyleSheet", 0);
-        window.FastAddValue((KeyString)"CSSStyleSheet", cssStyleSheetCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("CSSStyleSheet", cssStyleSheetCtor, JSPropertyAttributes.EnumerableConfigurableValue);
         context["CSSStyleSheet"] = cssStyleSheetCtor;
         // getComputedStyle (CSSOM), co-located in the ComputedStyleBinding feature module (Phase 3).
         window.FastAddValue(
-            (KeyString)"getComputedStyle",
+            "getComputedStyle",
             new JSFunction((in a) => Dom.Features.ComputedStyleBinding.GetComputedStyle(this, in a), "getComputedStyle", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         windowBasicsScope.Dispose();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -20,17 +20,17 @@ public sealed partial class DomBridge
 
     private JSObject RegisterWindowBasics(JSObject document, JSObject window)
     {
-        window.FastAddValue((KeyString)"document", document, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("document", document, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.localStorage / window.sessionStorage — the two Web Storage areas (HTML §12.2),
         // each an in-memory Storage object of its own. Built separately because they are separate
         // areas: a page that stashes per-tab state in one and durable state in the other must not
         // see the two answer each other's reads.
-        window.FastAddValue((KeyString)"localStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"sessionStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("localStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("sessionStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.matchMedia(query) — evaluates basic media queries
-        window.FastAddValue((KeyString)"matchMedia", new DomFunction((in a) => Dom.Features.MatchMediaBinding.MatchMedia(this, in a), "matchMedia", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("matchMedia", new DomFunction((in a) => Dom.Features.MatchMediaBinding.MatchMedia(this, in a), "matchMedia", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.location — the URL components here, and the navigation surface (`href`, assign,
         // replace, reload, toString) from LocationBinding. The components alone made
@@ -38,17 +38,17 @@ public sealed partial class DomBridge
         // of the calling function, so they are built together: see LocationBinding for what the
         // four do in a capture, and why they do not navigate.
         var location = new JSObject();
-        location.FastAddValue((KeyString)"protocol", new JSString(_pageProtocol), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"host", new JSString(_pageHost), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"hostname", new JSString(_pageHostName), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"port", new JSString(_pagePort), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"pathname", new JSString(_pagePathName), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"search", new JSString(_pageSearch), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"hash", new JSString(_pageHash), JSPropertyAttributes.EnumerableConfigurableValue);
-        location.FastAddValue((KeyString)"origin", new JSString(_pageOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("protocol", new JSString(_pageProtocol), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("host", new JSString(_pageHost), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("hostname", new JSString(_pageHostName), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("port", new JSString(_pagePort), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("pathname", new JSString(_pagePathName), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("search", new JSString(_pageSearch), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("hash", new JSString(_pageHash), JSPropertyAttributes.EnumerableConfigurableValue);
+        location.FastAddValue("origin", new JSString(_pageOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
         Dom.Features.LocationBinding.AddNavigationSurface(location, _pageUrl);
 
-        window.FastAddValue((KeyString)"location", location, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("location", location, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.location is the *same* Location as window.location (HTML §3.1.5: the getter
         // returns this document's relevant global object's Location), so it is the one object
@@ -59,25 +59,25 @@ public sealed partial class DomBridge
         // bundle `top` above died in — `dF=function(){var a=document.location;return
         // a.protocol+"//"+a.host}` is how it builds its own origin — so it is the next thing that
         // failed once `top` resolved.
-        document.FastAddValue((KeyString)"location", location, JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("location", location, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window timers / animation frames — thin adapters over the P2.4 BrowserEventLoop, co-located
         // in the TimerBinding feature module (Phase 3).
-        window.FastAddValue((KeyString)"setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, _windowContext, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"clearTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "clearTimeout", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"setInterval", new DomFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, _windowContext, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"clearInterval", new DomFunction((in a) => Dom.Features.TimerBinding.ClearInterval(_eventLoop, in a), "clearInterval", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"requestAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, _windowContext, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"cancelAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.CancelAnimationFrame(_eventLoop, in a), "cancelAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, _windowContext, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("clearTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "clearTimeout", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("setInterval", new DomFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, _windowContext, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("clearInterval", new DomFunction((in a) => Dom.Features.TimerBinding.ClearInterval(_eventLoop, in a), "clearInterval", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("requestAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, _windowContext, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("cancelAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.CancelAnimationFrame(_eventLoop, in a), "cancelAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.alert(msg) — logs to debug output
-        window.FastAddValue((KeyString)"alert", new DomFunction(Dom.Features.WindowDocumentMiscBinding.Alert, "alert", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("alert", new DomFunction(Dom.Features.WindowDocumentMiscBinding.Alert, "alert", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // btoa / atob — the WindowOrWorkerGlobalScope base64 pair (HTML §8.3), co-located in the
         // Base64Binding feature module. The window IS the global object, so registering here is
         // what makes the unqualified `atob(…)` a page writes resolve as well.
-        window.FastAddValue((KeyString)"btoa", new DomFunction((in a) => Dom.Features.Base64Binding.Btoa(_jsContext!, in a), "btoa", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"atob", new DomFunction((in a) => Dom.Features.Base64Binding.Atob(_jsContext!, in a), "atob", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("btoa", new DomFunction((in a) => Dom.Features.Base64Binding.Btoa(_jsContext!, in a), "btoa", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("atob", new DomFunction((in a) => Dom.Features.Base64Binding.Atob(_jsContext!, in a), "atob", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // console object (shared between window.console and global console)
         var console = Dom.Features.ConsoleBinding.Build();
@@ -86,9 +86,9 @@ public sealed partial class DomBridge
         // same object. Kept as one object here too, so a page that samples both does not have to
         // reconcile two answers taken a moment apart. See PerformanceMemoryBinding.
         _memoryInfo = Dom.Features.PerformanceMemoryBinding.Build();
-        console.FastAddValue((KeyString)"memory", _memoryInfo, JSPropertyAttributes.EnumerableConfigurableValue);
+        console.FastAddValue("memory", _memoryInfo, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"console", console, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("console", console, JSPropertyAttributes.EnumerableConfigurableValue);
 
         return console;
     }
@@ -96,23 +96,23 @@ public sealed partial class DomBridge
     private void RegisterWindowGlobals(JSContext context, JSObject document, JSObject window, JSObject console, JSFunction fetchFn)
     {
         context["window"] = window;
-        window.FastAddValue((KeyString)"Event", context["Event"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"CustomEvent", context["CustomEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"MouseEvent", context["MouseEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"FocusEvent", context["FocusEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"KeyboardEvent", context["KeyboardEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"WheelEvent", context["WheelEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"UIEvent", context["UIEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"InputEvent", context["InputEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Event", context["Event"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("CustomEvent", context["CustomEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("MouseEvent", context["MouseEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("FocusEvent", context["FocusEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("KeyboardEvent", context["KeyboardEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("WheelEvent", context["WheelEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("UIEvent", context["UIEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("InputEvent", context["InputEvent"], JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.parent — uses the JSContext global scope so that parent.X()
         // resolves user-defined globals (e.g. parent.notify() from sub-documents).
         var globalThis = context.Eval("this");
-        window.FastAddValue((KeyString)"parent", globalThis, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("parent", globalThis, JSPropertyAttributes.EnumerableConfigurableValue);
         context["parent"] = globalThis;
 
         // window.self — refers to this window
-        window.FastAddValue((KeyString)"self", window, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("self", window, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.top — the topmost browsing context. This document is the top-level one, so
         // `top`, `parent` and `self` are all this window; a sub-document's window instead gets
@@ -123,11 +123,11 @@ public sealed partial class DomBridge
         // unqualified (`if (top != self)`), so this is the first thing a page's boilerplate
         // touches: google.com's One-Google-bar bundle died on it, taking with it every listener
         // the rest of that script would have registered.
-        window.FastAddValue((KeyString)"top", globalThis, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("top", globalThis, JSPropertyAttributes.EnumerableConfigurableValue);
         context["top"] = globalThis;
 
         // document.defaultView — returns the window object
-        document.FastAddValue((KeyString)"defaultView", window, JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue("defaultView", window, JSPropertyAttributes.EnumerableConfigurableValue);
         context["console"] = console;
         context["fetch"] = fetchFn;
 
@@ -177,8 +177,8 @@ public sealed partial class DomBridge
         var performanceTimeOrigin = fetchTiming?.UnixTimeOriginMs ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var performanceMonotonicOrigin = fetchTiming?.MonotonicOrigin ?? System.Diagnostics.Stopwatch.GetTimestamp();
         var performanceObj = new JSObject();
-        performanceObj.FastAddValue((KeyString)"timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"now", new DomFunction((in _) => Dom.Features.WindowDocumentMiscBinding.PerformanceNow(performanceMonotonicOrigin, in _), "now", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("now", new DomFunction((in _) => Dom.Features.WindowDocumentMiscBinding.PerformanceNow(performanceMonotonicOrigin, in _), "now", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The Performance Timeline getters (Performance Timeline §3), all three of which answer from
         // the one entry a document that has navigated once and loaded no instrumented resources has:
@@ -205,36 +205,36 @@ public sealed partial class DomBridge
         // performance.memory — the same MemoryInfo console.memory reports (built with the console in
         // RegisterWindowBasics, which runs first).
         if (_memoryInfo is { } memory)
-            performanceObj.FastAddValue((KeyString)"memory", memory, JSPropertyAttributes.EnumerableConfigurableValue);
+            performanceObj.FastAddValue("memory", memory, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // performance.mark() / performance.measure() — no-op stubs
-        performanceObj.FastAddValue((KeyString)"mark", UndefinedFunction("mark", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"measure", UndefinedFunction("measure", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("mark", UndefinedFunction("mark", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("measure", UndefinedFunction("measure", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The clear/resize counterparts to mark, measure and the resource buffer. Nothing is recorded
         // for them to clear, but a page that marks commonly clears in the same breath, and the throw
         // would land on the clear rather than on the mark it pairs with.
-        performanceObj.FastAddValue((KeyString)"clearMarks", UndefinedFunction("clearMarks", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"clearMeasures", UndefinedFunction("clearMeasures", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"clearResourceTimings", UndefinedFunction("clearResourceTimings", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"setResourceTimingBufferSize", UndefinedFunction("setResourceTimingBufferSize", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("clearMarks", UndefinedFunction("clearMarks", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("clearMeasures", UndefinedFunction("clearMeasures", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("clearResourceTimings", UndefinedFunction("clearResourceTimings", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue("setResourceTimingBufferSize", UndefinedFunction("setResourceTimingBufferSize", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // toJSON is how the interface serialises, and telemetry that ships timings reaches it through
         // JSON.stringify(performance) as often as by name.
         performanceObj.FastAddValue(
-            (KeyString)"toJSON",
+            "toJSON",
             new DomFunction(
                 (in _) =>
                 {
                     var json = new JSObject();
-                    json.FastAddValue((KeyString)"timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
+                    json.FastAddValue("timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
                     return json;
                 },
                 "toJSON",
                 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"performance", performanceObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("performance", performanceObj, JSPropertyAttributes.EnumerableConfigurableValue);
         context["performance"] = performanceObj;
     }
 
@@ -256,28 +256,28 @@ public sealed partial class DomBridge
     {
         var history = new JSObject();
 
-        history.FastAddValue((KeyString)"length", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
-        history.FastAddValue((KeyString)"state", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        history.FastAddValue((KeyString)"scrollRestoration", new JSString("auto"), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("length", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("state", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("scrollRestoration", new JSString("auto"), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // pushState/replaceState record the state the page hands them, because a page that writes
         // one commonly reads it straight back; neither changes the document's URL, which a capture
         // has no way to honour.
-        history.FastAddValue((KeyString)"pushState", new DomFunction((in a) => StoreHistoryState(history, in a), "pushState", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-        history.FastAddValue((KeyString)"replaceState", new DomFunction((in a) => StoreHistoryState(history, in a), "replaceState", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("pushState", new DomFunction((in a) => StoreHistoryState(history, in a), "pushState", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("replaceState", new DomFunction((in a) => StoreHistoryState(history, in a), "replaceState", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        history.FastAddValue((KeyString)"back", UndefinedFunction("back", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        history.FastAddValue((KeyString)"forward", UndefinedFunction("forward", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        history.FastAddValue((KeyString)"go", UndefinedFunction("go", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("back", UndefinedFunction("back", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("forward", UndefinedFunction("forward", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        history.FastAddValue("go", UndefinedFunction("go", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"history", history, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("history", history, JSPropertyAttributes.EnumerableConfigurableValue);
         context["history"] = history;
     }
 
     private static JSValue StoreHistoryState(JSObject history, in Arguments arguments)
     {
         history.FastAddValue(
-            (KeyString)"state",
+            "state",
             arguments.Length > 0 ? arguments[0] : JSNull.Value,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -306,36 +306,36 @@ public sealed partial class DomBridge
             return;
 
         var observerPrototype = new JSObject();
-        observerPrototype.FastAddValue((KeyString)"observe", UndefinedFunction("observe", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        observerPrototype.FastAddValue((KeyString)"disconnect", UndefinedFunction("disconnect", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        observerPrototype.FastAddValue((KeyString)"takeRecords", new DomFunction((in _) => new JSArray(), "takeRecords", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        observerPrototype.FastAddValue("observe", UndefinedFunction("observe", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        observerPrototype.FastAddValue("disconnect", UndefinedFunction("disconnect", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        observerPrototype.FastAddValue("takeRecords", new DomFunction((in _) => new JSArray(), "takeRecords", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         var performanceObserver = new JSFunction((in _) =>
         {
             var instance = new JSObject();
-            instance.FastAddValue((KeyString)"observe", UndefinedFunction("observe", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            instance.FastAddValue((KeyString)"disconnect", UndefinedFunction("disconnect", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            instance.FastAddValue((KeyString)"takeRecords", new DomFunction((in _) => new JSArray(), "takeRecords", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            instance.FastAddValue("observe", UndefinedFunction("observe", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            instance.FastAddValue("disconnect", UndefinedFunction("disconnect", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            instance.FastAddValue("takeRecords", new DomFunction((in _) => new JSArray(), "takeRecords", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             return instance;
         }, "PerformanceObserver", 1);
 
-        performanceObserver.FastAddValue((KeyString)"prototype", observerPrototype, JSPropertyAttributes.ConfigurableValue);
+        performanceObserver.FastAddValue("prototype", observerPrototype, JSPropertyAttributes.ConfigurableValue);
 
         // Feature detection reads this before observing, and an observer that claims to support
         // nothing is the honest answer for a capture that reports no entries.
-        performanceObserver.FastAddValue((KeyString)"supportedEntryTypes", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObserver.FastAddValue("supportedEntryTypes", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"PerformanceObserver", performanceObserver, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("PerformanceObserver", performanceObserver, JSPropertyAttributes.EnumerableConfigurableValue);
         context["PerformanceObserver"] = performanceObserver;
 
         if (window[(KeyString)"requestIdleCallback"] is JSUndefined)
         {
             var requestIdle = new DomFunction((in a) => Dom.Features.TimerBinding.RequestIdleCallback(_eventLoop, _windowContext, in a), "requestIdleCallback", 1);
-            window.FastAddValue((KeyString)"requestIdleCallback", requestIdle, JSPropertyAttributes.EnumerableConfigurableValue);
+            window.FastAddValue("requestIdleCallback", requestIdle, JSPropertyAttributes.EnumerableConfigurableValue);
             context["requestIdleCallback"] = requestIdle;
 
             var cancelIdle = new DomFunction((in a) => Dom.Features.TimerBinding.CancelIdleCallback(_eventLoop, in a), "cancelIdleCallback", 1);
-            window.FastAddValue((KeyString)"cancelIdleCallback", cancelIdle, JSPropertyAttributes.EnumerableConfigurableValue);
+            window.FastAddValue("cancelIdleCallback", cancelIdle, JSPropertyAttributes.EnumerableConfigurableValue);
             context["cancelIdleCallback"] = cancelIdle;
         }
     }
@@ -346,15 +346,15 @@ public sealed partial class DomBridge
         var navigatorObj = new JSObject();
         // The same string the network sees, rather than a second copy of it: a page that compares
         // what it was told with what its own fetches report is entitled to one answer.
-        navigatorObj.FastAddValue((KeyString)"userAgent", new JSString(Layout.Net.BroilerUserAgent.Value), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigatorObj.FastAddValue((KeyString)"language", new JSString("en-US"), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigatorObj.FastAddValue((KeyString)"languages", new JSArray([new JSString("en-US"), new JSString("en")]), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigatorObj.FastAddValue((KeyString)"cookieEnabled", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        navigatorObj.FastAddValue((KeyString)"onLine", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        navigatorObj.FastAddValue((KeyString)"platform", new JSString("Win32"), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("userAgent", new JSString(Layout.Net.BroilerUserAgent.Value), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("language", new JSString("en-US"), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("languages", new JSArray([new JSString("en-US"), new JSString("en")]), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("cookieEnabled", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("onLine", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("platform", new JSString("Win32"), JSPropertyAttributes.EnumerableConfigurableValue);
         // Conforming and truthful: §8.9 allows exactly "", "Apple Computer, Inc." or "Google Inc.",
         // and Broiler's user agent does not claim to be Chrome. See NavigatorIdentityBinding.
-        navigatorObj.FastAddValue((KeyString)"vendor", new JSString(""), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("vendor", new JSString(""), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Who the browser is and what the machine underneath it has — the legacy identity constants
         // §8.9 mandates for every user agent, `webdriver`, and the measured hardware members. Takes
@@ -362,7 +362,7 @@ public sealed partial class DomBridge
         Dom.Features.NavigatorIdentityBinding.Install(navigatorObj, Layout.Net.BroilerUserAgent.Value);
 
         // sendBeacon(url, data) — queues a fire-and-forget POST via fetch semantics
-        navigatorObj.FastAddValue((KeyString)"sendBeacon", new DomFunction((in a) => Dom.Features.BeaconBinding.Send(window, in a), "sendBeacon", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue("sendBeacon", new DomFunction((in a) => Dom.Features.BeaconBinding.Send(window, in a), "sendBeacon", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // What the host machine can do — javaEnabled, plugins/mimeTypes, getGamepads, getBattery,
         // requestMediaKeySystemAccess — and the legacy storage-quota pair, each answering "no" in
@@ -377,7 +377,7 @@ public sealed partial class DomBridge
         // and mediaCapabilities stay absent — see NavigatorSurfacesBinding for each decision.
         Dom.Features.NavigatorSurfacesBinding.Install(navigatorObj, context, Layout.Net.BroilerUserAgent.Value);
 
-        window.FastAddValue((KeyString)"navigator", navigatorObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("navigator", navigatorObj, JSPropertyAttributes.EnumerableConfigurableValue);
 
         context["navigator"] = navigatorObj;
         context["postMessage"] = window[(KeyString)"postMessage"];
@@ -389,14 +389,14 @@ public sealed partial class DomBridge
         var vpWidth = _viewportWidth;
         var vpHeight = _viewportHeight;
 
-        window.FastAddProperty((KeyString)"innerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get innerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"innerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get innerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"outerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get outerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"outerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get outerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"scrollX", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"scrollY", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"pageXOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"pageYOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("innerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get innerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("innerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get innerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("outerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get outerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("outerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get outerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("scrollX", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("scrollY", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("pageXOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("pageYOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // The window's position on the screen (CSSOM View §4). Zero, and not as a placeholder: the
         // capture's viewport IS its screen — `screen.width`/`height` below are the viewport's own
@@ -404,10 +404,10 @@ public sealed partial class DomBridge
         // older spelling of the same pair and must agree with it. Absent, all four read `undefined`,
         // and the popup-positioning arithmetic that reads them (`screenX + (outerWidth - w) / 2`, the
         // standard centre-on-parent idiom) produced NaN rather than a coordinate.
-        window.FastAddProperty((KeyString)"screenX", new DomFunction((in _) => new JSNumber(0), "get screenX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"screenY", new DomFunction((in _) => new JSNumber(0), "get screenY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"screenLeft", new DomFunction((in _) => new JSNumber(0), "get screenLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"screenTop", new DomFunction((in _) => new JSNumber(0), "get screenTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("screenX", new DomFunction((in _) => new JSNumber(0), "get screenX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("screenY", new DomFunction((in _) => new JSNumber(0), "get screenY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("screenLeft", new DomFunction((in _) => new JSNumber(0), "get screenLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("screenTop", new DomFunction((in _) => new JSNumber(0), "get screenTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // window.devicePixelRatio — physical pixels per CSS pixel. One, because that is what this
         // renderer does: it has no device-scale or backing-store-scale concept at all, so a CSS pixel
@@ -415,7 +415,7 @@ public sealed partial class DomBridge
         // `visualViewport.scale` below, which is where a page should read it.) Absent, the near-universal
         // `devicePixelRatio || 1` fallback happened to survive, but the equally common
         // `canvas.width = rect.width * devicePixelRatio` produced NaN and collapsed the canvas.
-        window.FastAddProperty((KeyString)"devicePixelRatio", new DomFunction((in _) => new JSNumber(1), "get devicePixelRatio"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("devicePixelRatio", new DomFunction((in _) => new JSNumber(1), "get devicePixelRatio"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // The six BarProp objects. See WindowBarPropBinding for why every one reports not-visible.
         Dom.Features.WindowBarPropBinding.Install(window);
@@ -425,20 +425,20 @@ public sealed partial class DomBridge
         // definition left to satisfy; `true` is the value the reference engine reports, and the point
         // of having it at all is that the read yields a boolean rather than `undefined`. Grouped with
         // the geometry above because it is the last member of that same audited block.
-        window.FastAddProperty((KeyString)"offscreenBuffering", new DomFunction((in _) => JSBoolean.True, "get offscreenBuffering"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("offscreenBuffering", new DomFunction((in _) => JSBoolean.True, "get offscreenBuffering"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // window scroll / scrollTo / scrollBy, co-located in the WindowScrollBinding feature module (Phase 3).
-        window.FastAddValue((KeyString)"scroll", new DomFunction((in a) => Dom.Features.WindowScrollBinding.Scroll(this, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"scrollTo", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollTo(this, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"scrollBy", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollBy(this, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("scroll", new DomFunction((in a) => Dom.Features.WindowScrollBinding.Scroll(this, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("scrollTo", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollTo(this, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("scrollBy", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollBy(this, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         // window addEventListener / removeEventListener / dispatchEvent, co-located in the
         // WindowEventTargetBinding feature module (Phase 3). These reach the global object — so
         // the idiomatic unqualified `addEventListener("load", …)` registers a window listener,
         // as it does in a browser — through MirrorWindowMembersOntoGlobal, which shares the
         // identical function objects so the two spellings address one listener store.
-        window.FastAddValue((KeyString)"addEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"removeEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"dispatchEvent", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("addEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("removeEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("dispatchEvent", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         _messaging.RegisterWindowMessaging(window);
 
@@ -447,46 +447,46 @@ public sealed partial class DomBridge
         // Now that the window IS the global the second write would simply overwrite the first,
         // freezing `frames` to whatever existed before any <iframe> was scripted. The accessor is
         // the correct one for both spellings, so it is the only registration.
-        window.FastAddProperty((KeyString)"frames", new DomFunction((in _) => BuildWindowFramesArray(), "get frames"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty("frames", new DomFunction((in _) => BuildWindowFramesArray(), "get frames"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // window.screen — basic stub for screen dimensions
         var screenObj = new JSObject();
-        screenObj.FastAddValue((KeyString)"width", new JSNumber(vpWidth), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"height", new JSNumber(vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"availWidth", new JSNumber(vpWidth), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"availHeight", new JSNumber(vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("width", new JSNumber(vpWidth), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("height", new JSNumber(vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("availWidth", new JSNumber(vpWidth), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("availHeight", new JSNumber(vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The origin of the available area (CSSOM View §5). Zero for the same reason the avail sizes
         // above equal the full screen: nothing — no dock, no taskbar — is reserved out of a capture's
         // screen, so the available rectangle starts at the screen origin. They complete the pair the
         // avail sizes belong to; a page computing `availLeft + availWidth` was getting NaN.
-        screenObj.FastAddValue((KeyString)"availLeft", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"availTop", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"colorDepth", new JSNumber(24), JSPropertyAttributes.EnumerableConfigurableValue);
-        screenObj.FastAddValue((KeyString)"pixelDepth", new JSNumber(24), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("availLeft", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("availTop", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("colorDepth", new JSNumber(24), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("pixelDepth", new JSNumber(24), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // screen.orientation — derived from the screen's own shape, so it stays consistent with the
         // width/height above rather than being a second, independent claim. See
         // ScreenOrientationBinding.
-        screenObj.FastAddValue((KeyString)"orientation", Dom.Features.ScreenOrientationBinding.Build(vpWidth, vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
+        screenObj.FastAddValue("orientation", Dom.Features.ScreenOrientationBinding.Build(vpWidth, vpHeight), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"screen", screenObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("screen", screenObj, JSPropertyAttributes.EnumerableConfigurableValue);
         context["screen"] = screenObj;
 
         var visualViewport = new JSObject();
         _visualViewportJSObject = visualViewport;
-        visualViewport.FastAddProperty((KeyString)"width", new DomFunction((in _) => new JSNumber(GetVisualViewportWidth()), "get width"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"height", new DomFunction((in _) => new JSNumber(GetVisualViewportHeight()), "get height"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"scale", new DomFunction((in _) => new JSNumber(GetVisualViewportScale()), "get scale"), new DomFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetVisualViewportScale(this, in a), "set scale"), JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"pageLeft", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: false)), "get pageLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"pageTop", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: true)), "get pageTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty("width", new DomFunction((in _) => new JSNumber(GetVisualViewportWidth()), "get width"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty("height", new DomFunction((in _) => new JSNumber(GetVisualViewportHeight()), "get height"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty("scale", new DomFunction((in _) => new JSNumber(GetVisualViewportScale()), "get scale"), new DomFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetVisualViewportScale(this, in a), "set scale"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty("pageLeft", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: false)), "get pageLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty("pageTop", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: true)), "get pageTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // visualViewport addEventListener / removeEventListener (scroll), co-located in the
         // VisualViewportEventTargetBinding feature module (Phase 3).
-        visualViewport.FastAddValue((KeyString)"addEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.AddEventListener(this, in a), "addEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        visualViewport.FastAddValue((KeyString)"removeEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        visualViewport.FastAddValue("addEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.AddEventListener(this, in a), "addEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        visualViewport.FastAddValue("removeEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        window.FastAddValue((KeyString)"visualViewport", visualViewport, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("visualViewport", visualViewport, JSPropertyAttributes.EnumerableConfigurableValue);
         context["visualViewport"] = visualViewport;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -118,7 +118,7 @@ public sealed partial class DomBridge
         var sheet = new JSObject();
 
         // ownerNode
-        sheet.FastAddProperty((KeyString)"ownerNode", new DomFunction((in _) => ToJSObject(styleElement), "get ownerNode"),
+        sheet.FastAddProperty("ownerNode", new DomFunction((in _) => ToJSObject(styleElement), "get ownerNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // href — CSSOM §2.1 StyleSheet.href: the location of the sheet, null for an inline
@@ -126,14 +126,14 @@ public sealed partial class DomBridge
         // document.styleSheets as an inline sheet that happened to have no rules. A live getter
         // rather than a captured value: the sheet object is cached per element for identity, and a
         // script can re-point the link at another href afterwards.
-        sheet.FastAddProperty((KeyString)"href",
+        sheet.FastAddProperty("href",
             new DomFunction((in _) => StyleSheetHrefValue(styleElement), "get href"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // disabled — CSSOM StyleSheet.disabled. A true value prevents the sheet from
         // applying (CSSOM §2.3). Getting reads the effective state (script flag, else the
         // <link disabled> content attribute); setting stores the script flag and re-cascades.
-        sheet.FastAddProperty((KeyString)"disabled",
+        sheet.FastAddProperty("disabled",
             new DomFunction((in _) => IsStyleSheetDisabled(styleElement) ? JSBoolean.True : JSBoolean.False, "get disabled"),
             new DomFunction((in a) => { SetStyleSheetDisabledFlag(styleElement, a.Length > 0 && a[0].BooleanValue); return JSUndefined.Value; }, "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -150,11 +150,11 @@ public sealed partial class DomBridge
         var liveCssRules = new JSObject();
         var lastSyncedRuleCount = 0;
         // length is a live getter that always reflects the current rule count
-        liveCssRules.FastAddProperty((KeyString)"length",
+        liveCssRules.FastAddProperty("length",
             new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        liveCssRules.FastAddValue((KeyString)"item",
+        liveCssRules.FastAddValue("item",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -175,18 +175,18 @@ public sealed partial class DomBridge
         }
 
         // cssRules — returns the live collection, syncing indices on access
-        sheet.FastAddProperty((KeyString)"cssRules",
+        sheet.FastAddProperty("cssRules",
             new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // insertRule(rule, index) — mutates the shared model (marking it mutated so
         // the renderer/engine serialize from it) and resyncs the live collection
-        sheet.FastAddValue((KeyString)"insertRule",
+        sheet.FastAddValue("insertRule",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // deleteRule(index) — removes a rule from the shared model
-        sheet.FastAddValue((KeyString)"deleteRule",
+        sheet.FastAddValue("deleteRule",
             new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -78,8 +78,8 @@ public sealed partial class DomBridge
         try
         {
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("load"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString("load"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             DispatchEventOnElement(element, evt);
         }
         catch (Exception ex)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -35,14 +35,14 @@ public sealed partial class DomBridge
     private JSObject CreateDomRectObject((double Left, double Top, double Width, double Height) rectData)
     {
         var rect = new JSObject();
-        rect.FastAddValue((KeyString)"x", new JSNumber(rectData.Left), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"y", new JSNumber(rectData.Top), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"top", new JSNumber(rectData.Top), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"left", new JSNumber(rectData.Left), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"right", new JSNumber(rectData.Left + rectData.Width), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"bottom", new JSNumber(rectData.Top + rectData.Height), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"width", new JSNumber(rectData.Width), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"height", new JSNumber(rectData.Height), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("x", new JSNumber(rectData.Left), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("y", new JSNumber(rectData.Top), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("top", new JSNumber(rectData.Top), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("left", new JSNumber(rectData.Left), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("right", new JSNumber(rectData.Left + rectData.Width), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("bottom", new JSNumber(rectData.Top + rectData.Height), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("width", new JSNumber(rectData.Width), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("height", new JSNumber(rectData.Height), JSPropertyAttributes.EnumerableConfigurableValue);
         return rect;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
@@ -123,9 +123,9 @@ internal sealed class AttributesBinding(IAttributesHost host)
 
         byName.Remove(name);
         DomBridge.TryGetAttribute(element, name, out var lastValue);
-        attr.FastAddValue((KeyString)"ownerElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"value", new JSString(lastValue ?? string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"nodeValue", new JSString(lastValue ?? string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("ownerElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("value", new JSString(lastValue ?? string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("nodeValue", new JSString(lastValue ?? string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     /// <summary>
@@ -317,31 +317,31 @@ internal sealed class AttributesBinding(IAttributesHost host)
         var localName = explicitLocalName ?? (colonIdx >= 0 ? name[(colonIdx + 1)..] : name);
         var prefix = colonIdx >= 0 ? name[..colonIdx] : null;
 
-        attr.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
         if (accessor is { } live)
         {
-            attr.FastAddProperty((KeyString)"value",
+            attr.FastAddProperty("value",
                 new DomFunction((in _) => live.Read(), "get value"),
                 new DomFunction(live.Write, "set value"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
-            attr.FastAddProperty((KeyString)"nodeValue",
+            attr.FastAddProperty("nodeValue",
                 new DomFunction((in _) => live.Read(), "get nodeValue"),
                 new DomFunction(live.Write, "set nodeValue"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else
         {
-            attr.FastAddValue((KeyString)"value", liveValue ?? new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-            attr.FastAddValue((KeyString)"nodeValue", liveValue ?? new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+            attr.FastAddValue("value", liveValue ?? new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+            attr.FastAddValue("nodeValue", liveValue ?? new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
-        attr.FastAddValue((KeyString)"specified", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"ownerElement", ownerElement, JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"nodeType", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"nodeName", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"localName", new JSString(localName), JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"prefix", prefix != null ? new JSString(prefix) : JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        attr.FastAddValue((KeyString)"namespaceURI", namespaceUri != null ? new JSString(namespaceUri) : JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("specified", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("ownerElement", ownerElement, JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("nodeType", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("nodeName", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("localName", new JSString(localName), JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("prefix", prefix != null ? new JSString(prefix) : JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        attr.FastAddValue("namespaceURI", namespaceUri != null ? new JSString(namespaceUri) : JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
 
         return attr;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/BlobBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/BlobBinding.cs
@@ -174,11 +174,11 @@ internal sealed class BlobBinding
             return;
 
         url.FastAddValue(
-            (KeyString)"createObjectURL",
+            "createObjectURL",
             new DomFunction((in a) => CreateObjectUrl(in a), "createObjectURL", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         url.FastAddValue(
-            (KeyString)"revokeObjectURL",
+            "revokeObjectURL",
             new DomFunction((in a) => RevokeObjectUrl(in a), "revokeObjectURL", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -383,13 +383,13 @@ internal sealed class BlobBinding
 
     private void Method(JSObject prototype, string name, int length, BlobOperation body) =>
         prototype.FastAddValue(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => body(DataFor(in a, name), in a), name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
     private void Getter(JSObject prototype, string name, Func<BlobData, JSValue> read) =>
         prototype.FastAddProperty(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => read(DataFor(in a, name)), $"get {name}"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
@@ -62,11 +62,11 @@ internal static class CanvasBinding
         if (!string.Equals(element.TagName, "canvas", StringComparison.OrdinalIgnoreCase))
             return;
 
-        obj.FastAddValue((KeyString)"getContext",
+        obj.FastAddValue("getContext",
             new DomFunction((in a) => GetContext(host, obj, element, in a), "getContext", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddValue((KeyString)"toDataURL",
+        obj.FastAddValue("toDataURL",
             new DomFunction((in a) => ElementToDataUrl(host, obj, element, in a), "toDataURL", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -86,7 +86,7 @@ internal static class CanvasBinding
 
     private static void InstallDimension(JSObject obj, DomElement element, string name, int fallback)
     {
-        obj.FastAddProperty((KeyString)name,
+        obj.FastAddProperty(name,
             new DomFunction((in _) => new JSNumber(Dimension(element, name, fallback)), "get " + name),
             new DomFunction((in a) => SetDimension(element, name, in a), "set " + name),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -165,37 +165,37 @@ internal static class CanvasBinding
             Dimension(canvas, "height", DefaultHeight));
 
         // fillStyle (get/set)
-        ctx.FastAddProperty((KeyString)"fillStyle",
+        ctx.FastAddProperty("fillStyle",
             new DomFunction((in _) => new JSString(context2d.FillStyle), "get fillStyle"),
             new DomFunction((in a) => SetFillStyle(context2d, in a), "set fillStyle"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // strokeStyle (get/set)
-        ctx.FastAddProperty((KeyString)"strokeStyle",
+        ctx.FastAddProperty("strokeStyle",
             new DomFunction((in _) => new JSString(context2d.StrokeStyle), "get strokeStyle"),
             new DomFunction((in a) => SetStrokeStyle(context2d, in a), "set strokeStyle"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lineWidth (get/set)
-        ctx.FastAddProperty((KeyString)"lineWidth",
+        ctx.FastAddProperty("lineWidth",
             new DomFunction((in _) => new JSNumber(context2d.LineWidth), "get lineWidth"),
             new DomFunction((in a) => SetLineWidth(context2d, in a), "set lineWidth"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // font (get/set)
-        ctx.FastAddProperty((KeyString)"font",
+        ctx.FastAddProperty("font",
             new DomFunction((in _) => new JSString(context2d.Font), "get font"),
             new DomFunction((in a) => SetFont(context2d, in a), "set font"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // textAlign (get/set)
-        ctx.FastAddProperty((KeyString)"textAlign",
+        ctx.FastAddProperty("textAlign",
             new DomFunction((in _) => new JSString(context2d.TextAlign), "get textAlign"),
             new DomFunction((in a) => SetTextAlign(context2d, in a), "set textAlign"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // globalAlpha (get/set)
-        ctx.FastAddProperty((KeyString)"globalAlpha",
+        ctx.FastAddProperty("globalAlpha",
             new DomFunction((in _) => new JSNumber(context2d.GlobalAlpha), "get globalAlpha"),
             new DomFunction((in a) => SetGlobalAlpha(context2d, in a), "set globalAlpha"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -204,57 +204,57 @@ internal static class CanvasBinding
         // extensible object grew on assignment, so an operator the rasteriser cannot honour is rejected
         // at the setter (the spec's "ignore an invalid value") instead of round-tripping as if it had
         // been applied.
-        ctx.FastAddProperty((KeyString)"globalCompositeOperation",
+        ctx.FastAddProperty("globalCompositeOperation",
             new DomFunction((in _) => new JSString(context2d.GlobalCompositeOperation), "get globalCompositeOperation"),
             new DomFunction((in a) => SetGlobalCompositeOperation(context2d, in a), "set globalCompositeOperation"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // canvas — the element that owns this context. Was a fresh empty object, so ctx.canvas.width did
         // not answer and ctx.canvas === theCanvas was false.
-        ctx.FastAddProperty((KeyString)"canvas",
+        ctx.FastAddProperty("canvas",
             new DomFunction((in _) => canvasObject, "get canvas"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // Drawing methods
-        ctx.FastAddValue((KeyString)"fillRect", new DomFunction((in a) => FillRect(context2d, in a), "fillRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("fillRect", new DomFunction((in a) => FillRect(context2d, in a), "fillRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"strokeRect", new DomFunction((in a) => StrokeRect(context2d, in a), "strokeRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("strokeRect", new DomFunction((in a) => StrokeRect(context2d, in a), "strokeRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"clearRect", new DomFunction((in a) => ClearRect(context2d, in a), "clearRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("clearRect", new DomFunction((in a) => ClearRect(context2d, in a), "clearRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"beginPath", new DomFunction((in _) => BeginPath(context2d, in _), "beginPath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("beginPath", new DomFunction((in _) => BeginPath(context2d, in _), "beginPath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"moveTo", new DomFunction((in a) => MoveTo(context2d, in a), "moveTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("moveTo", new DomFunction((in a) => MoveTo(context2d, in a), "moveTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"lineTo", new DomFunction((in a) => LineTo(context2d, in a), "lineTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("lineTo", new DomFunction((in a) => LineTo(context2d, in a), "lineTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"arc", new DomFunction((in a) => Arc(context2d, in a), "arc", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("arc", new DomFunction((in a) => Arc(context2d, in a), "arc", 5), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"rect", new DomFunction((in a) => Rect(context2d, in a), "rect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("rect", new DomFunction((in a) => Rect(context2d, in a), "rect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"closePath", new DomFunction((in _) => ClosePath(context2d, in _), "closePath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("closePath", new DomFunction((in _) => ClosePath(context2d, in _), "closePath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"fill", new DomFunction((in _) => Fill(context2d, in _), "fill", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("fill", new DomFunction((in _) => Fill(context2d, in _), "fill", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"stroke", new DomFunction((in _) => Stroke(context2d, in _), "stroke", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("stroke", new DomFunction((in _) => Stroke(context2d, in _), "stroke", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"fillText", new DomFunction((in a) => FillText(context2d, in a), "fillText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("fillText", new DomFunction((in a) => FillText(context2d, in a), "fillText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"strokeText", new DomFunction((in a) => StrokeText(context2d, in a), "strokeText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("strokeText", new DomFunction((in a) => StrokeText(context2d, in a), "strokeText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"save", new DomFunction((in _) => Save(context2d, in _), "save", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("save", new DomFunction((in _) => Save(context2d, in _), "save", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"restore", new DomFunction((in _) => Restore(context2d, in _), "restore", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("restore", new DomFunction((in _) => Restore(context2d, in _), "restore", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // measureText(text) — returns { width: ... }
-        ctx.FastAddValue((KeyString)"measureText", new DomFunction((in a) => MeasureText(context2d, in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("measureText", new DomFunction((in a) => MeasureText(context2d, in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Pixel access
-        ctx.FastAddValue((KeyString)"getImageData", new DomFunction((in a) => GetImageData(context2d, host, in a), "getImageData", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("getImageData", new DomFunction((in a) => GetImageData(context2d, host, in a), "getImageData", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"putImageData", new DomFunction((in a) => PutImageData(context2d, in a), "putImageData", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("putImageData", new DomFunction((in a) => PutImageData(context2d, in a), "putImageData", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"createImageData", new DomFunction((in a) => CreateImageData(host, in a), "createImageData", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue("createImageData", new DomFunction((in a) => CreateImageData(host, in a), "createImageData", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // No toDataURL here: HTML puts it on HTMLCanvasElement only, and a page reaches it from a context
         // through ctx.canvas. Adding it to the context would be a name feature detection could trip on.
@@ -430,7 +430,7 @@ internal static class CanvasBinding
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var result = new JSObject();
-        result.FastAddValue((KeyString)"width", new JSNumber(context2d.MeasureTextWidth(text)), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("width", new JSNumber(context2d.MeasureTextWidth(text)), JSPropertyAttributes.EnumerableConfigurableValue);
         return result;
     }
 
@@ -523,9 +523,9 @@ internal static class CanvasBinding
     private static JSObject BuildImageData(ICanvasHost host, byte[] pixels, int width, int height)
     {
         var imageData = new JSObject();
-        imageData.FastAddValue((KeyString)"width", new JSNumber(width), JSPropertyAttributes.EnumerableConfigurableValue);
-        imageData.FastAddValue((KeyString)"height", new JSNumber(height), JSPropertyAttributes.EnumerableConfigurableValue);
-        imageData.FastAddValue((KeyString)"data", BuildPixelArray(host, pixels), JSPropertyAttributes.EnumerableConfigurableValue);
+        imageData.FastAddValue("width", new JSNumber(width), JSPropertyAttributes.EnumerableConfigurableValue);
+        imageData.FastAddValue("height", new JSNumber(height), JSPropertyAttributes.EnumerableConfigurableValue);
+        imageData.FastAddValue("data", BuildPixelArray(host, pixels), JSPropertyAttributes.EnumerableConfigurableValue);
         return imageData;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ClassListBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ClassListBinding.cs
@@ -25,23 +25,23 @@ internal static class ClassListBinding
     {
         var classList = new JSObject();
 
-        classList.FastAddValue((KeyString)"contains",
+        classList.FastAddValue("contains",
             new DomFunction((in a) => Contains(element, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        classList.FastAddValue((KeyString)"add",
+        classList.FastAddValue("add",
             new DomFunction((in a) => Add(element, onClassChanged, in a), "add"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        classList.FastAddValue((KeyString)"remove",
+        classList.FastAddValue("remove",
             new DomFunction((in a) => Remove(element, onClassChanged, in a), "remove"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        classList.FastAddValue((KeyString)"toggle",
+        classList.FastAddValue("toggle",
             new DomFunction((in a) => Toggle(element, onClassChanged, in a), "toggle", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        classList.FastAddValue((KeyString)"replace",
+        classList.FastAddValue("replace",
             new DomFunction((in a) => Replace(element, onClassChanged, in a), "replace", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ConsoleBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ConsoleBinding.cs
@@ -25,22 +25,22 @@ internal static class ConsoleBinding
         var console = new JSObject();
 
         console.FastAddValue(
-            (KeyString)"log",
+            "log",
             new DomFunction(Log, "log"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
-            (KeyString)"warn",
+            "warn",
             new DomFunction(Warn, "warn"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
-            (KeyString)"error",
+            "error",
             new DomFunction(Error, "error"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
-            (KeyString)"info",
+            "info",
             new DomFunction(Info, "info"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/CryptoBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CryptoBinding.cs
@@ -26,12 +26,12 @@ internal static class CryptoBinding
         var crypto = new JSObject();
 
         crypto.FastAddValue(
-            (KeyString)"getRandomValues",
+            "getRandomValues",
             new DomFunction(GetRandomValues, "getRandomValues", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         crypto.FastAddValue(
-            (KeyString)"randomUUID",
+            "randomUUID",
             new DomFunction(RandomUuid, "randomUUID", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/CssBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CssBinding.cs
@@ -24,12 +24,12 @@ internal static class CssBinding
         var css = new JSObject();
 
         css.FastAddValue(
-            (KeyString)"supports",
+            "supports",
             new DomFunction(Supports, "supports", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         css.FastAddValue(
-            (KeyString)"escape",
+            "escape",
             new DomFunction(Escape, "escape", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/DialogBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DialogBinding.cs
@@ -28,10 +28,10 @@ internal sealed class DialogBinding(IDialogHost host)
     /// </summary>
     internal void InstallElementMembers(JSObject target, ElementSource element)
     {
-        target.FastAddValue((KeyString)"requestFullscreen",
+        target.FastAddValue("requestFullscreen",
             new DomFunction((in a) => RequestFullscreen(element(in a, "requestFullscreen")), "requestFullscreen", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        target.FastAddValue((KeyString)"webkitRequestFullscreen",
+        target.FastAddValue("webkitRequestFullscreen",
             new DomFunction((in a) => RequestFullscreen(element(in a, "webkitRequestFullscreen")), "webkitRequestFullscreen", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -45,7 +45,7 @@ internal sealed class DialogBinding(IDialogHost host)
     {
         if (tag == "details")
         {
-            obj.FastAddProperty((KeyString)"open",
+            obj.FastAddProperty("open",
                 new DomFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
                 new DomFunction((in a) => SetOpenState(element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -53,14 +53,14 @@ internal sealed class DialogBinding(IDialogHost host)
 
         if (tag == "dialog")
         {
-            obj.FastAddValue((KeyString)"showModal", new DomFunction((in _) => ShowModal(element), "showModal", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"show", new DomFunction((in _) => Show(element), "show", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"close", new DomFunction((in a) => Close(element, in a), "close", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddProperty((KeyString)"open",
+            obj.FastAddValue("showModal", new DomFunction((in _) => ShowModal(element), "showModal", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("show", new DomFunction((in _) => Show(element), "show", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("close", new DomFunction((in a) => Close(element, in a), "close", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty("open",
                 new DomFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
                 new DomFunction((in a) => SetOpenState(element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"returnValue",
+            obj.FastAddProperty("returnValue",
                 new DomFunction((in _) => new JSString(_host.GetReturnValue(element)), "get returnValue"),
                 new DomFunction((in a) => SetReturnValue(element, in a), "set returnValue"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -70,8 +70,8 @@ internal sealed class DialogBinding(IDialogHost host)
         // carrying the global `popover` attribute, not tied to a tag.
         if (hasPopover)
         {
-            obj.FastAddValue((KeyString)"showPopover", new DomFunction((in _) => ShowPopover(element), "showPopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"hidePopover", new DomFunction((in _) => HidePopover(element), "hidePopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("showPopover", new DomFunction((in _) => ShowPopover(element), "showPopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("hidePopover", new DomFunction((in _) => HidePopover(element), "hidePopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/DomCollectionBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DomCollectionBinding.cs
@@ -279,7 +279,7 @@ internal static class DomCollectionBinding
 
         void Install(string name, int length, Func<NamedNodeMapOperations, Func<Arguments, JSValue>> pick) =>
             prototype.FastAddValue(
-                (KeyString)name,
+                name,
                 new DomFunction(
                     (in Arguments a) =>
                     {

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementContentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementContentBinding.cs
@@ -30,13 +30,13 @@ internal static class ElementContentBinding
     public static void InstallHtmlSerialization(IElementContentHost host, JSObject target, ElementSource element)
     {
         // innerHTML (read/write)
-        target.FastAddProperty((KeyString)"innerHTML",
+        target.FastAddProperty("innerHTML",
             new DomFunction((in a) => new JSString(host.SerializeChildrenToHtml(element(in a, "innerHTML"))), "get innerHTML"),
             new DomFunction((in a) => SetInnerHtml(host, element(in a, "innerHTML"), in a), "set innerHTML"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // outerHTML (read/write)
-        target.FastAddProperty((KeyString)"outerHTML",
+        target.FastAddProperty("outerHTML",
             new DomFunction((in a) => new JSString(host.SerializeElementToHtml(element(in a, "outerHTML"))), "get outerHTML"),
             new DomFunction((in a) => SetOuterHtml(host, element(in a, "outerHTML"), in a), "set outerHTML"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -50,7 +50,7 @@ internal static class ElementContentBinding
     /// </summary>
     public static void InstallTextContent(IElementContentHost host, JSObject obj, DomElement element)
     {
-        obj.FastAddProperty((KeyString)"textContent",
+        obj.FastAddProperty("textContent",
             new DomFunction((in _) => host.GetNodeTextValue(element), "get textContent"),
             new DomFunction((in a) => SetTextContent(host, element, in a), "set textContent"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -62,11 +62,11 @@ internal static class ElementContentBinding
     /// </summary>
     public static void InstallHtmlElementMembers(IElementContentHost host, JSObject target, ElementSource element)
     {
-        target.FastAddProperty((KeyString)"innerText",
+        target.FastAddProperty("innerText",
             new DomFunction((in a) => host.GetNodeTextValue(element(in a, "innerText")), "get innerText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"outerText",
+        target.FastAddProperty("outerText",
             new DomFunction((in a) => host.GetNodeTextValue(element(in a, "outerText")), "get outerText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementGeometryBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementGeometryBinding.cs
@@ -38,63 +38,63 @@ internal static class ElementGeometryBinding
         // -- TODO-G4 / TODO-G19: Box model properties for all elements --
         // clientWidth/clientHeight, scrollWidth/scrollHeight, scrollTop/scrollLeft, and
         // getBoundingClientRect()
-        target.FastAddProperty((KeyString)"clientTop",
+        target.FastAddProperty("clientTop",
             new DomFunction((in a) => new JSNumber(host.GetClientTopForDomElement(element(in a, "clientTop"))), "get clientTop"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"clientLeft",
+        target.FastAddProperty("clientLeft",
             new DomFunction((in a) => new JSNumber(host.GetClientLeftForDomElement(element(in a, "clientLeft"))), "get clientLeft"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"clientWidth",
+        target.FastAddProperty("clientWidth",
             new DomFunction((in a) => Metric(host, element(in a, "clientWidth"), host.GetClientWidthForDomElement), "get clientWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"clientHeight",
+        target.FastAddProperty("clientHeight",
             new DomFunction((in a) => Metric(host, element(in a, "clientHeight"), host.GetClientHeightForDomElement), "get clientHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"scrollWidth",
+        target.FastAddProperty("scrollWidth",
             new DomFunction((in a) => Metric(host, element(in a, "scrollWidth"), host.GetScrollWidthForDomElement), "get scrollWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"scrollHeight",
+        target.FastAddProperty("scrollHeight",
             new DomFunction((in a) => Metric(host, element(in a, "scrollHeight"), host.GetScrollHeightForDomElement), "get scrollHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"scrollTop",
+        target.FastAddProperty("scrollTop",
             new DomFunction((in a) => GetScrollTop(host, element(in a, "scrollTop")), "get scrollTop"),
             new DomFunction((in a) => SetScrollTop(host, element(in a, "scrollTop"), in a), "set scrollTop"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"scrollLeft",
+        target.FastAddProperty("scrollLeft",
             new DomFunction((in a) => GetScrollLeft(host, element(in a, "scrollLeft")), "get scrollLeft"),
             new DomFunction((in a) => SetScrollLeft(host, element(in a, "scrollLeft"), in a), "set scrollLeft"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getBoundingClientRect() — returns DOMRect-like object
-        target.FastAddValue((KeyString)"getBoundingClientRect",
+        target.FastAddValue("getBoundingClientRect",
             new DomFunction((in a) => Rect(host, element(in a, "getBoundingClientRect"), GetBoundingClientRect), "getBoundingClientRect", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getClientRects() — returns array with one DOMRect for root elements
-        target.FastAddValue((KeyString)"getClientRects",
+        target.FastAddValue("getClientRects",
             new DomFunction((in a) => Rect(host, element(in a, "getClientRects"), GetClientRects), "getClientRects", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"scrollIntoView",
+        target.FastAddValue("scrollIntoView",
             new DomFunction((in a) => ScrollIntoView(host, element(in a, "scrollIntoView"), in a), "scrollIntoView", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"scroll",
+        target.FastAddValue("scroll",
             new DomFunction((in a) => Scroll(host, element(in a, "scroll"), in a), "scroll", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"scrollTo",
+        target.FastAddValue("scrollTo",
             new DomFunction((in a) => Scroll(host, element(in a, "scrollTo"), in a), "scrollTo", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"scrollBy",
+        target.FastAddValue("scrollBy",
             new DomFunction((in a) => ScrollBy(host, element(in a, "scrollBy"), in a), "scrollBy", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -106,23 +106,23 @@ internal static class ElementGeometryBinding
     /// </summary>
     public static void InstallHtmlElementMembers(IElementGeometryHost host, JSObject target, ElementSource element)
     {
-        target.FastAddProperty((KeyString)"offsetWidth",
+        target.FastAddProperty("offsetWidth",
             new DomFunction((in a) => Metric(host, element(in a, "offsetWidth"), host.GetOffsetWidthForDomElement), "get offsetWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"offsetHeight",
+        target.FastAddProperty("offsetHeight",
             new DomFunction((in a) => Metric(host, element(in a, "offsetHeight"), host.GetOffsetHeightForDomElement), "get offsetHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"offsetTop",
+        target.FastAddProperty("offsetTop",
             new DomFunction((in a) => new JSNumber(host.GetOffsetTopForDomElement(element(in a, "offsetTop"))), "get offsetTop"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"offsetLeft",
+        target.FastAddProperty("offsetLeft",
             new DomFunction((in a) => new JSNumber(host.GetOffsetLeftForDomElement(element(in a, "offsetLeft"))), "get offsetLeft"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        target.FastAddProperty((KeyString)"offsetParent",
+        target.FastAddProperty("offsetParent",
             new DomFunction((in a) => GetOffsetParent(host, element(in a, "offsetParent")), "get offsetParent"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }
@@ -133,7 +133,7 @@ internal static class ElementGeometryBinding
     /// </summary>
     public static void InstallBridgeMembers(IElementGeometryHost host, JSObject obj, DomElement element)
     {
-        obj.FastAddValue((KeyString)"scrollParent",
+        obj.FastAddValue("scrollParent",
             new DomFunction((in _) => GetScrollParent(host, element), "scrollParent", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -199,14 +199,14 @@ internal static class ElementGeometryBinding
     private static JSObject BuildRect(double left, double top, double width, double height)
     {
         var rect = new JSObject();
-        rect.FastAddValue((KeyString)"x", new JSNumber(left), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"y", new JSNumber(top), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"top", new JSNumber(top), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"left", new JSNumber(left), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"right", new JSNumber(left + width), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"bottom", new JSNumber(top + height), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"width", new JSNumber(width), JSPropertyAttributes.EnumerableConfigurableValue);
-        rect.FastAddValue((KeyString)"height", new JSNumber(height), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("x", new JSNumber(left), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("y", new JSNumber(top), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("top", new JSNumber(top), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("left", new JSNumber(left), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("right", new JSNumber(left + width), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("bottom", new JSNumber(top + height), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("width", new JSNumber(width), JSPropertyAttributes.EnumerableConfigurableValue);
+        rect.FastAddValue("height", new JSNumber(height), JSPropertyAttributes.EnumerableConfigurableValue);
         return rect;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementInternalsBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementInternalsBinding.cs
@@ -199,14 +199,14 @@ internal sealed class ElementInternalsBinding(IElementInternalsHost host)
         {
             var name = flag;
             validityPrototype.FastAddProperty(
-                (KeyString)name,
+                name,
                 new DomFunction((in a) => Bool(StateForValidity(in a, name).Flags.Contains(name)), $"get {name}"),
                 null,
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         validityPrototype.FastAddProperty(
-            (KeyString)"valid",
+            "valid",
             new DomFunction((in a) => Bool(StateForValidity(in a, "valid").Flags.Count == 0), "get valid"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -391,13 +391,13 @@ internal sealed class ElementInternalsBinding(IElementInternalsHost host)
 
     private void Method(JSObject prototype, string name, int length, InternalsOperation body) =>
         prototype.FastAddValue(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => body(StateFor(in a, name, execute: true), in a), name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
     private void Getter(JSObject prototype, string name, Func<InternalsState, JSValue> read, bool formOnly = true) =>
         prototype.FastAddProperty(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => read(StateFor(in a, name, execute: false, formOnly: formOnly)), $"get {name}"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/EventDispatchBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/EventDispatchBinding.cs
@@ -63,30 +63,30 @@ internal sealed class EventDispatchBinding(IEventDispatchHost host)
         evt[(KeyString)"srcElement"] = evt[(KeyString)"target"];
         evt[(KeyString)"eventPhase"] = new JSNumber(0);
 
-        evt.FastAddValue((KeyString)"stopPropagation",
+        evt.FastAddValue("stopPropagation",
             new DomFunction((in _) => EventStopPropagation(ref legacyCancelBubble, ref stopped, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation",
+        evt.FastAddValue("stopImmediatePropagation",
             new DomFunction((in _) => EventStopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, ref stopped, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        evt.FastAddValue((KeyString)"preventDefault",
+        evt.FastAddValue("preventDefault",
             new DomFunction((in _) => EventPreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddProperty(
-            (KeyString)"cancelBubble",
+            "cancelBubble",
             new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
             new DomFunction((in setArgs) => EventSetCancelBubble(ref legacyCancelBubble, ref stopped, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        evt.FastAddProperty((KeyString)"returnValue",
+        evt.FastAddProperty("returnValue",
             new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
             new DomFunction((in setArgs) => EventSetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        evt.FastAddValue((KeyString)"composedPath",
+        evt.FastAddValue("composedPath",
             new DomFunction((in _) => BuildComposedPathValue(target, path), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/EventTargetBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/EventTargetBinding.cs
@@ -86,17 +86,17 @@ internal static class EventTargetBinding
         }
 
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("click"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"stopImmediatePropagation", DomBridge.UndefinedFunction("stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"preventDefault", DomBridge.UndefinedFunction("preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("click"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopImmediatePropagation", DomBridge.UndefinedFunction("stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("preventDefault", DomBridge.UndefinedFunction("preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         host.DispatchEventOnElement(element, evt);
         // Per HTML spec: clicking a submit button triggers form submission
         if (string.Equals(element.TagName, "input", StringComparison.OrdinalIgnoreCase) || string.Equals(element.TagName, "button", StringComparison.OrdinalIgnoreCase))
@@ -116,22 +116,22 @@ internal static class EventTargetBinding
                 {
                     // Dispatch a submit event on the form
                     var submitEvt = new JSObject();
-                    submitEvt.FastAddValue((KeyString)"type", new JSString("submit"), JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("type", new JSString("submit"), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
                     JSValue JsJsObjectsPreventDefault100(in Arguments __)
                     {
                         submitEvt[(KeyString)"defaultPrevented"] = JSBoolean.True;
                         return JSUndefined.Value;
                     }
 
-                    submitEvt.FastAddValue((KeyString)"preventDefault", new DomFunction(JsJsObjectsPreventDefault100, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-                    submitEvt.FastAddValue((KeyString)"stopImmediatePropagation", DomBridge.UndefinedFunction("stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("preventDefault", new DomFunction(JsJsObjectsPreventDefault100, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue("stopImmediatePropagation", DomBridge.UndefinedFunction("stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
                     host.DispatchEventOnElement(form, submitEvt);
                 }
             }
@@ -149,19 +149,19 @@ internal static class EventTargetBinding
     private static JSValue DispatchSyntheticFocusEvent(IEventTargetHost host, DomElement element, string type)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString(type), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"view", host.WindowJSObject ?? JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString(type), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("view", host.WindowJSObject ?? JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
         host.DispatchEventOnElement(element, evt);
         return JSUndefined.Value;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.cs
@@ -139,28 +139,28 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 return values.TryGetValue(name, out var currentValue) ? new JSString(currentValue) : JSNull.Value;
             }
 
-            headersObject.FastAddValue((KeyString)"get", new JSFunction(JsRegistrationGet078, "get", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("get", new JSFunction(JsRegistrationGet078, "get", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationHas079(in Arguments a)
             {
                 if (a.Length == 0)
                     return JSBoolean.False;
                 return values.ContainsKey(a[0].ToString()) ? JSBoolean.True : JSBoolean.False;
             }
-            headersObject.FastAddValue((KeyString)"has", new JSFunction(JsRegistrationHas079, "has", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("has", new JSFunction(JsRegistrationHas079, "has", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationSet080(in Arguments a)
             {
                 if (a.Length >= 2)
                     SetHeader(a[0].ToString(), a[1].ToString());
                 return JSUndefined.Value;
             }
-            headersObject.FastAddValue((KeyString)"set", new JSFunction(JsRegistrationSet080, "set", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("set", new JSFunction(JsRegistrationSet080, "set", 2), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationAppend081(in Arguments a)
             {
                 if (a.Length >= 2)
                     AppendHeader(a[0].ToString(), a[1].ToString());
                 return JSUndefined.Value;
             }
-            headersObject.FastAddValue((KeyString)"append", new JSFunction(JsRegistrationAppend081, "append", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("append", new JSFunction(JsRegistrationAppend081, "append", 2), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationDelete082(in Arguments a)
             {
                 if (a.Length > 0)
@@ -174,7 +174,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return JSUndefined.Value;
             }
-            headersObject.FastAddValue((KeyString)"delete", new JSFunction(JsRegistrationDelete082, "delete", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("delete", new JSFunction(JsRegistrationDelete082, "delete", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationForEach083(in Arguments a)
             {
                 if (a.Length > 0 && a[0] is JSFunction cb)
@@ -188,7 +188,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return JSUndefined.Value;
             }
-            headersObject.FastAddValue((KeyString)"forEach", new JSFunction(JsRegistrationForEach083, "forEach", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            headersObject.FastAddValue("forEach", new JSFunction(JsRegistrationForEach083, "forEach", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
             return headersObject;
         }
@@ -308,7 +308,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 return JSUndefined.Value;
             }
 
-            formDataObject.FastAddValue((KeyString)"append", new JSFunction(JsRegistrationAppend084, "append", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("append", new JSFunction(JsRegistrationAppend084, "append", 2), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationDelete085(in Arguments a)
             {
                 if (a.Length > 0)
@@ -319,7 +319,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return JSUndefined.Value;
             }
-            formDataObject.FastAddValue((KeyString)"delete", new JSFunction(JsRegistrationDelete085, "delete", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("delete", new JSFunction(JsRegistrationDelete085, "delete", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationForEach086(in Arguments a)
             {
                 if (a.Length > 0 && a[0] is JSFunction cb)
@@ -330,7 +330,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return JSUndefined.Value;
             }
-            formDataObject.FastAddValue((KeyString)"forEach", new JSFunction(JsRegistrationForEach086, "forEach", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("forEach", new JSFunction(JsRegistrationForEach086, "forEach", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationGet087(in Arguments a)
             {
                 if (a.Length == 0)
@@ -344,7 +344,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return JSNull.Value;
             }
-            formDataObject.FastAddValue((KeyString)"get", new JSFunction(JsRegistrationGet087, "get", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("get", new JSFunction(JsRegistrationGet087, "get", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationGetAll088(in Arguments a)
             {
                 var result = new JSArray();
@@ -359,7 +359,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
 
                 return result;
             }
-            formDataObject.FastAddValue((KeyString)"getAll", new JSFunction(JsRegistrationGetAll088, "getAll", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("getAll", new JSFunction(JsRegistrationGetAll088, "getAll", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationHas089(in Arguments a)
             {
                 if (a.Length == 0)
@@ -367,15 +367,15 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 var name = a[0].ToString();
                 return entries.Any(entry => string.Equals(entry.Key, name, StringComparison.Ordinal)) ? JSBoolean.True : JSBoolean.False;
             }
-            formDataObject.FastAddValue((KeyString)"has", new JSFunction(JsRegistrationHas089, "has", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("has", new JSFunction(JsRegistrationHas089, "has", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationSet090(in Arguments a)
             {
                 if (a.Length >= 2)
                     SetEntry(a[0].ToString(), a[1].ToString());
                 return JSUndefined.Value;
             }
-            formDataObject.FastAddValue((KeyString)"set", new JSFunction(JsRegistrationSet090, "set", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-            formDataObject.FastAddValue((KeyString)"toString", new JSFunction((in _) => new JSString(string.Join("&", entries.Select(static entry => $"{EncodeFormComponent(entry.Key)}={EncodeFormComponent(entry.Value)}"))),
+            formDataObject.FastAddValue("set", new JSFunction(JsRegistrationSet090, "set", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+            formDataObject.FastAddValue("toString", new JSFunction((in _) => new JSString(string.Join("&", entries.Select(static entry => $"{EncodeFormComponent(entry.Key)}={EncodeFormComponent(entry.Value)}"))),
                 "toString", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
             return formDataObject;
@@ -481,7 +481,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                     throw new JSException("Failed to execute 'clone' on 'Request': body is already used.");
                 return CreateRequestObject(requestObject);
             }
-            requestObject.FastAddValue((KeyString)"clone", new JSFunction(JsRegistrationClone098, "clone", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("clone", new JSFunction(JsRegistrationClone098, "clone", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationText099(in Arguments _)
             {
                 if (IsBodyUnavailable(requestObject))
@@ -489,7 +489,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 requestObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => body == null ? new JSString(string.Empty) : new JSString(body));
             }
-            requestObject.FastAddValue((KeyString)"text", new JSFunction(JsRegistrationText099, "text", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("text", new JSFunction(JsRegistrationText099, "text", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationJson100(in Arguments _)
             {
                 if (IsBodyUnavailable(requestObject))
@@ -497,7 +497,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 requestObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => ParseJsonText(body ?? string.Empty));
             }
-            requestObject.FastAddValue((KeyString)"json", new JSFunction(JsRegistrationJson100, "json", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("json", new JSFunction(JsRegistrationJson100, "json", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationArrayBuffer101(in Arguments _)
             {
                 if (IsBodyUnavailable(requestObject))
@@ -505,7 +505,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 requestObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => new JSArrayBuffer(Encoding.UTF8.GetBytes(body ?? string.Empty)));
             }
-            requestObject.FastAddValue((KeyString)"arrayBuffer", new JSFunction(JsRegistrationArrayBuffer101, "arrayBuffer", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("arrayBuffer", new JSFunction(JsRegistrationArrayBuffer101, "arrayBuffer", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationBlob102(in Arguments _)
             {
                 if (IsBodyUnavailable(requestObject))
@@ -513,7 +513,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 requestObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => CreateBlobBody(body ?? string.Empty, headersObject));
             }
-            requestObject.FastAddValue((KeyString)"blob", new JSFunction(JsRegistrationBlob102, "blob", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("blob", new JSFunction(JsRegistrationBlob102, "blob", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationFormData103(in Arguments _)
             {
                 if (IsBodyUnavailable(requestObject))
@@ -521,7 +521,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 requestObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => CreateFormDataObject(new JSString(body ?? string.Empty)));
             }
-            requestObject.FastAddValue((KeyString)"formData", new JSFunction(JsRegistrationFormData103, "formData", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            requestObject.FastAddValue("formData", new JSFunction(JsRegistrationFormData103, "formData", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
             return requestObject;
         }
@@ -550,7 +550,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 responseObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => new JSString(body));
             }
-            responseObject.FastAddValue((KeyString)"text", new JSFunction(JsRegistrationText104, "text", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("text", new JSFunction(JsRegistrationText104, "text", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationJson105(in Arguments _)
             {
                 if (IsBodyUnavailable(responseObject))
@@ -558,7 +558,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 responseObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => ParseResponseJsonText(body));
             }
-            responseObject.FastAddValue((KeyString)"json", new JSFunction(JsRegistrationJson105, "json", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("json", new JSFunction(JsRegistrationJson105, "json", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationArrayBuffer106(in Arguments _)
             {
                 if (IsBodyUnavailable(responseObject))
@@ -566,7 +566,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 responseObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => new JSArrayBuffer(Encoding.UTF8.GetBytes(body)));
             }
-            responseObject.FastAddValue((KeyString)"arrayBuffer", new JSFunction(JsRegistrationArrayBuffer106, "arrayBuffer", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("arrayBuffer", new JSFunction(JsRegistrationArrayBuffer106, "arrayBuffer", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationBlob107(in Arguments _)
             {
                 if (IsBodyUnavailable(responseObject))
@@ -574,7 +574,7 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 responseObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => CreateBlobBody(body, headersObject));
             }
-            responseObject.FastAddValue((KeyString)"blob", new JSFunction(JsRegistrationBlob107, "blob", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("blob", new JSFunction(JsRegistrationBlob107, "blob", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationFormData108(in Arguments _)
             {
                 if (IsBodyUnavailable(responseObject))
@@ -582,14 +582,14 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
                 responseObject[(KeyString)"bodyUsed"] = JSBoolean.True;
                 return CreateThenable(() => CreateFormDataObject(new JSString(body)));
             }
-            responseObject.FastAddValue((KeyString)"formData", new JSFunction(JsRegistrationFormData108, "formData", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("formData", new JSFunction(JsRegistrationFormData108, "formData", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue JsRegistrationClone109(in Arguments _)
             {
                 if (IsBodyUnavailable(responseObject))
                     throw new JSException("Failed to execute 'clone' on 'Response': body is already used.");
                 return CreateResponse(body, statusCode, statusText, responseUrl, type, redirected, new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase));
             }
-            responseObject.FastAddValue((KeyString)"clone", new JSFunction(JsRegistrationClone109, "clone", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            responseObject.FastAddValue("clone", new JSFunction(JsRegistrationClone109, "clone", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
             return responseObject;
         }
@@ -649,21 +649,21 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
         var headersCtor = new JSFunction((in a) => CreateHeadersObject(a.Length > 0 ? a[0] : null), "Headers", 1);
         var requestCtor = new JSFunction((in a) => CreateRequestObject(a.Length > 0 ? a[0] : JSUndefined.Value, a.Length > 1 ? a[1] : null), "Request", 2);
         var responseCtor = new JSFunction((in a) => JsRegistrationResponse113Core(ParseResponseInit, CreateResponse, in a), "Response", 2);
-        responseCtor.FastAddValue((KeyString)"json", new JSFunction((in a) => JsRegistrationJson114Core(ParseResponseInit, CreateResponse, in a), "json", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        responseCtor.FastAddValue((KeyString)"error", new JSFunction((in _) => CreateResponse(string.Empty, 0, string.Empty, string.Empty, "error", false, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)),
+        responseCtor.FastAddValue("json", new JSFunction((in a) => JsRegistrationJson114Core(ParseResponseInit, CreateResponse, in a), "json", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        responseCtor.FastAddValue("error", new JSFunction((in _) => CreateResponse(string.Empty, 0, string.Empty, string.Empty, "error", false, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)),
             "error", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-        responseCtor.FastAddValue((KeyString)"redirect", new JSFunction((in a) => JsRegistrationRedirect116Core(ResolveResponseRedirectUrl, CreateResponse, in a), "redirect", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"FormData", formDataCtor, JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"Headers", headersCtor, JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"Request", requestCtor, JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"Response", responseCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        responseCtor.FastAddValue("redirect", new JSFunction((in a) => JsRegistrationRedirect116Core(ResolveResponseRedirectUrl, CreateResponse, in a), "redirect", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("FormData", formDataCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Headers", headersCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Request", requestCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Response", responseCtor, JSPropertyAttributes.EnumerableConfigurableValue);
         context["FormData"] = formDataCtor;
         context["Headers"] = headersCtor;
         context["Request"] = requestCtor;
         context["Response"] = responseCtor;
         // fetch(url, options) — polyfill backed by the injected ResourceLoader
         var fetchFn = new JSFunction((in a) => JsRegistrationFetch120Core(TryGetJsPropertyString, EnumerateObjectStringEntries, CreateAbortErrorValue, CreateResponse, in a), "fetch", 1);
-        window.FastAddValue((KeyString)"fetch", fetchFn, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("fetch", fetchFn, JSPropertyAttributes.EnumerableConfigurableValue);
         // XMLHttpRequest — basic polyfill backed by fetch/the ResourceLoader
         RegisterXMLHttpRequest(context);
         return fetchFn;

--- a/src/Broiler.HtmlBridge.Dom/Features/FormAssociationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormAssociationBinding.cs
@@ -59,21 +59,21 @@ internal static class FormAssociationBinding
     {
         if (FormAssociatedTags.Contains(tag))
         {
-            obj.FastAddProperty((KeyString)"form",
+            obj.FastAddProperty("form",
                 new DomFunction((in _) => FormOwnerValue(host, element), "get form"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         if (LabelableTags.Contains(tag))
         {
-            obj.FastAddProperty((KeyString)"labels",
+            obj.FastAddProperty("labels",
                 new DomFunction((in _) => LabelsValue(host, element), "get labels"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         if (string.Equals(tag, "label", StringComparison.OrdinalIgnoreCase))
         {
-            obj.FastAddProperty((KeyString)"control",
+            obj.FastAddProperty("control",
                 new DomFunction((in _) => LabeledControl(host, element) is { } control
                     ? host.ToJSObject(control)
                     : JSNull.Value, "get control"),

--- a/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
@@ -31,22 +31,22 @@ internal sealed class FormBinding(IFormHost host)
             return;
 
         // elements — the form controls collection (numeric + named access)
-        obj.FastAddProperty((KeyString)"elements",
+        obj.FastAddProperty("elements",
             new DomFunction((in _) => BuildElementsCollection(element), "get elements"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         // length — alias for elements.length
-        obj.FastAddProperty((KeyString)"length",
+        obj.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(_host.CollectFormControls(element).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         // action (read/write)
-        obj.FastAddProperty((KeyString)"action",
+        obj.FastAddProperty("action",
             new DomFunction((in _) => DomBridge.TryGetAttribute(element, "action", out var act) ? new JSString(act) : new JSString(string.Empty), "get action"),
             new DomFunction((in a) => SetAction(element, in a), "set action"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         // reset() — HTML §4.10.21.4. It did not exist, so `form.reset()` was a TypeError on
         // undefined: the call that a "clear this form" control is written as aborted the handler
         // rather than clearing anything, and every edited control kept its edited state.
-        obj.FastAddValue((KeyString)"reset",
+        obj.FastAddValue("reset",
             new DomFunction((in _) => { _host.ResetForm(element); return JSUndefined.Value; }, "reset", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -62,7 +62,7 @@ internal sealed class FormBinding(IFormHost host)
             collection.FastAddValue((uint)i, _host.ToJSObject(controls[i]),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-        collection.FastAddProperty((KeyString)"length",
+        collection.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(_host.CollectFormControls(form).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/FormControlBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormControlBinding.cs
@@ -29,7 +29,7 @@ internal sealed class FormControlBinding(IFormControlHost host)
     {
         // value (read/write) — for input, textarea, select elements.
         // The IDL 'value' property is NOT reflected as a content attribute for inputs.
-        obj.FastAddProperty((KeyString)"value",
+        obj.FastAddProperty("value",
             new DomFunction((in _) => GetValue(element), "get value"),
             new DomFunction((in a) => SetValue(element, in a), "set value"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -37,7 +37,7 @@ internal sealed class FormControlBinding(IFormControlHost host)
         // checked (read/write) — for checkbox and radio inputs. Uses the typed checked-state slot as the
         // "dirty" IDL state that tracks programmatic changes; setAttribute("checked") only sets the
         // content attribute and does NOT affect this IDL state.
-        obj.FastAddProperty((KeyString)"checked",
+        obj.FastAddProperty("checked",
             new DomFunction((in _) => GetChecked(element), "get checked"),
             new DomFunction((in a) => SetChecked(element, in a), "set checked"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -47,38 +47,38 @@ internal sealed class FormControlBinding(IFormControlHost host)
         // comparing the current value against the original to decide whether a field is unsaved
         // compared against `undefined` and concluded "changed" for every field, including the ones
         // it had just reset.
-        obj.FastAddProperty((KeyString)"defaultValue",
+        obj.FastAddProperty("defaultValue",
             new DomFunction((in _) => GetDefaultValue(element), "get defaultValue"),
             new DomFunction((in a) => SetDefaultValue(element, in a), "set defaultValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // defaultChecked (read/write) — reflects the `checked` content attribute, which is exactly
         // the state `checked` falls back to when no dirty checkedness has been set.
-        obj.FastAddProperty((KeyString)"defaultChecked",
+        obj.FastAddProperty("defaultChecked",
             new DomFunction((in _) => DomBridge.HasAttr(element, "checked") ? JSBoolean.True : JSBoolean.False, "get defaultChecked"),
             new DomFunction((in a) => SetDefaultChecked(element, in a), "set defaultChecked"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // type (read/write) — for input/button elements; getter returns lowercase.
-        obj.FastAddProperty((KeyString)"type",
+        obj.FastAddProperty("type",
             new DomFunction((in _) => GetType(element), "get type"),
             new DomFunction((in a) => SetType(element, in a), "set type"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // name (read/write) — for form elements; syncs with content attribute.
-        obj.FastAddProperty((KeyString)"name",
+        obj.FastAddProperty("name",
             new DomFunction((in _) => GetName(element), "get name"),
             new DomFunction((in a) => SetName(element, in a), "set name"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // disabled (read/write) — for form controls.
-        obj.FastAddProperty((KeyString)"disabled",
+        obj.FastAddProperty("disabled",
             new DomFunction((in _) => DomBridge.HasAttr(element, "disabled") ? JSBoolean.True : JSBoolean.False, "get disabled"),
             new DomFunction((in a) => SetDisabled(element, in a), "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // required (read/write) — form validation.
-        obj.FastAddProperty((KeyString)"required",
+        obj.FastAddProperty("required",
             new DomFunction((in _) => DomBridge.HasAttr(element, "required") ? JSBoolean.True : JSBoolean.False, "get required"),
             new DomFunction((in a) => SetRequired(element, in a), "set required"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -88,7 +88,7 @@ internal sealed class FormControlBinding(IFormControlHost host)
         // `if (input.files && input.files.length)` was a TypeError on the input it was written for.
         // The list is empty because this engine has no file selection, which is also what a browser
         // reports for an input nobody has touched.
-        obj.FastAddProperty((KeyString)"files",
+        obj.FastAddProperty("files",
             new DomFunction((in _) => GetFiles(element), "get files"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -103,13 +103,13 @@ internal sealed class FormControlBinding(IFormControlHost host)
     internal void InstallHtmlElementMembers(JSObject target, ElementSource element)
     {
         // hidden (read/write) — global reflected boolean attribute.
-        target.FastAddProperty((KeyString)"hidden",
+        target.FastAddProperty("hidden",
             new DomFunction((in a) => DomBridge.HasAttr(element(in a, "hidden"), "hidden") ? JSBoolean.True : JSBoolean.False, "get hidden"),
             new DomFunction((in a) => SetHidden(element(in a, "hidden"), in a), "set hidden"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // tabIndex (read/write) — global reflected numeric attribute.
-        target.FastAddProperty((KeyString)"tabIndex",
+        target.FastAddProperty("tabIndex",
             new DomFunction((in a) => GetTabIndex(element(in a, "tabIndex")), "get tabIndex"),
             new DomFunction((in a) => SetTabIndex(element(in a, "tabIndex"), in a), "set tabIndex"),
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/FormSubmitBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormSubmitBinding.cs
@@ -27,12 +27,12 @@ internal static class FormSubmitBinding
         {
             // Fire submit event
             var submitEvt = new JSObject();
-            submitEvt.FastAddValue((KeyString)"type", new JSString("submit"), JSPropertyAttributes.EnumerableConfigurableValue);
-            submitEvt.FastAddValue((KeyString)"target", obj, JSPropertyAttributes.EnumerableConfigurableValue);
-            submitEvt.FastAddValue((KeyString)"bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-            submitEvt.FastAddValue((KeyString)"cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("type", new JSString("submit"), JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("target", obj, JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("bubbles", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("cancelable", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
             var prevented = false;
-            submitEvt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             JSValue PreventDefault(in Arguments _)
             {
                 prevented = true;
@@ -40,8 +40,8 @@ internal static class FormSubmitBinding
                 return JSUndefined.Value;
             }
 
-            submitEvt.FastAddValue((KeyString)"preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            submitEvt.FastAddValue((KeyString)"stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue("stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             if (host.GetEventListeners(element).TryGetValue("submit", out var submitListeners))
             {
                 foreach (var registration in submitListeners.ToList())

--- a/src/Broiler.HtmlBridge.Dom/Features/GlobalAttributeBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/GlobalAttributeBinding.cs
@@ -30,13 +30,13 @@ internal static class GlobalAttributeBinding
     /// </summary>
     public static void InstallElementMembers(IGlobalAttributeHost host, JSObject target, ElementSource element)
     {
-        target.FastAddProperty((KeyString)"id",
+        target.FastAddProperty("id",
             new DomFunction((in a) => element(in a, "id") is { Id: { } id } ? new JSString(id) : JSNull.Value, "get id"),
             new DomFunction((in a) => SetId(host, element(in a, "id"), in a), "set id"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // className (read/write) — reflects the 'class' content attribute
-        target.FastAddProperty((KeyString)"className",
+        target.FastAddProperty("className",
             new DomFunction((in a) => GetClassName(element(in a, "className")), "get className"),
             new DomFunction((in a) => SetClassName(host, element(in a, "className"), in a), "set className"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -50,31 +50,31 @@ internal static class GlobalAttributeBinding
     public static void InstallHtmlElementMembers(IGlobalAttributeHost host, JSObject target, ElementSource element)
     {
         // title (read/write) — synced with attributes["title"]
-        target.FastAddProperty((KeyString)"title",
+        target.FastAddProperty("title",
             new DomFunction((in a) => ReflectedGet(element(in a, "title"), "title"), "get title"),
             new DomFunction((in a) => ReflectedSet(element(in a, "title"), "title", in a), "set title"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lang (read/write) — synced with attributes["lang"]
-        target.FastAddProperty((KeyString)"lang",
+        target.FastAddProperty("lang",
             new DomFunction((in a) => ReflectedGet(element(in a, "lang"), "lang"), "get lang"),
             new DomFunction((in a) => ReflectedSet(element(in a, "lang"), "lang", in a), "set lang"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // accessKey (read/write) — synced with attributes["accesskey"]
-        target.FastAddProperty((KeyString)"accessKey",
+        target.FastAddProperty("accessKey",
             new DomFunction((in a) => ReflectedGet(element(in a, "accessKey"), "accesskey"), "get accessKey"),
             new DomFunction((in a) => ReflectedSet(element(in a, "accessKey"), "accesskey", in a), "set accessKey"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // dir (read/write) — synced with attributes["dir"]
-        target.FastAddProperty((KeyString)"dir",
+        target.FastAddProperty("dir",
             new DomFunction((in a) => ReflectedGet(element(in a, "dir"), "dir"), "get dir"),
             new DomFunction((in a) => SetDir(host, element(in a, "dir"), in a), "set dir"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // draggable (read/write) — reflected enumerated attribute
-        target.FastAddProperty((KeyString)"draggable",
+        target.FastAddProperty("draggable",
             new DomFunction((in a) => GetDraggable(element(in a, "draggable")), "get draggable"),
             new DomFunction((in a) => SetDraggable(element(in a, "draggable"), in a), "set draggable"),
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/IframeElementBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/IframeElementBinding.cs
@@ -30,32 +30,32 @@ internal static class IframeElementBinding
         if (!string.Equals(element.TagName, "iframe", StringComparison.OrdinalIgnoreCase))
             return;
 
-        obj.FastAddProperty((KeyString)"contentDocument",
+        obj.FastAddProperty("contentDocument",
             new DomFunction((in _) => GetContentDocument(host, element), "get contentDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"contentWindow",
+        obj.FastAddProperty("contentWindow",
             new DomFunction((in _) => GetContentWindow(host, element), "get contentWindow"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getSVGDocument() — returns contentDocument (same as contentDocument for same-origin)
-        obj.FastAddValue((KeyString)"getSVGDocument",
+        obj.FastAddValue("getSVGDocument",
             new DomFunction((in _) => GetContentDocument(host, element), "getSVGDocument", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // src property (read/write) — for iframe elements
-        obj.FastAddProperty((KeyString)"src",
+        obj.FastAddProperty("src",
             new DomFunction((in _) => DomBridge.TryGetAttribute(element, "src", out var s) ? new JSString(s) : new JSString(string.Empty), "get src"),
             new DomFunction((in a) => SetFrameAttribute(host, element, "src", in a), "set src"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddProperty((KeyString)"srcdoc",
+        obj.FastAddProperty("srcdoc",
             new DomFunction((in _) => DomBridge.TryGetAttribute(element, "srcdoc", out var s) ? new JSString(s) : new JSString(string.Empty), "get srcdoc"),
             new DomFunction((in a) => SetFrameAttribute(host, element, "srcdoc", in a), "set srcdoc"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // sandbox attribute access
-        obj.FastAddProperty((KeyString)"sandbox",
+        obj.FastAddProperty("sandbox",
             new DomFunction((in _) => DomBridge.TryGetAttribute(element, "sandbox", out var sandbox) ? new JSString(sandbox) : new JSString(string.Empty), "get sandbox"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/InsertAdjacentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/InsertAdjacentBinding.cs
@@ -26,15 +26,15 @@ internal static class InsertAdjacentBinding
     /// </summary>
     public static void Install(IInsertAdjacentHost host, JSObject target, ElementSource element)
     {
-        target.FastAddValue((KeyString)"insertAdjacentElement",
+        target.FastAddValue("insertAdjacentElement",
             new DomFunction((in a) => InsertAdjacentElement(host, element(in a, "insertAdjacentElement"), in a), "insertAdjacentElement", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"insertAdjacentText",
+        target.FastAddValue("insertAdjacentText",
             new DomFunction((in a) => InsertAdjacentText(host, element(in a, "insertAdjacentText"), in a), "insertAdjacentText", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"insertAdjacentHTML",
+        target.FastAddValue("insertAdjacentHTML",
             new DomFunction((in a) => InsertAdjacentHtml(host, element(in a, "insertAdjacentHTML"), in a), "insertAdjacentHTML", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/JSWorker.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/JSWorker.cs
@@ -188,8 +188,8 @@ internal sealed class JSWorker
             var data = JSGlobalStatic.StructuredClone(new Arguments(JSUndefined.Value, detached));
 
             var evt = new JSObject();
-            evt.FastAddValue((KeyString)"type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
-            evt.FastAddValue((KeyString)"data", data, JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue("data", data, JSPropertyAttributes.EnumerableConfigurableValue);
 
             if (context["onmessage"] is JSFunction handler)
                 handler.InvokeFunction(new Arguments(JSUndefined.Value, evt));
@@ -333,7 +333,7 @@ internal sealed class JSWorker
         {
             var captured = level;
             console.FastAddValue(
-                (KeyString)captured,
+                captured,
                 new JSFunction((in a) =>
                 {
                     var text = a.Length > 0 ? a[0]?.ToString() ?? string.Empty : string.Empty;

--- a/src/Broiler.HtmlBridge.Dom/Features/LegacyEventBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/LegacyEventBinding.cs
@@ -24,41 +24,41 @@ internal static class LegacyEventBinding
         var evt = new JSObject();
         var legacyCancelBubble = false;
 
-        evt.FastAddValue((KeyString)"type", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"view", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"screenX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"screenY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"clientX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"clientY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"x", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"y", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"ctrlKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"altKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"shiftKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"metaKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"key", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"location", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"repeat", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"keyCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"charCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"which", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"button", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"buttons", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaZ", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaMode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("view", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("screenX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("screenY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("clientX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("clientY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("x", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("y", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("ctrlKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("altKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("shiftKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("metaKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("key", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("location", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("repeat", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("keyCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("charCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("which", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("button", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("buttons", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaZ", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaMode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
 
         JSValue JsRegistrationStopPropagation018(in Arguments _)
         {
@@ -66,14 +66,14 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopPropagation", new DomFunction(JsRegistrationStopPropagation018, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopPropagation", new DomFunction(JsRegistrationStopPropagation018, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationStopImmediatePropagation019(in Arguments _)
         {
             legacyCancelBubble = true;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation", new DomFunction(JsRegistrationStopImmediatePropagation019, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopImmediatePropagation", new DomFunction(JsRegistrationStopImmediatePropagation019, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationPreventDefault020(in Arguments _)
         {
             var cancelable = evt[(KeyString)"cancelable"];
@@ -82,7 +82,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"preventDefault", new DomFunction(JsRegistrationPreventDefault020, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("preventDefault", new DomFunction(JsRegistrationPreventDefault020, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationGetCancelBubble021(in Arguments _)
         {
             return legacyCancelBubble ? JSBoolean.True : JSBoolean.False;
@@ -95,7 +95,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"cancelBubble", new DomFunction(JsRegistrationGetCancelBubble021, "get cancelBubble"), new DomFunction(JsRegistrationSetCancelBubble022, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty("cancelBubble", new DomFunction(JsRegistrationGetCancelBubble021, "get cancelBubble"), new DomFunction(JsRegistrationSetCancelBubble022, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue JsRegistrationGetReturnValue023(in Arguments _)
         {
             return evt[(KeyString)"defaultPrevented"].BooleanValue ? JSBoolean.False : JSBoolean.True;
@@ -109,7 +109,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"returnValue", new DomFunction(JsRegistrationGetReturnValue023, "get returnValue"), new DomFunction(JsRegistrationSetReturnValue024, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty("returnValue", new DomFunction(JsRegistrationGetReturnValue023, "get returnValue"), new DomFunction(JsRegistrationSetReturnValue024, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue JsRegistrationInitEvent025(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -121,7 +121,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initEvent", new DomFunction(JsRegistrationInitEvent025, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initEvent", new DomFunction(JsRegistrationInitEvent025, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitUIEvent026(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -137,7 +137,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initUIEvent", new DomFunction(JsRegistrationInitUIEvent026, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initUIEvent", new DomFunction(JsRegistrationInitUIEvent026, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitInputEvent027(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -157,7 +157,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initInputEvent", new DomFunction(JsRegistrationInitInputEvent027, "initInputEvent", 7), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initInputEvent", new DomFunction(JsRegistrationInitInputEvent027, "initInputEvent", 7), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitCustomEvent028(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -170,7 +170,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initCustomEvent", new DomFunction(JsRegistrationInitCustomEvent028, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initCustomEvent", new DomFunction(JsRegistrationInitCustomEvent028, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitFocusEvent029(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -188,7 +188,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initFocusEvent", new DomFunction(JsRegistrationInitFocusEvent029, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initFocusEvent", new DomFunction(JsRegistrationInitFocusEvent029, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitKeyboardEvent030(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -231,7 +231,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initKeyboardEvent", new DomFunction(JsRegistrationInitKeyboardEvent030, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initKeyboardEvent", new DomFunction(JsRegistrationInitKeyboardEvent030, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitMouseEvent031(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -286,7 +286,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initMouseEvent", new DomFunction(JsRegistrationInitMouseEvent031, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initMouseEvent", new DomFunction(JsRegistrationInitMouseEvent031, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitWheelEvent032(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -339,7 +339,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initWheelEvent", new DomFunction(JsRegistrationInitWheelEvent032, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initWheelEvent", new DomFunction(JsRegistrationInitWheelEvent032, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
         return evt;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/LocationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/LocationBinding.cs
@@ -82,21 +82,21 @@ internal static class LocationBinding
         // had been asked, and the URL then disagreed with the document still in hand. As an
         // accessor it answers the document's own URL and routes the write where assign() goes.
         location.FastAddProperty(
-            (KeyString)"href",
+            "href",
             new DomFunction((in _) => new JSString(href), "get href"),
             new DomFunction((in a) => Navigate(href, "href", in a), "set href"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         location.FastAddValue(
-            (KeyString)"assign",
+            "assign",
             new DomFunction((in a) => Navigate(href, "assign", in a), "assign", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         location.FastAddValue(
-            (KeyString)"replace",
+            "replace",
             new DomFunction((in a) => Navigate(href, "replace", in a), "replace", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         location.FastAddValue(
-            (KeyString)"reload",
+            "reload",
             new DomFunction((in _) =>
             {
                 RenderLogger.LogDebug(LogCategory.JavaScript, LogContext, $"location.reload() requested; the capture renders the document it was given and does not reload {href}");
@@ -107,7 +107,7 @@ internal static class LocationBinding
         // Location stringifies to its href, not to "[object Object]". Pages build URLs with
         // `"" + location` and log it, and the default Object.prototype.toString made both useless.
         location.FastAddValue(
-            (KeyString)"toString",
+            "toString",
             new DomFunction((in _) => new JSString(href), "toString", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -131,5 +131,5 @@ internal static class LocationBinding
     }
 
     private static void Add(JSObject location, string name, string value)
-        => location.FastAddValue((KeyString)name, new JSString(value), JSPropertyAttributes.EnumerableConfigurableValue);
+        => location.FastAddValue(name, new JSString(value), JSPropertyAttributes.EnumerableConfigurableValue);
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/MatchMediaBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MatchMediaBinding.cs
@@ -31,11 +31,11 @@ internal static class MatchMediaBinding
             new CssEnvironment(host.ViewportWidth, host.ViewportHeight));
 
         var result = new JSObject();
-        result.FastAddValue((KeyString)"matches", matches ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"media", new JSString(query), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("matches", matches ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("media", new JSString(query), JSPropertyAttributes.EnumerableConfigurableValue);
         // addListener / removeListener stubs (the legacy MediaQueryList API) — no-ops.
-        result.FastAddValue((KeyString)"addListener", NoOp("addListener"), JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"removeListener", NoOp("removeListener"), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("addListener", NoOp("addListener"), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("removeListener", NoOp("removeListener"), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // CSSOM View §4.2 made MediaQueryList an EventTarget, and that is the pair current code
         // registers with — the two above are the deprecated spelling kept for old callers. Having
@@ -49,13 +49,13 @@ internal static class MatchMediaBinding
         // A capture renders one frame at a fixed viewport, so no `change` event can ever fire and
         // the listener is genuinely never called; what matters is that registering one is not an
         // error. `dispatchEvent` reports false — nothing was dispatched — for the same reason.
-        result.FastAddValue((KeyString)"addEventListener", NoOp("addEventListener"), JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"removeEventListener", NoOp("removeEventListener"), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("addEventListener", NoOp("addEventListener"), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("removeEventListener", NoOp("removeEventListener"), JSPropertyAttributes.EnumerableConfigurableValue);
         result.FastAddValue(
-            (KeyString)"dispatchEvent",
+            "dispatchEvent",
             new JSFunction((in _) => JSBoolean.False, "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"onchange", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("onchange", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
 
         return result;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/MediaCapabilityBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MediaCapabilityBinding.cs
@@ -60,7 +60,7 @@ internal static class MediaCapabilityBinding
         if (tag is not ("video" or "audio"))
             return;
 
-        obj.FastAddValue((KeyString)"canPlayType",
+        obj.FastAddValue("canPlayType",
             new DomFunction((in _) => NotSupported, "canPlayType", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -81,7 +81,7 @@ internal static class MediaCapabilityBinding
     {
         var constructor = new JSFunction((in _) => NewMediaSource(context), "MediaSource", 0);
 
-        constructor.FastAddValue((KeyString)"isTypeSupported",
+        constructor.FastAddValue("isTypeSupported",
             new DomFunction((in _) => JSBoolean.False, "isTypeSupported", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -94,14 +94,14 @@ internal static class MediaCapabilityBinding
 
         // "closed" is the state a MediaSource is in until it is attached to a media element. It is
         // the one this never leaves, because there is no element for it to be attached to.
-        source.FastAddValue((KeyString)"readyState", new JSString("closed"), JSPropertyAttributes.EnumerableConfigurableValue);
+        source.FastAddValue("readyState", new JSString("closed"), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The buffer lists are empty and stay empty: addSourceBuffer refuses every type, which is
         // what the specification requires of a type isTypeSupported rejects.
-        source.FastAddValue((KeyString)"sourceBuffers", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
-        source.FastAddValue((KeyString)"activeSourceBuffers", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
+        source.FastAddValue("sourceBuffers", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
+        source.FastAddValue("activeSourceBuffers", new JSArray(), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        source.FastAddValue((KeyString)"addSourceBuffer",
+        source.FastAddValue("addSourceBuffer",
             new DomFunction((in a) => AddSourceBuffer(context, in a), "addSourceBuffer", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
@@ -52,15 +52,15 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     /// generic event target (a message port or a sub-window).</summary>
     internal void InstallEventTargetApi(JSObject target, string logContext)
     {
-        target.FastAddValue((KeyString)"addEventListener",
+        target.FastAddValue("addEventListener",
             new DomFunction((in a) => AddEventListener(target, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"removeEventListener",
+        target.FastAddValue("removeEventListener",
             new DomFunction((in a) => RemoveEventListener(target, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        target.FastAddValue((KeyString)"dispatchEvent",
+        target.FastAddValue("dispatchEvent",
             new DomFunction((in a) => DispatchEvent(logContext, target, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -111,10 +111,10 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     private JSValue DispatchEventTarget(JSObject target, JSObject evt, string logContext)
     {
         var eventType = evt[(KeyString)"type"]?.ToString() ?? "unknown";
-        evt.FastAddValue((KeyString)"target", target, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", target, JSPropertyAttributes.EnumerableConfigurableValue);
         evt[(KeyString)"srcElement"] = target;
-        evt.FastAddValue((KeyString)"currentTarget", target, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", target, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         var immediateStopped = false;
         var prevented = evt[(KeyString)"defaultPrevented"] is JSValue defaultPreventedValue &&
@@ -123,29 +123,29 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         var legacyCancelBubble = false;
         evt[(KeyString)"defaultPrevented"] = prevented ? JSBoolean.True : JSBoolean.False;
 
-        evt.FastAddValue((KeyString)"stopPropagation",
+        evt.FastAddValue("stopPropagation",
             new DomFunction((in _) => StopPropagation(ref legacyCancelBubble, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation",
+        evt.FastAddValue("stopImmediatePropagation",
             new DomFunction((in _) => StopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        evt.FastAddValue((KeyString)"preventDefault",
+        evt.FastAddValue("preventDefault",
             new DomFunction((in _) => PreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        evt.FastAddProperty((KeyString)"cancelBubble",
+        evt.FastAddProperty("cancelBubble",
             new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
             new DomFunction((in setArgs) => SetCancelBubble(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        evt.FastAddProperty((KeyString)"returnValue",
+        evt.FastAddProperty("returnValue",
             new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
             new DomFunction((in setArgs) => SetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        evt.FastAddValue((KeyString)"composedPath",
+        evt.FastAddValue("composedPath",
             new DomFunction((in _) => new JSArray(target), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -247,7 +247,7 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     internal void RegisterWindowMessaging(JSObject window)
     {
         window.FastAddValue(
-            (KeyString)"postMessage",
+            "postMessage",
             new DomFunction((in a) => WindowPostMessage(window, in a), "postMessage", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -357,7 +357,7 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         if (transferredBuffers.Count > 0)
         {
             var transferOptions = new JSObject();
-            transferOptions.FastAddValue((KeyString)"transfer", new JSArray(transferredBuffers), JSPropertyAttributes.EnumerableConfigurableValue);
+            transferOptions.FastAddValue("transfer", new JSArray(transferredBuffers), JSPropertyAttributes.EnumerableConfigurableValue);
             cloneOptions = transferOptions;
         }
 
@@ -441,15 +441,15 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     private static JSObject CreateMessageEvent(JSValue data, JSObject? sourceWindow, string origin, JSArray ports)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"data", data, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"origin", new JSString(origin), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"lastEventId", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"source", sourceWindow ?? JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"ports", ports, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("data", data, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("origin", new JSString(origin), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("lastEventId", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("source", sourceWindow ?? JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("ports", ports, JSPropertyAttributes.EnumerableConfigurableValue);
         return evt;
     }
 
@@ -464,8 +464,8 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         _messagePorts.Link(port1, port2);
 
         var channel = new JSObject();
-        channel.FastAddValue((KeyString)"port1", port1, JSPropertyAttributes.EnumerableConfigurableValue);
-        channel.FastAddValue((KeyString)"port2", port2, JSPropertyAttributes.EnumerableConfigurableValue);
+        channel.FastAddValue("port1", port1, JSPropertyAttributes.EnumerableConfigurableValue);
+        channel.FastAddValue("port2", port2, JSPropertyAttributes.EnumerableConfigurableValue);
         return channel;
     }
 
@@ -477,20 +477,20 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         InstallEventTargetApi(port, "DomBridge.messagePort.dispatchEvent");
         JSValue onMessageHandler = JSNull.Value;
 
-        port.FastAddValue((KeyString)"postMessage",
+        port.FastAddValue("postMessage",
             new DomFunction((in a) => PortPostMessage(port, in a), "postMessage", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        port.FastAddProperty((KeyString)"onmessage",
+        port.FastAddProperty("onmessage",
             new DomFunction((in _) => onMessageHandler, "get onmessage"),
             new DomFunction((in a) => SetOnMessage(ref onMessageHandler, port, in a), "set onmessage"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        port.FastAddValue((KeyString)"start",
+        port.FastAddValue("start",
             new DomFunction((in a) => StartPort(port, in a), "start", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        port.FastAddValue((KeyString)"close",
+        port.FastAddValue("close",
             new DomFunction((in a) => ClosePort(port, in a), "close", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/NavigationTimingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NavigationTimingBinding.cs
@@ -72,15 +72,15 @@ internal static class NavigationTimingBinding
     {
         var navigation = BuildNavigationEntry(pageUrl, pageProtocol, timing, fetchTiming);
 
-        performance.FastAddValue((KeyString)"getEntries",
+        performance.FastAddValue("getEntries",
             new DomFunction((in _) => new JSArray([navigation]), "getEntries", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        performance.FastAddValue((KeyString)"getEntriesByType",
+        performance.FastAddValue("getEntriesByType",
             new DomFunction((in a) => EntriesByType(navigation, in a), "getEntriesByType", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        performance.FastAddValue((KeyString)"getEntriesByName",
+        performance.FastAddValue("getEntriesByName",
             new DomFunction((in a) => EntriesByName(navigation, pageUrl, in a), "getEntriesByName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -104,9 +104,9 @@ internal static class NavigationTimingBinding
         // PerformanceEntry (Performance Timeline §3.1). A navigation entry is named by the
         // document's URL and its startTime is 0 by definition — the time origin *is* this
         // navigation's start.
-        entry.FastAddValue((KeyString)"name", new JSString(pageUrl), JSPropertyAttributes.EnumerableConfigurableValue);
-        entry.FastAddValue((KeyString)"entryType", new JSString("navigation"), JSPropertyAttributes.EnumerableConfigurableValue);
-        entry.FastAddValue((KeyString)"startTime", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("name", new JSString(pageUrl), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("entryType", new JSString("navigation"), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("startTime", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // duration is loadEventEnd - startTime (Navigation Timing §4), and startTime is 0 for a
         // navigation entry, so it *is* loadEventEnd. It was a hardcoded 0, which is right only until
@@ -120,17 +120,17 @@ internal static class NavigationTimingBinding
         // PerformanceResourceTiming (Resource Timing §4.1), of which a navigation entry is a
         // subtype. `initiatorType` is fixed at "navigation" for one, and the protocol is the engine's
         // own — see BroilerHttpProtocol, which pins the request version this names.
-        entry.FastAddValue((KeyString)"initiatorType", new JSString("navigation"), JSPropertyAttributes.EnumerableConfigurableValue);
-        entry.FastAddValue((KeyString)"nextHopProtocol", new JSString(NextHopProtocol(pageProtocol)), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("initiatorType", new JSString("navigation"), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("nextHopProtocol", new JSString(NextHopProtocol(pageProtocol)), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // PerformanceNavigationTiming (Navigation Timing §4). "navigate" is the plain case — the
         // alternatives ("reload", "back_forward", "prerender") describe entries into a session
         // history Broiler does not keep, so none of them can arise here.
-        entry.FastAddValue((KeyString)"type", new JSString("navigate"), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("type", new JSString("navigate"), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Redirects are followed inside the HTTP client, which does not report how many it took, so
         // this is the count Broiler can vouch for rather than a measurement.
-        entry.FastAddValue((KeyString)"redirectCount", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("redirectCount", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // --- Timing attributes (Navigation Timing §4). ---
         //
@@ -192,7 +192,7 @@ internal static class NavigationTimingBinding
         AddTimingConstant(entry, "encodedBodySize", fetchTiming?.EncodedBodySize ?? 0);
         AddTimingConstant(entry, "decodedBodySize", fetchTiming?.DecodedBodySize ?? 0);
 
-        entry.FastAddValue((KeyString)"toJSON",
+        entry.FastAddValue("toJSON",
             new DomFunction((in _) => entry, "toJSON", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -224,11 +224,11 @@ internal static class NavigationTimingBinding
 
     /// <summary>A live timing mark: an accessor so the entry reports the value at read time.</summary>
     private static void AddTimingAccessor(JSObject entry, string name, Func<double> read)
-        => entry.FastAddProperty((KeyString)name,
+        => entry.FastAddProperty(name,
             new DomFunction((in _) => new JSNumber(read()), $"get {name}"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
     /// <summary>A mark whose value cannot change for this document.</summary>
     private static void AddTimingConstant(JSObject entry, string name, double value)
-        => entry.FastAddValue((KeyString)name, new JSNumber(value), JSPropertyAttributes.EnumerableConfigurableValue);
+        => entry.FastAddValue(name, new JSNumber(value), JSPropertyAttributes.EnumerableConfigurableValue);
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/NavigatorCapabilityBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NavigatorCapabilityBinding.cs
@@ -50,7 +50,7 @@ internal static class NavigatorCapabilityBinding
     {
         // navigator.javaEnabled() (HTML §8.9) — specified to return false. Not "false because
         // Broiler has no Java": the method is a vestige whose only conforming answer is false.
-        navigator.FastAddValue((KeyString)"javaEnabled",
+        navigator.FastAddValue("javaEnabled",
             new DomFunction((in _) => JSBoolean.False, "javaEnabled", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -59,24 +59,24 @@ internal static class NavigatorCapabilityBinding
         // entries a Chromium reports are its bundled viewer, not a plugin system. `pdfViewerEnabled`
         // is the flag that decides between the two branches, so it is registered beside them rather
         // than left for a page to infer from the empty lists.
-        navigator.FastAddValue((KeyString)"plugins", BuildEmptyPluginArray("PluginArray"), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigator.FastAddValue((KeyString)"mimeTypes", BuildEmptyPluginArray("MimeTypeArray"), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigator.FastAddValue((KeyString)"pdfViewerEnabled", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue("plugins", BuildEmptyPluginArray("PluginArray"), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue("mimeTypes", BuildEmptyPluginArray("MimeTypeArray"), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue("pdfViewerEnabled", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // navigator.getGamepads() (Gamepad §2.2) — the gamepads currently connected. Broiler has no
         // gamepad input path, so none ever are, and an empty list is what the specification asks
         // for in that case.
-        navigator.FastAddValue((KeyString)"getGamepads",
+        navigator.FastAddValue("getGamepads",
             new DomFunction((in _) => new JSArray(), "getGamepads", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // navigator.getBattery() (Battery Status §4).
-        navigator.FastAddValue((KeyString)"getBattery",
+        navigator.FastAddValue("getBattery",
             new DomFunction((in _) => GetBattery(), "getBattery", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // navigator.requestMediaKeySystemAccess() (EME §5).
-        navigator.FastAddValue((KeyString)"requestMediaKeySystemAccess",
+        navigator.FastAddValue("requestMediaKeySystemAccess",
             new DomFunction((in a) => RequestMediaKeySystemAccess(context, in a), "requestMediaKeySystemAccess", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
@@ -90,14 +90,14 @@ internal static class NavigatorCapabilityBinding
     {
         var collection = new JSObject();
 
-        collection.FastAddValue((KeyString)"length", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        collection.FastAddValue((KeyString)"item", DomBridge.NullFunction("item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        collection.FastAddValue((KeyString)"namedItem", DomBridge.NullFunction("namedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        collection.FastAddValue("length", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        collection.FastAddValue("item", DomBridge.NullFunction("item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        collection.FastAddValue("namedItem", DomBridge.NullFunction("namedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // refresh() exists only on PluginArray, and re-checks for newly installed plugins. There are
         // none to find, but a page that calls it before iterating must not lose the iteration.
         if (name == "PluginArray")
-            collection.FastAddValue((KeyString)"refresh", DomBridge.UndefinedFunction("refresh", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            collection.FastAddValue("refresh", DomBridge.UndefinedFunction("refresh", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         return collection;
     }
@@ -113,17 +113,17 @@ internal static class NavigatorCapabilityBinding
     {
         var battery = new JSObject();
 
-        battery.FastAddValue((KeyString)"charging", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
-        battery.FastAddValue((KeyString)"chargingTime", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        battery.FastAddValue((KeyString)"dischargingTime", new JSNumber(double.PositiveInfinity), JSPropertyAttributes.EnumerableConfigurableValue);
-        battery.FastAddValue((KeyString)"level", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        battery.FastAddValue("charging", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);
+        battery.FastAddValue("chargingTime", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        battery.FastAddValue("dischargingTime", new JSNumber(double.PositiveInfinity), JSPropertyAttributes.EnumerableConfigurableValue);
+        battery.FastAddValue("level", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The four event-handler attributes, settable and never fired: none of the four values above
         // can change, so there is no change to deliver. A page assigns to them unconditionally.
         foreach (var handler in BatteryEventHandlers)
         {
             JSValue stored = JSNull.Value;
-            battery.FastAddProperty((KeyString)handler,
+            battery.FastAddProperty(handler,
                 new DomFunction((in _) => stored, "get " + handler),
                 new DomFunction((in a) => stored = a.Length > 0 ? a[0] : JSNull.Value, "set " + handler),
                 JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/NavigatorIdentityBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NavigatorIdentityBinding.cs
@@ -89,7 +89,7 @@ internal static class NavigatorIdentityBinding
     }
 
     private static void Add(JSObject navigator, string name, JSValue value)
-        => navigator.FastAddValue((KeyString)name, value, JSPropertyAttributes.EnumerableConfigurableValue);
+        => navigator.FastAddValue(name, value, JSPropertyAttributes.EnumerableConfigurableValue);
 
     /// <summary>
     /// The machine's memory in GiB, rounded down to the nearest power of two and clamped to

--- a/src/Broiler.HtmlBridge.Dom/Features/NavigatorSurfacesBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NavigatorSurfacesBinding.cs
@@ -129,8 +129,8 @@ internal static class NavigatorSurfacesBinding
         Method(prototype, "estimate", 0, static (in Arguments _) =>
         {
             var estimate = new JSObject();
-            estimate.FastAddValue((KeyString)"usage", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-            estimate.FastAddValue((KeyString)"quota", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+            estimate.FastAddValue("usage", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+            estimate.FastAddValue("quota", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
             return Resolved(estimate);
         });
 
@@ -177,7 +177,7 @@ internal static class NavigatorSurfacesBinding
 
         // The state never changes, so this handler is never called — which is the correct behaviour
         // rather than a missing one. It is present because a page assigns to it unconditionally.
-        statusPrototype.FastAddValue((KeyString)"onchange",
+        statusPrototype.FastAddValue("onchange",
             JavaScript.BuiltIns.Null.JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
@@ -219,22 +219,22 @@ internal static class NavigatorSurfacesBinding
             // A hint that is not asked for is absent, which is the interface's own shape: the
             // caller names what it wants and gets exactly that.
             if (hints.Contains("architecture"))
-                result.FastAddValue((KeyString)"architecture", new JSString("x86"), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("architecture", new JSString("x86"), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("bitness"))
-                result.FastAddValue((KeyString)"bitness", new JSString(is64Bit ? "64" : "32"), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("bitness", new JSString(is64Bit ? "64" : "32"), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("model"))
-                result.FastAddValue((KeyString)"model", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("model", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("platformVersion"))
-                result.FastAddValue((KeyString)"platformVersion", new JSString(platformVersion), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("platformVersion", new JSString(platformVersion), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("uaFullVersion"))
-                result.FastAddValue((KeyString)"uaFullVersion", new JSString(version), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("uaFullVersion", new JSString(version), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("fullVersionList"))
-                result.FastAddValue((KeyString)"fullVersionList", BrandList(brand, version), JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("fullVersionList", BrandList(brand, version), JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("wow64"))
-                result.FastAddValue((KeyString)"wow64", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+                result.FastAddValue("wow64", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
             if (hints.Contains("formFactors"))
             {
-                result.FastAddValue((KeyString)"formFactors",
+                result.FastAddValue("formFactors",
                     new JSArray([new JSString("Desktop")]), JSPropertyAttributes.EnumerableConfigurableValue);
             }
 
@@ -245,17 +245,17 @@ internal static class NavigatorSurfacesBinding
     private static JSObject LowEntropyObject(string brand, string majorVersion, string platform)
     {
         var result = new JSObject();
-        result.FastAddValue((KeyString)"brands", BrandList(brand, majorVersion), JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"mobile", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        result.FastAddValue((KeyString)"platform", new JSString(platform), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("brands", BrandList(brand, majorVersion), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("mobile", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue("platform", new JSString(platform), JSPropertyAttributes.EnumerableConfigurableValue);
         return result;
     }
 
     private static JSArray BrandList(string brand, string version)
     {
         var entry = new JSObject();
-        entry.FastAddValue((KeyString)"brand", new JSString(brand), JSPropertyAttributes.EnumerableConfigurableValue);
-        entry.FastAddValue((KeyString)"version", new JSString(version), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("brand", new JSString(brand), JSPropertyAttributes.EnumerableConfigurableValue);
+        entry.FastAddValue("version", new JSString(version), JSPropertyAttributes.EnumerableConfigurableValue);
         return new JSArray([entry]);
     }
 
@@ -335,12 +335,12 @@ internal static class NavigatorSurfacesBinding
     }
 
     private static void Method(JSObject prototype, string name, int length, JSFunctionDelegate body) =>
-        prototype.FastAddValue((KeyString)name, new DomFunction(body, name, length),
+        prototype.FastAddValue(name, new DomFunction(body, name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
     private static void Getter(JSObject prototype, string name, Func<JSObject, JSValue> read) =>
         prototype.FastAddProperty(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => a.This is JSObject receiver ? read(receiver) : JSUndefined.Value, $"get {name}"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -357,5 +357,5 @@ internal static class NavigatorSurfacesBinding
     }
 
     private static void Add(JSObject navigator, string name, JSValue value) =>
-        navigator.FastAddValue((KeyString)name, value, JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue(name, value, JSPropertyAttributes.EnumerableConfigurableValue);
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/NodeConstantsBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NodeConstantsBinding.cs
@@ -66,7 +66,7 @@ internal static class NodeConstantsBinding
     public static void Install(JSObject obj)
     {
         foreach (var (name, value) in Constants)
-            obj.FastAddValue((KeyString)name, new JSNumber(value), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue(name, new JSNumber(value), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     /// <summary>The constant names, for dropping the copies a wrapper installed before it had a chain.</summary>

--- a/src/Broiler.HtmlBridge.Dom/Features/NotificationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/NotificationBinding.cs
@@ -45,17 +45,17 @@ internal static class NotificationBinding
     {
         var constructor = new JSFunction(NewNotification, "Notification", 2);
 
-        constructor.FastAddValue((KeyString)"permission",
+        constructor.FastAddValue("permission",
             new JSString(Permission), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        constructor.FastAddValue((KeyString)"requestPermission",
+        constructor.FastAddValue("requestPermission",
             new DomFunction(RequestPermission, "requestPermission", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // The maximum number of actions a notification may carry. Zero is the honest count for a
         // notification that is never displayed, and it is a value the specification expects to vary
         // by user agent, so a page reading it is already prepared for zero.
-        constructor.FastAddValue((KeyString)"maxActions",
+        constructor.FastAddValue("maxActions",
             new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         return constructor;
@@ -81,7 +81,7 @@ internal static class NotificationBinding
     {
         var notification = new JSObject();
 
-        notification.FastAddValue((KeyString)"title",
+        notification.FastAddValue("title",
             a.Length > 0 ? new JSString(a[0].ToString()) : new JSString(string.Empty),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -91,18 +91,18 @@ internal static class NotificationBinding
         foreach (var (name, fallback) in ReflectedOptions)
         {
             var value = options[(KeyString)name];
-            notification.FastAddValue((KeyString)name,
+            notification.FastAddValue(name,
                 value is JSUndefined ? fallback : value,
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         JSValue onError = JSNull.Value;
-        notification.FastAddProperty((KeyString)"onerror",
+        notification.FastAddProperty("onerror",
             new DomFunction((in _) => onError, "get onerror"),
             new DomFunction((in b) => onError = b.Length > 0 ? b[0] : JSNull.Value, "set onerror"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        notification.FastAddValue((KeyString)"close",
+        notification.FastAddValue("close",
             DomBridge.UndefinedFunction("close", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/PerformanceMemoryBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/PerformanceMemoryBinding.cs
@@ -44,15 +44,15 @@ internal static class PerformanceMemoryBinding
     {
         var memory = new JSObject();
 
-        memory.FastAddProperty((KeyString)"jsHeapSizeLimit",
+        memory.FastAddProperty("jsHeapSizeLimit",
             new DomFunction((in _) => new JSNumber(Sample().Limit), "get jsHeapSizeLimit"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        memory.FastAddProperty((KeyString)"totalJSHeapSize",
+        memory.FastAddProperty("totalJSHeapSize",
             new DomFunction((in _) => new JSNumber(Sample().Total), "get totalJSHeapSize"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        memory.FastAddProperty((KeyString)"usedJSHeapSize",
+        memory.FastAddProperty("usedJSHeapSize",
             new DomFunction((in _) => new JSNumber(Sample().Used), "get usedJSHeapSize"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ScreenOrientationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ScreenOrientationBinding.cs
@@ -45,13 +45,13 @@ internal static class ScreenOrientationBinding
     {
         var orientation = new JSObject();
 
-        orientation.FastAddProperty((KeyString)"type",
+        orientation.FastAddProperty("type",
             new DomFunction((in _) => new JSString(TypeOf(width, height)), "get type"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // The angle between the current orientation and the device's natural one. Broiler's output
         // surface is its natural orientation, so the two never differ.
-        orientation.FastAddProperty((KeyString)"angle",
+        orientation.FastAddProperty("angle",
             new DomFunction((in _) => new JSNumber(0), "get angle"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -59,14 +59,14 @@ internal static class ScreenOrientationBinding
         // orientation cannot change. It is present because a page assigns to it unconditionally,
         // and null is the value the attribute has before anything is assigned.
         JSValue onChange = JSNull.Value;
-        orientation.FastAddProperty((KeyString)"onchange",
+        orientation.FastAddProperty("onchange",
             new DomFunction((in _) => onChange, "get onchange"),
             new DomFunction((in a) => onChange = a.Length > 0 ? a[0] : JSNull.Value, "set onchange"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // unlock() releases a lock; with no way to take one there is never a lock to release, which
         // makes doing nothing the specified behaviour rather than a stub.
-        orientation.FastAddValue((KeyString)"unlock",
+        orientation.FastAddValue("unlock",
             DomBridge.UndefinedFunction("unlock", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/SelectBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SelectBinding.cs
@@ -29,17 +29,17 @@ internal sealed class SelectBinding(ISelectHost host)
     {
         if (tag == "select")
         {
-            obj.FastAddValue((KeyString)"add",
+            obj.FastAddValue("add",
                 new DomFunction((in a) => Add(element, in a), "add", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddProperty((KeyString)"options",
+            obj.FastAddProperty("options",
                 new DomFunction((in _) => GetOptions(element), "get options"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"selectedIndex",
+            obj.FastAddProperty("selectedIndex",
                 new DomFunction((in _) => new JSNumber(GetSelectedIndex(element)), "get selectedIndex"),
                 new DomFunction((in a) => SetSelectedIndexCallback(element, in a), "set selectedIndex"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"size",
+            obj.FastAddProperty("size",
                 new DomFunction((in _) => GetSize(element), "get size"),
                 new DomFunction((in a) => SetSize(element, in a), "set size"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -47,7 +47,7 @@ internal sealed class SelectBinding(ISelectHost host)
 
         if (tag == "option")
         {
-            obj.FastAddProperty((KeyString)"defaultSelected",
+            obj.FastAddProperty("defaultSelected",
                 new DomFunction((in _) => _host.GetOptionDefaultSelected(element) ? JSBoolean.True : JSBoolean.False, "get defaultSelected"),
                 new DomFunction((in a) => SetDefaultSelected(element, in a), "set defaultSelected"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -91,7 +91,7 @@ internal sealed class SelectBinding(ISelectHost host)
             if (string.Equals(c.TagName, "option", StringComparison.OrdinalIgnoreCase))
                 opts.Add(_host.ToJSObject(c));
         var arr = new JSArray(opts);
-        arr.FastAddProperty((KeyString)"length",
+        arr.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(opts.Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         return arr;

--- a/src/Broiler.HtmlBridge.Dom/Features/StorageQuotaBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StorageQuotaBinding.cs
@@ -39,15 +39,15 @@ internal static class StorageQuotaBinding
     /// </summary>
     public static void Install(JSObject navigator)
     {
-        navigator.FastAddValue((KeyString)"webkitTemporaryStorage", BuildStorageQuota(), JSPropertyAttributes.EnumerableConfigurableValue);
-        navigator.FastAddValue((KeyString)"webkitPersistentStorage", BuildStorageQuota(), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue("webkitTemporaryStorage", BuildStorageQuota(), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigator.FastAddValue("webkitPersistentStorage", BuildStorageQuota(), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     private static JSObject BuildStorageQuota()
     {
         var quota = new JSObject();
 
-        quota.FastAddValue((KeyString)"queryUsageAndQuota",
+        quota.FastAddValue("queryUsageAndQuota",
             new DomFunction(QueryUsageAndQuota, "queryUsageAndQuota", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/StreamsBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StreamsBinding.cs
@@ -92,7 +92,7 @@ internal sealed class StreamsBinding
             return;
 
         blobPrototype.FastAddValue(
-            (KeyString)"stream",
+            "stream",
             new DomFunction(
                 (in a) => a.This is JSObject receiver && blobs.BytesOf(receiver) is { } bytes
                     ? StreamOverBytes(context, bytes)

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleDeclarationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleDeclarationBinding.cs
@@ -74,41 +74,41 @@ internal static partial class StyleDeclarationBinding
     {
         var style = new CssStyleDeclaration(host, element, onMutation, onPositionAreaInvalidate);
 
-        style.FastAddProperty((KeyString)"cssText",
+        style.FastAddProperty("cssText",
             new DomFunction((in a) => InlineGetCssText(host, element, in a), "get cssText"),
             new DomFunction((in a) => InlineSetCssText(host, element, onMutation, in a), "set cssText"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddValue((KeyString)"setProperty",
+        style.FastAddValue("setProperty",
             new DomFunction((in a) => InlineSetProperty(host, element, onMutation, in a), "setProperty", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"getPropertyValue",
+        style.FastAddValue("getPropertyValue",
             new DomFunction((in a) => InlineGetPropertyValue(host, element, in a), "getPropertyValue", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"removeProperty",
+        style.FastAddValue("removeProperty",
             new DomFunction((in a) => InlineRemoveProperty(host, element, onMutation, in a), "removeProperty", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddProperty((KeyString)"cssFloat",
+        style.FastAddProperty("cssFloat",
             new DomFunction((in a) => InlineGetCssFloat(host, element, in a), "get cssFloat"),
             new DomFunction((in a) => InlineSetCssFloat(host, element, onMutation, in a), "set cssFloat"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddProperty((KeyString)"length",
+        style.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(GetStylePropertyNames(host, element).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddValue((KeyString)"item",
+        style.FastAddValue("item",
             new DomFunction((in a) => InlineItem(host, element, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"getPropertyPriority",
+        style.FastAddValue("getPropertyPriority",
             new DomFunction((in a) => InlineGetPropertyPriority(host, element, in a), "getPropertyPriority", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddProperty((KeyString)"parentRule",
+        style.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -121,41 +121,41 @@ internal static partial class StyleDeclarationBinding
     {
         var style = new CssRuleStyleDeclaration(styleMap);
 
-        style.FastAddProperty((KeyString)"cssText",
+        style.FastAddProperty("cssText",
             new DomFunction((in _) => RuleGetCssText(styleMap, in _), "get cssText"),
             new DomFunction((in a) => RuleSetCssText(styleMap, in a), "set cssText"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddValue((KeyString)"setProperty",
+        style.FastAddValue("setProperty",
             new DomFunction((in a) => RuleSetProperty(styleMap, in a), "setProperty", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"getPropertyValue",
+        style.FastAddValue("getPropertyValue",
             new DomFunction((in a) => RuleGetPropertyValue(styleMap, in a), "getPropertyValue", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"removeProperty",
+        style.FastAddValue("removeProperty",
             new DomFunction((in a) => RuleRemoveProperty(styleMap, in a), "removeProperty", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddProperty((KeyString)"cssFloat",
+        style.FastAddProperty("cssFloat",
             new DomFunction((in _) => RuleGetCssFloat(styleMap, in _), "get cssFloat"),
             new DomFunction((in a) => RuleSetCssFloat(styleMap, in a), "set cssFloat"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddProperty((KeyString)"length",
+        style.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(GetStylePropertyNames(styleMap).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        style.FastAddValue((KeyString)"item",
+        style.FastAddValue("item",
             new DomFunction((in a) => RuleItem(styleMap, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddValue((KeyString)"getPropertyPriority",
+        style.FastAddValue("getPropertyPriority",
             new DomFunction((in a) => RuleGetPropertyPriority(styleMap, in a), "getPropertyPriority", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        style.FastAddProperty((KeyString)"parentRule",
+        style.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -175,19 +175,19 @@ internal static partial class StyleDeclarationBinding
         {
             var camel = CssPropertyNames.ToDomPropertyName(kv.Key);
             var normalized = CssPriority.Strip(kv.Value);
-            obj.FastAddValue((KeyString)kv.Key, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue(kv.Key, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
             if (camel != kv.Key)
-                obj.FastAddValue((KeyString)camel, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
+                obj.FastAddValue(camel, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // getPropertyValue method (supports both kebab-case and camelCase lookups)
-        obj.FastAddValue((KeyString)"getPropertyValue", new DomFunction((in a) => ComputedGetPropertyValue(computed, in a), "getPropertyValue", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddProperty((KeyString)"length", new DomFunction((in _) => new JSNumber(propertyNames.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddValue("getPropertyValue", new DomFunction((in a) => ComputedGetPropertyValue(computed, in a), "getPropertyValue", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddProperty("length", new DomFunction((in _) => new JSNumber(propertyNames.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddValue((KeyString)"item", new DomFunction((in a) => ComputedItem(propertyNames, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"getPropertyPriority", new DomFunction((in _) => new JSString(string.Empty), "getPropertyPriority", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue("item", new DomFunction((in a) => ComputedItem(propertyNames, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue("getPropertyPriority", new DomFunction((in _) => new JSString(string.Empty), "getPropertyPriority", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        obj.FastAddProperty((KeyString)"parentRule", DomBridge.NullFunction("get parentRule"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty("parentRule", DomBridge.NullFunction("get parentRule"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         return obj;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.Rules.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.Rules.cs
@@ -55,14 +55,14 @@ internal static partial class StyleSheetBinding
             return BuildCssRuleObject(CssSerializer.Serialize(rule), parentStyleSheet, parentRule);
 
         var ruleObj = new JSObject();
-        ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
+        ruleObj.FastAddProperty("parentStyleSheet",
             new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        ruleObj.FastAddProperty((KeyString)"parentRule",
+        ruleObj.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        ruleObj.FastAddValue((KeyString)"type", new JSNumber((int)kind), JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddValue("type", new JSNumber((int)kind), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Builds the JS CSSStyleDeclaration for a declaration-bodied rule from the
         // model's declaration block — identical to the legacy substring path because
@@ -80,8 +80,8 @@ internal static partial class StyleSheetBinding
             case CssomRuleType.Charset:
                 {
                     var encoding = CssomRuleMetadata.GetCharsetEncoding((CssAtRule)rule);
-                    ruleObj.FastAddValue((KeyString)"encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -90,9 +90,9 @@ internal static partial class StyleSheetBinding
             case CssomRuleType.Import:
                 {
                     var import = CssomRuleMetadata.GetImport((CssAtRule)rule);
-                    ruleObj.FastAddValue((KeyString)"href", new JSString(import.Href), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"media", new JSString(import.Media), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("href", new JSString(import.Href), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("media", new JSString(import.Media), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText017Core(import.Href, import.Media, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -107,9 +107,9 @@ internal static partial class StyleSheetBinding
                         nestedRuleObjects,
                         text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
 
-                    ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -118,10 +118,10 @@ internal static partial class StyleSheetBinding
             case CssomRuleType.FontFace:
                 {
                     var styleObj = StyleFromBlock(((CssAtRule)rule).Declarations);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
-                    ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                     break;
                 }
 
@@ -133,9 +133,9 @@ internal static partial class StyleSheetBinding
                     var nestedCssRules = BuildCssRuleListObject(nestedRuleObjects,
                         text => BuildCssKeyframeRuleObject(text, parentStyleSheet, ruleObj));
 
-                    ruleObj.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -152,13 +152,13 @@ internal static partial class StyleSheetBinding
                         || !string.Equals(inheritsValue, "false", StringComparison.OrdinalIgnoreCase);
                     var initialValue = descriptors.GetValueOrDefault("initial-value");
 
-                    ruleObj.FastAddValue((KeyString)"name", new JSString(propertyName), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"syntax", new JSString(syntax), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"inherits", inherits ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"initialValue",
+                    ruleObj.FastAddValue("name", new JSString(propertyName), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("syntax", new JSString(syntax), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("inherits", inherits ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("initialValue",
                         string.IsNullOrEmpty(initialValue) ? JSNull.Value : new JSString(initialValue),
                         JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -170,7 +170,7 @@ internal static partial class StyleSheetBinding
                     var ruleName = atRule.Prelude;
                     var descriptors = DomBridge.ParseStyle(CssSerializer.Serialize(atRule.Declarations ?? new CssDeclarationBlock([])));
 
-                    ruleObj.FastAddValue((KeyString)"name", new JSString(ruleName), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("name", new JSString(ruleName), JSPropertyAttributes.EnumerableConfigurableValue);
 
                     var descriptorMap = new (string CssName, string JsName)[]
                     {
@@ -188,12 +188,12 @@ internal static partial class StyleSheetBinding
 
                     foreach (var (cssName, jsName) in descriptorMap)
                     {
-                        ruleObj.FastAddValue((KeyString)jsName,
+                        ruleObj.FastAddValue(jsName,
                             descriptors.TryGetValue(cssName, out var value) ? new JSString(value) : JSUndefined.Value,
                             JSPropertyAttributes.EnumerableConfigurableValue);
                     }
 
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -208,9 +208,9 @@ internal static partial class StyleSheetBinding
                         nestedRuleObjects,
                         text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
 
-                    ruleObj.FastAddValue((KeyString)"conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -226,22 +226,22 @@ internal static partial class StyleSheetBinding
                         var nestedCssRules = BuildCssRuleListObject(nestedRuleObjects,
                             text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
 
-                        ruleObj.FastAddValue((KeyString)"name",
+                        ruleObj.FastAddValue("name",
                             string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
                             JSPropertyAttributes.EnumerableConfigurableValue);
-                        ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                        ruleObj.FastAddProperty((KeyString)"cssText",
+                        ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                        ruleObj.FastAddProperty("cssText",
                             new DomFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
                             null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     }
                     else
                     {
                         // Statement form: `@layer a, b;` — no block, empty cssRules.
-                        ruleObj.FastAddValue((KeyString)"name",
+                        ruleObj.FastAddValue("name",
                             string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
                             JSPropertyAttributes.EnumerableConfigurableValue);
-                        ruleObj.FastAddValue((KeyString)"cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
-                        ruleObj.FastAddProperty((KeyString)"cssText",
+                        ruleObj.FastAddValue("cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
+                        ruleObj.FastAddProperty("cssText",
                             new DomFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
                             null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     }
@@ -251,11 +251,11 @@ internal static partial class StyleSheetBinding
             case CssomRuleType.Namespace:
                 {
                     var ns = CssomRuleMetadata.GetNamespace((CssAtRule)rule);
-                    ruleObj.FastAddValue((KeyString)"namespaceURI", new JSString(ns.Uri), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"prefix",
+                    ruleObj.FastAddValue("namespaceURI", new JSString(ns.Uri), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("prefix",
                         string.IsNullOrEmpty(ns.Prefix) ? JSUndefined.Value : new JSString(ns.Prefix),
                         JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText026Core(ns.Uri, ns.Prefix, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -266,9 +266,9 @@ internal static partial class StyleSheetBinding
                     var atRule = (CssAtRule)rule;
                     var selectorText = atRule.Prelude;
                     var styleObj = StyleFromBlock(atRule.Declarations);
-                    ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
@@ -279,12 +279,12 @@ internal static partial class StyleSheetBinding
                     // CSSStyleRule — type 1
                     var styleRule = (CssStyleRule)rule;
                     var selectorText = CssomRuleMetadata.GetSelectorText(styleRule);
-                    ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
-                    ruleObj.FastAddProperty((KeyString)"cssText",
+                    ruleObj.FastAddValue("selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty("cssText",
                         new DomFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     var styleObj = StyleFromBlock(styleRule.Declarations);
-                    ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                     break;
                 }
         }
@@ -296,10 +296,10 @@ internal static partial class StyleSheetBinding
     {
         var ruleObj = new JSObject();
         ruleObj.FastAddProperty(
-            (KeyString)"parentStyleSheet",
+            "parentStyleSheet",
             new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        ruleObj.FastAddProperty((KeyString)"parentRule",
+        ruleObj.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -308,19 +308,19 @@ internal static partial class StyleSheetBinding
         if (trimmedRuleText.StartsWith("@charset", StringComparison.OrdinalIgnoreCase))
         {
             // CSSCharsetRule — type 2
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var charsetBody = trimmedRuleText[8..].Trim().TrimEnd(';').Trim();
             var encoding = charsetBody.Trim('"', '\'');
 
-            ruleObj.FastAddValue((KeyString)"encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddProperty((KeyString)"cssText",
+            ruleObj.FastAddValue("encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddProperty("cssText",
                 new DomFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@import", StringComparison.OrdinalIgnoreCase))
         {
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var importBody = trimmedRuleText[7..].Trim().TrimEnd(';').Trim();
             var href = string.Empty;
@@ -347,15 +347,15 @@ internal static partial class StyleSheetBinding
                 }
             }
 
-            ruleObj.FastAddValue((KeyString)"href", new JSString(href), JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddProperty((KeyString)"cssText",
+            ruleObj.FastAddValue("href", new JSString(href), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddProperty("cssText",
                 new DomFunction((in _) => JsStyleSheetsGetCssText017Core(href, mediaText, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@media", StringComparison.OrdinalIgnoreCase))
         {
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
 
             int braceOpen = ruleText.IndexOf('{');
             int braceClose = ruleText.LastIndexOf('}');
@@ -368,9 +368,9 @@ internal static partial class StyleSheetBinding
                     nestedRuleObjects,
                     rule => BuildCssRuleObject(rule, parentStyleSheet, ruleObj));
 
-                ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -378,7 +378,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@font-face", StringComparison.OrdinalIgnoreCase))
         {
             // CSSFontFaceRule — type 5
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(5), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(5), JSPropertyAttributes.EnumerableConfigurableValue);
 
             // Extract declarations from @font-face { ... }
             int braceOpen = ruleText.IndexOf('{');
@@ -388,16 +388,16 @@ internal static partial class StyleSheetBinding
                 var declarations = ruleText.Substring(braceOpen + 1, braceClose - braceOpen - 1).Trim();
                 var styleMap = DomBridge.ParseStyle(declarations);
                 var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(styleMap, ruleObj);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
-                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
             }
         }
         else if (trimmedRuleText.StartsWith("@keyframes", StringComparison.OrdinalIgnoreCase))
         {
             // CSSKeyframesRule — type 7
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(7), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(7), JSPropertyAttributes.EnumerableConfigurableValue);
 
             int braceOpen = ruleText.IndexOf('{');
             int braceClose = ruleText.LastIndexOf('}');
@@ -410,9 +410,9 @@ internal static partial class StyleSheetBinding
                     nestedRuleObjects,
                     rule => BuildCssKeyframeRuleObject(rule, parentStyleSheet, ruleObj));
 
-                ruleObj.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -420,7 +420,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@property", StringComparison.OrdinalIgnoreCase))
         {
             // CSSPropertyRule — type 25
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(25), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(25), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var braceOpen = trimmedRuleText.IndexOf('{');
             var braceClose = trimmedRuleText.LastIndexOf('}');
@@ -436,13 +436,13 @@ internal static partial class StyleSheetBinding
                     || !string.Equals(inheritsValue, "false", StringComparison.OrdinalIgnoreCase);
                 var initialValue = descriptors.GetValueOrDefault("initial-value");
 
-                ruleObj.FastAddValue((KeyString)"name", new JSString(propertyName), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"syntax", new JSString(syntax), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"inherits", inherits ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"initialValue",
+                ruleObj.FastAddValue("name", new JSString(propertyName), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("syntax", new JSString(syntax), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("inherits", inherits ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("initialValue",
                     string.IsNullOrEmpty(initialValue) ? JSNull.Value : new JSString(initialValue),
                     JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -450,7 +450,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@counter-style", StringComparison.OrdinalIgnoreCase))
         {
             // CSSCounterStyleRule — type 10
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var braceOpen = trimmedRuleText.IndexOf('{');
             var braceClose = trimmedRuleText.LastIndexOf('}');
@@ -460,7 +460,7 @@ internal static partial class StyleSheetBinding
                 var descriptorsText = trimmedRuleText.Substring(braceOpen + 1, braceClose - braceOpen - 1).Trim();
                 var descriptors = DomBridge.ParseStyle(descriptorsText);
 
-                ruleObj.FastAddValue((KeyString)"name", new JSString(ruleName), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("name", new JSString(ruleName), JSPropertyAttributes.EnumerableConfigurableValue);
 
                 var descriptorMap = new (string CssName, string JsName)[]
                 {
@@ -478,12 +478,12 @@ internal static partial class StyleSheetBinding
 
                 foreach (var (cssName, jsName) in descriptorMap)
                 {
-                    ruleObj.FastAddValue((KeyString)jsName,
+                    ruleObj.FastAddValue(jsName,
                         descriptors.TryGetValue(cssName, out var value) ? new JSString(value) : JSUndefined.Value,
                         JSPropertyAttributes.EnumerableConfigurableValue);
                 }
 
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -491,7 +491,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@supports", StringComparison.OrdinalIgnoreCase))
         {
             // CSSSupportsRule — type 11
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(11), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(11), JSPropertyAttributes.EnumerableConfigurableValue);
 
             int braceOpen = ruleText.IndexOf('{');
             int braceClose = ruleText.LastIndexOf('}');
@@ -503,9 +503,9 @@ internal static partial class StyleSheetBinding
                 var nestedCssRules = BuildCssRuleListObject(nestedRuleObjects,
                     rule => BuildCssRuleObject(rule, parentStyleSheet, ruleObj));
 
-                ruleObj.FastAddValue((KeyString)"conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -513,7 +513,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@layer", StringComparison.OrdinalIgnoreCase))
         {
             // CSSLayerRule — type 12
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(12), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(12), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var layerBody = ruleText[6..].Trim();
             var braceOpen = ruleText.IndexOf('{');
@@ -526,22 +526,22 @@ internal static partial class StyleSheetBinding
                 var nestedCssRules = BuildCssRuleListObject(nestedRuleObjects,
                     rule => BuildCssRuleObject(rule, parentStyleSheet, ruleObj));
 
-                ruleObj.FastAddValue((KeyString)"name",
+                ruleObj.FastAddValue("name",
                     string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
                     JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
             else
             {
                 var nameText = layerBody.TrimEnd(';').Trim();
-                ruleObj.FastAddValue((KeyString)"name",
+                ruleObj.FastAddValue("name",
                     string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
                     JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -549,7 +549,7 @@ internal static partial class StyleSheetBinding
         else if (trimmedRuleText.StartsWith("@namespace", StringComparison.OrdinalIgnoreCase))
         {
             // CSSNamespaceRule — type 9
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var namespaceBody = trimmedRuleText[10..].Trim().TrimEnd(';').Trim();
             string? prefix = null;
@@ -566,18 +566,18 @@ internal static partial class StyleSheetBinding
                 namespaceUri = CssomRuleMetadata.ExtractNamespaceUri(parts[0]);
             }
 
-            ruleObj.FastAddValue((KeyString)"namespaceURI", new JSString(namespaceUri), JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddValue((KeyString)"prefix",
+            ruleObj.FastAddValue("namespaceURI", new JSString(namespaceUri), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("prefix",
                 string.IsNullOrEmpty(prefix) ? JSUndefined.Value : new JSString(prefix),
                 JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddProperty((KeyString)"cssText",
+            ruleObj.FastAddProperty("cssText",
                 new DomFunction((in _) => JsStyleSheetsGetCssText026Core(namespaceUri, prefix, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@page", StringComparison.OrdinalIgnoreCase))
         {
             // CSSPageRule — type 6
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(6), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(6), JSPropertyAttributes.EnumerableConfigurableValue);
 
             var braceOpen = ruleText.IndexOf('{');
             var braceClose = ruleText.LastIndexOf('}');
@@ -588,9 +588,9 @@ internal static partial class StyleSheetBinding
                 var styleMap = DomBridge.ParseStyle(declarations);
                 var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(styleMap, ruleObj);
 
-                ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
@@ -598,15 +598,15 @@ internal static partial class StyleSheetBinding
         else
         {
             // CSSStyleRule — type 1
-            ruleObj.FastAddValue((KeyString)"type", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddValue("type", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
 
             // Extract selector text
             int braceOpen = ruleText.IndexOf('{');
             if (braceOpen >= 0)
             {
                 var selectorText = ruleText[..braceOpen].Trim();
-                ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
-                ruleObj.FastAddProperty((KeyString)"cssText",
+                ruleObj.FastAddValue("selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty("cssText",
                     new DomFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -616,7 +616,7 @@ internal static partial class StyleSheetBinding
                     var declarations = ruleText.Substring(braceOpen + 1, braceClose - braceOpen - 1).Trim();
                     var styleMap = DomBridge.ParseStyle(declarations);
                     var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(styleMap, ruleObj);
-                    ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                 }
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.cs
@@ -60,19 +60,19 @@ internal static partial class StyleSheetBinding
 
         SyncIndices();
 
-        cssRuleList.FastAddProperty((KeyString)"length",
+        cssRuleList.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(rules.Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        cssRuleList.FastAddValue((KeyString)"item",
+        cssRuleList.FastAddValue("item",
             new DomFunction((in a) => JsStyleSheetsItem008Core(rules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        cssRuleList.FastAddValue((KeyString)"insertRule",
+        cssRuleList.FastAddValue("insertRule",
             new DomFunction((in a) => JsStyleSheetsInsertRule009Core(SyncIndices, ruleFactory, rules, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        cssRuleList.FastAddValue((KeyString)"deleteRule",
+        cssRuleList.FastAddValue("deleteRule",
             new DomFunction((in a) => JsStyleSheetsDeleteRule010Core(SyncIndices, rules, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -113,24 +113,24 @@ internal static partial class StyleSheetBinding
             return BuildCssKeyframeRuleObject(CssSerializer.Serialize(rule), parentStyleSheet, parentRule);
 
         var ruleObj = new JSObject();
-        ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
+        ruleObj.FastAddProperty("parentStyleSheet",
             new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        ruleObj.FastAddProperty((KeyString)"parentRule",
+        ruleObj.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        ruleObj.FastAddValue((KeyString)"type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddValue("type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
 
         var keyText = CssomRuleMetadata.GetSelectorText(styleRule);
-        ruleObj.FastAddValue((KeyString)"keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
-        ruleObj.FastAddProperty((KeyString)"cssText",
+        ruleObj.FastAddValue("keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddProperty("cssText",
             new DomFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(DomBridge.ParseStyle(CssSerializer.Serialize(styleRule.Declarations)), ruleObj);
-        ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
 
         return ruleObj;
     }
@@ -138,22 +138,22 @@ internal static partial class StyleSheetBinding
     private static JSObject BuildCssKeyframeRuleObject(string ruleText, JSObject parentStyleSheet, JSObject parentRule)
     {
         var ruleObj = new JSObject();
-        ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
+        ruleObj.FastAddProperty("parentStyleSheet",
             new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        ruleObj.FastAddProperty((KeyString)"parentRule",
+        ruleObj.FastAddProperty("parentRule",
             new DomFunction((in _) => parentRule, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        ruleObj.FastAddValue((KeyString)"type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddValue("type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
 
         int braceOpen = ruleText.IndexOf('{');
         if (braceOpen >= 0)
         {
             var keyText = ruleText[..braceOpen].Trim();
-            ruleObj.FastAddValue((KeyString)"keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
-            ruleObj.FastAddProperty((KeyString)"cssText",
+            ruleObj.FastAddValue("keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
+            ruleObj.FastAddProperty("cssText",
                 new DomFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -163,7 +163,7 @@ internal static partial class StyleSheetBinding
                 var declarations = ruleText.Substring(braceOpen + 1, braceClose - braceOpen - 1).Trim();
                 var styleMap = DomBridge.ParseStyle(declarations);
                 var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(styleMap, ruleObj);
-                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue("style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Events.cs
@@ -19,62 +19,62 @@ internal sealed partial class SubDocumentBinding
     {
         var evt = new JSObject();
         var legacyCancelBubble = false;
-        evt.FastAddValue((KeyString)"type", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"view", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"screenX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"screenY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"clientX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"clientY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"x", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"y", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"ctrlKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"altKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"shiftKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"metaKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"key", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"location", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"repeat", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"keyCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"charCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"which", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"button", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"buttons", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaZ", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"deltaMode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("cancelable", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("defaultPrevented", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("target", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("currentTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("srcElement", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("eventPhase", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("isTrusted", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("timeStamp", new JSNumber(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("detail", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("view", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("screenX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("screenY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("clientX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("clientY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("x", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("y", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("ctrlKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("altKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("shiftKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("metaKey", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("key", new JSString(string.Empty), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("location", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("repeat", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("keyCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("charCode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("which", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("button", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("buttons", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaX", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaY", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaZ", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("deltaMode", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("relatedTarget", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue StopPropagation(in Arguments __)
         {
             legacyCancelBubble = true;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopPropagation", new DomFunction(StopPropagation, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopPropagation", new DomFunction(StopPropagation, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue StopImmediatePropagation(in Arguments __)
         {
             legacyCancelBubble = true;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation", new DomFunction(StopImmediatePropagation, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("stopImmediatePropagation", new DomFunction(StopImmediatePropagation, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue PreventDefault(in Arguments __)
         {
             evt[(KeyString)"defaultPrevented"] = JSBoolean.True;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue GetCancelBubble(in Arguments __)
         {
             return legacyCancelBubble ? JSBoolean.True : JSBoolean.False;
@@ -87,7 +87,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"cancelBubble", new DomFunction(GetCancelBubble, "get cancelBubble"), new DomFunction(SetCancelBubble, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty("cancelBubble", new DomFunction(GetCancelBubble, "get cancelBubble"), new DomFunction(SetCancelBubble, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue GetReturnValue(in Arguments __)
         {
             return evt[(KeyString)"defaultPrevented"].BooleanValue ? JSBoolean.False : JSBoolean.True;
@@ -100,7 +100,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"returnValue", new DomFunction(GetReturnValue, "get returnValue"), new DomFunction(SetReturnValue, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty("returnValue", new DomFunction(GetReturnValue, "get returnValue"), new DomFunction(SetReturnValue, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue InitEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -112,7 +112,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initEvent", new DomFunction(InitEvent, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initEvent", new DomFunction(InitEvent, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitUIEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -128,7 +128,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initUIEvent", new DomFunction(InitUIEvent, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initUIEvent", new DomFunction(InitUIEvent, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitCustomEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -141,7 +141,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initCustomEvent", new DomFunction(InitCustomEvent, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initCustomEvent", new DomFunction(InitCustomEvent, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitFocusEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -159,7 +159,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initFocusEvent", new DomFunction(InitFocusEvent, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initFocusEvent", new DomFunction(InitFocusEvent, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitKeyboardEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -202,7 +202,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initKeyboardEvent", new DomFunction(InitKeyboardEvent, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initKeyboardEvent", new DomFunction(InitKeyboardEvent, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitMouseEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -257,7 +257,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initMouseEvent", new DomFunction(InitMouseEvent, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initMouseEvent", new DomFunction(InitMouseEvent, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitWheelEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -310,7 +310,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initWheelEvent", new DomFunction(InitWheelEvent, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("initWheelEvent", new DomFunction(InitWheelEvent, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
         return evt;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
@@ -52,26 +52,26 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         // collections are the main document's, over this root's sub-tree.
         var collections = new SubDocumentCollectionHost(_host, docRoot);
 
-        doc.FastAddProperty((KeyString)"documentElement",
+        doc.FastAddProperty("documentElement",
             new DomFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } de ? _host.ToJSObject(de) : JSNull.Value, "get documentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        doc.FastAddProperty((KeyString)"scrollingElement",
+        doc.FastAddProperty("scrollingElement",
             new DomFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } se ? _host.ToJSObject(se) : JSNull.Value, "get scrollingElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // body
-        doc.FastAddProperty((KeyString)"body",
+        doc.FastAddProperty("body",
             new DomFunction((in _) => GetBody(docRoot), "get body"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // head
-        doc.FastAddProperty((KeyString)"head",
+        doc.FastAddProperty("head",
             new DomFunction((in _) => GetHead(docRoot), "get head"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // title (dynamic getter from <title> element in <head>)
-        doc.FastAddProperty((KeyString)"title",
+        doc.FastAddProperty("title",
             new DomFunction((in _) => GetTitle(docRoot), "get title"),
             new DomFunction((in a) => SetTitle(docRoot, in a), "set title"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -84,47 +84,47 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         RegisterMetadata(doc, docRoot);
 
         // childNodes
-        doc.FastAddProperty((KeyString)"childNodes",
+        doc.FastAddProperty("childNodes",
             new DomFunction((in _) => GetChildNodes(docRoot), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstChild
-        doc.FastAddProperty((KeyString)"firstChild",
+        doc.FastAddProperty("firstChild",
             new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, 0)) : JSNull.Value, "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastChild
-        doc.FastAddProperty((KeyString)"lastChild",
+        doc.FastAddProperty("lastChild",
             new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, ^1)) : JSNull.Value, "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hasChildNodes()
-        doc.FastAddValue((KeyString)"hasChildNodes",
+        doc.FastAddValue("hasChildNodes",
             new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // nodeType = DOCUMENT_NODE (9)
-        doc.FastAddProperty((KeyString)"nodeType",
+        doc.FastAddProperty("nodeType",
             new DomFunction((in _) => new JSNumber(9), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeName = "#document"
-        doc.FastAddProperty((KeyString)"nodeName",
+        doc.FastAddProperty("nodeName",
             new DomFunction((in _) => new JSString("#document"), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // localName = null for document
-        doc.FastAddProperty((KeyString)"localName",
+        doc.FastAddProperty("localName",
             DomBridge.NullFunction("get localName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getElementById(id)
-        doc.FastAddValue((KeyString)"getElementById",
+        doc.FastAddValue("getElementById",
             new DomFunction((in a) => GetElementById(docRoot, in a), "getElementById", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getElementsByTagName(tag)
-        doc.FastAddValue((KeyString)"getElementsByTagName",
+        doc.FastAddValue("getElementsByTagName",
             new DomFunction((in a) => GetElementsByTagName(docRoot, in a), "getElementsByTagName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -132,93 +132,93 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         // frame's document was missing while the main document had them. A script in a frame is a
         // script like any other: absent, these read as undefined rather than as missing methods, so
         // calling one threw and took the frame's whole <script> with it.
-        doc.FastAddValue((KeyString)"getElementsByClassName",
+        doc.FastAddValue("getElementsByClassName",
             new DomFunction((in a) => GetElementsByClassName(docRoot, in a), "getElementsByClassName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"getElementsByName",
+        doc.FastAddValue("getElementsByName",
             new DomFunction((in a) => GetElementsByName(docRoot, in a), "getElementsByName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createElement(tag)
-        doc.FastAddValue((KeyString)"createElement",
+        doc.FastAddValue("createElement",
             new DomFunction((in a) => CreateElement(docRoot, in a), "createElement", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createTextNode(text)
-        doc.FastAddValue((KeyString)"createTextNode",
+        doc.FastAddValue("createTextNode",
             new DomFunction((in a) => CreateTextNode(docRoot, in a), "createTextNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createComment(data)
-        doc.FastAddValue((KeyString)"createComment",
+        doc.FastAddValue("createComment",
             new DomFunction((in a) => CreateComment(docRoot, in a), "createComment", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createElementNS(ns, localName)
-        doc.FastAddValue((KeyString)"createElementNS",
+        doc.FastAddValue("createElementNS",
             new DomFunction((in a) => CreateElementNS(docRoot, in a), "createElementNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // adoptNode(node) — the one document method that moves a node between documents rather than
         // copying it. A frame's document needs it as much as the page's: the interesting direction is
         // adopting *into* this document, which is exactly what the page's own adoptNode cannot do.
-        doc.FastAddValue((KeyString)"adoptNode",
+        doc.FastAddValue("adoptNode",
             new DomFunction((in a) => AdoptNode(docRoot, in a), "adoptNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createEvent(type)
-        doc.FastAddValue((KeyString)"createEvent",
+        doc.FastAddValue("createEvent",
             new DomFunction((in a) => CreateEvent(in a), "createEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // querySelector / querySelectorAll
-        doc.FastAddValue((KeyString)"querySelector",
+        doc.FastAddValue("querySelector",
             new DomFunction((in a) => QuerySelector(docRoot, in a), "querySelector", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"querySelectorAll",
+        doc.FastAddValue("querySelectorAll",
             new DomFunction((in a) => QuerySelectorAll(docRoot, in a), "querySelectorAll", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"elementFromPoint",
+        doc.FastAddValue("elementFromPoint",
             new DomFunction((in a) => ElementFromPoint(docRoot, in a), "elementFromPoint", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"elementsFromPoint",
+        doc.FastAddValue("elementsFromPoint",
             new DomFunction((in a) => ElementsFromPoint(docRoot, in a), "elementsFromPoint", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.open()
-        doc.FastAddValue((KeyString)"open",
+        doc.FastAddValue("open",
             new DomFunction((in _) => Open(doc, docRoot), "open", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.close()
-        doc.FastAddValue((KeyString)"close",
+        doc.FastAddValue("close",
             DomBridge.UndefinedFunction("close", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.write(html)
-        doc.FastAddValue((KeyString)"write",
+        doc.FastAddValue("write",
             new DomFunction((in a) => Write(docRoot, in a), "write", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeChild on document
-        doc.FastAddValue((KeyString)"removeChild",
+        doc.FastAddValue("removeChild",
             new DomFunction((in a) => RemoveChild(docRoot, in a), "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // appendChild on document
-        doc.FastAddValue((KeyString)"appendChild",
+        doc.FastAddValue("appendChild",
             new DomFunction((in a) => AppendChild(docRoot, in a), "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"append",
+        doc.FastAddValue("append",
             new DomFunction((in a) => Append(docRoot, in a), "append", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        doc.FastAddValue((KeyString)"prepend",
+        doc.FastAddValue("prepend",
             new DomFunction((in a) => Prepend(docRoot, in a), "prepend", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -230,35 +230,35 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
 
         // document.implementation on sub-documents
         var subImpl = new JSObject();
-        subImpl.FastAddValue((KeyString)"hasFeature",
+        subImpl.FastAddValue("hasFeature",
             DomBridge.TrueFunction("hasFeature", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        subImpl.FastAddValue((KeyString)"createDocumentType",
+        subImpl.FastAddValue("createDocumentType",
             new DomFunction((in a) => CreateDocumentType(in a), "createDocumentType", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        subImpl.FastAddValue((KeyString)"createDocument",
+        subImpl.FastAddValue("createDocument",
             new DomFunction((in a) => CreateDocument(in a), "createDocument", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        subImpl.FastAddValue((KeyString)"createHTMLDocument",
+        subImpl.FastAddValue("createHTMLDocument",
             new DomFunction((in a) => CreateHTMLDocument(in a), "createHTMLDocument", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        doc.FastAddValue((KeyString)"implementation",
+        doc.FastAddValue("implementation",
             subImpl, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // defaultView — return the main window object so getComputedStyle is accessible
         if (_host.WindowJSObject != null)
         {
-            doc.FastAddValue((KeyString)"defaultView",
+            doc.FastAddValue("defaultView",
                 _host.WindowJSObject, JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // createTreeWalker(root, whatToShow, filter)
-        doc.FastAddValue((KeyString)"createTreeWalker",
+        doc.FastAddValue("createTreeWalker",
             new DomFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createNodeIterator(root, whatToShow, filter)
-        doc.FastAddValue((KeyString)"createNodeIterator",
+        doc.FastAddValue("createNodeIterator",
             new DomFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -266,19 +266,19 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         // Absent here, a page driving a transition inside its <iframe> through contentDocument hit a
         // TypeError that aborted the rest of its script, so the main frame's own transition never ran
         // either (WPT css-view-transitions/iframe-and-main-frame-transition-*).
-        doc.FastAddValue((KeyString)"startViewTransition",
+        doc.FastAddValue("startViewTransition",
             new DomFunction((in a) => _host.StartViewTransition(docRoot, in a), "startViewTransition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createRange()
-        doc.FastAddValue((KeyString)"createRange",
+        doc.FastAddValue("createRange",
             new DomFunction((in _) => _host.BuildRange(docRoot), "createRange", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getSelection() — this document's own selection, distinct from the containing page's. The
         // method exists on every document, but only one being displayed has a selection to report, so
         // a createDocument/createHTMLDocument result answers null; the host draws that line.
-        doc.FastAddValue((KeyString)"getSelection",
+        doc.FastAddValue("getSelection",
             new DomFunction((in _) => _host.GetSelection(docRoot), "getSelection", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -325,7 +325,7 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
 
         void Getter(string name, Func<JSValue> read) =>
             doc.FastAddProperty(
-                (KeyString)name, new DomFunction((in _) => read(), $"get {name}"), null,
+                name, new DomFunction((in _) => read(), $"get {name}"), null,
                 JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 
@@ -344,14 +344,14 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
     private void RegisterMetadata(JSObject doc, DomNode docRoot)
     {
         doc.FastAddProperty(
-            (KeyString)"doctype",
+            "doctype",
             new DomFunction((in _) => DocumentTypeNode(docRoot) is { } doctype ? _host.ToJSObject(doctype) : JSNull.Value, "get doctype"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // HTML §3.2.6: the getter is limited to only known values — the canonical lower-case keyword
         // or the empty string — while the setter writes the assigned text through unchanged.
         doc.FastAddProperty(
-            (KeyString)"dir",
+            "dir",
             new DomFunction((in _) => new JSString(DocumentDirection(docRoot)), "get dir"),
             new DomFunction((in a) =>
             {
@@ -365,7 +365,7 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         // (ASCII case-insensitively) is ignored rather than stored.
         var designMode = "off";
         doc.FastAddProperty(
-            (KeyString)"designMode",
+            "designMode",
             new DomFunction((in _) => new JSString(designMode), "get designMode"),
             new DomFunction((in a) =>
             {

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -143,7 +143,7 @@ internal sealed class SubWindowBinding(
         _messaging.InstallEventTargetApi(subWindow, "DomBridge.subWindow.dispatchEvent");
         _messaging.RegisterWindowMessaging(subWindow);
 
-        subWindow.FastAddProperty((KeyString)"document",
+        subWindow.FastAddProperty("document",
             new DomFunction((in _) => _host.GetOrCreateSubDocument(containerElement), "get document"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
@@ -152,37 +152,37 @@ internal sealed class SubWindowBinding(
         // as a top-level one and a missing method is a TypeError that takes its caller with it.
         var locationHref = GetSubWindowLocationHref(containerElement);
         var iframeLocation = LocationBinding.Build(locationHref);
-        subWindow.FastAddValue((KeyString)"location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        subWindow.FastAddProperty((KeyString)"scrollX", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"scrollY", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"pageXOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"pageYOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty("scrollX", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty("scrollY", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty("pageXOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty("pageYOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        subWindow.FastAddValue((KeyString)"scroll", new DomFunction((in a) => Scroll(containerElement, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        subWindow.FastAddValue((KeyString)"scrollTo", new DomFunction((in a) => ScrollTo(containerElement, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        subWindow.FastAddValue((KeyString)"scrollBy", new DomFunction((in a) => ScrollBy(containerElement, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("scroll", new DomFunction((in a) => Scroll(containerElement, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("scrollTo", new DomFunction((in a) => ScrollTo(containerElement, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("scrollBy", new DomFunction((in a) => ScrollBy(containerElement, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        subWindow.FastAddValue((KeyString)"self", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
-        subWindow.FastAddValue((KeyString)"window", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("self", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("window", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        subWindow.FastAddValue((KeyString)"globalThis", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("globalThis", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
         foreach (var ctorName in MirroredGlobals)
         {
             if (_host.GetGlobal(ctorName) is { } ctor)
-                subWindow.FastAddValue((KeyString)ctorName, ctor, JSPropertyAttributes.EnumerableConfigurableValue);
+                subWindow.FastAddValue(ctorName, ctor, JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         var parentWindow = GetParentWindowForSubDocument(containerElement);
         if (parentWindow != null)
         {
-            subWindow.FastAddValue((KeyString)"parent", parentWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+            subWindow.FastAddValue("parent", parentWindow, JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
-        subWindow.FastAddValue((KeyString)"top", _host.WindowJSObject ?? subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue("top", _host.WindowJSObject ?? subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        subDocument.FastAddValue((KeyString)"defaultView", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+        subDocument.FastAddValue("defaultView", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.getSelection — the frame's own selection, distinct from the containing page's. It is
         // literally the document's function rather than a second one over the same root, so
@@ -190,18 +190,18 @@ internal sealed class SubWindowBinding(
         if (subDocument[(KeyString)"getSelection"] is { } documentGetSelection)
         {
             subWindow.FastAddValue(
-                (KeyString)"getSelection", documentGetSelection, JSPropertyAttributes.EnumerableConfigurableValue);
+                "getSelection", documentGetSelection, JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // The frame's document shares its window's Location, as the main document shares the main
         // window's. A framed page reads `document.location` for its origin exactly as a top-level
         // one does, and undefined there throws rather than reading as absent.
-        subDocument.FastAddValue((KeyString)"location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
+        subDocument.FastAddValue("location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.getComputedStyle — sub-window needs its own copy so that
         // doc.defaultView.getComputedStyle(node, "") resolves CSS rules from
         // the sub-document's <style> elements rather than the main document.
-        subWindow.FastAddValue((KeyString)"getComputedStyle", new DomFunction((in a) => GetComputedStyle(in a), "getComputedStyle", 2),
+        subWindow.FastAddValue("getComputedStyle", new DomFunction((in a) => GetComputedStyle(in a), "getComputedStyle", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Last, so the bridge's own members are already in place and win over a same-named

--- a/src/Broiler.HtmlBridge.Dom/Features/SvgElementBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SvgElementBinding.cs
@@ -51,7 +51,7 @@ internal static class SvgElementBinding
         foreach (var dimAttr in new[] { "width", "height", "x", "y", "cx", "cy", "r", "rx", "ry" })
         {
             var attrName = dimAttr; // capture for closure
-            obj.FastAddProperty((KeyString)attrName,
+            obj.FastAddProperty(attrName,
                 new DomFunction((in _) => BuildAnimatedLength(attrName, element), $"get {attrName}"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
@@ -59,7 +59,7 @@ internal static class SvgElementBinding
         // SVG viewBox attribute — returns SVGAnimatedRect with baseVal {x,y,width,height}
         if (tag == "svg" || tag == "svg:svg")
         {
-            obj.FastAddProperty((KeyString)"viewBox",
+            obj.FastAddProperty("viewBox",
                 new DomFunction((in _) => GetViewBox(element), "get viewBox"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
@@ -68,32 +68,32 @@ internal static class SvgElementBinding
         if (tag == "text" || tag == "svg:text" || tag == "tspan" || tag == "svg:tspan" ||
             tag == "textpath" || tag == "svg:textpath")
         {
-            obj.FastAddValue((KeyString)"getNumberOfChars",
+            obj.FastAddValue("getNumberOfChars",
                 new DomFunction((in _) => GetNumberOfChars(element), "getNumberOfChars", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getComputedTextLength() — returns estimated total advance width
-            obj.FastAddValue((KeyString)"getComputedTextLength",
+            obj.FastAddValue("getComputedTextLength",
                 new DomFunction((in _) => GetComputedTextLength(element), "getComputedTextLength", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getSubStringLength(charnum, nchars) — returns advance width of substring
-            obj.FastAddValue((KeyString)"getSubStringLength",
+            obj.FastAddValue("getSubStringLength",
                 new DomFunction((in a) => GetSubStringLength(element, in a), "getSubStringLength", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getStartPositionOfChar(charnum) — returns SVGPoint {x, y}
-            obj.FastAddValue((KeyString)"getStartPositionOfChar",
+            obj.FastAddValue("getStartPositionOfChar",
                 new DomFunction((in a) => GetStartPositionOfChar(element, in a), "getStartPositionOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getEndPositionOfChar(charnum) — returns SVGPoint {x, y}
-            obj.FastAddValue((KeyString)"getEndPositionOfChar",
+            obj.FastAddValue("getEndPositionOfChar",
                 new DomFunction((in a) => GetEndPositionOfChar(element, in a), "getEndPositionOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getRotationOfChar(charnum) — returns rotation angle in degrees
-            obj.FastAddValue((KeyString)"getRotationOfChar",
+            obj.FastAddValue("getRotationOfChar",
                 new DomFunction((in a) => GetRotationOfChar(element, in a), "getRotationOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -103,11 +103,11 @@ internal static class SvgElementBinding
         {
             double currentTime = 0;
 
-            obj.FastAddValue((KeyString)"getCurrentTime",
+            obj.FastAddValue("getCurrentTime",
                 new DomFunction((in _) => new JSNumber(currentTime), "getCurrentTime", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"setCurrentTime",
+            obj.FastAddValue("setCurrentTime",
                 new DomFunction((in a) => SetCurrentTime(ref currentTime, in a), "setCurrentTime", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -118,15 +118,15 @@ internal static class SvgElementBinding
             tag == "animatetransform" || tag == "svg:animatetransform" ||
             tag == "animatemotion" || tag == "svg:animatemotion")
         {
-            obj.FastAddValue((KeyString)"beginElement",
+            obj.FastAddValue("beginElement",
                 DomBridge.UndefinedFunction("beginElement", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"endElement",
+            obj.FastAddValue("endElement",
                 DomBridge.UndefinedFunction("endElement", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
-            obj.FastAddValue((KeyString)"getStartTime",
+            obj.FastAddValue("getStartTime",
                 DomBridge.ZeroFunction("getStartTime", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
@@ -140,8 +140,8 @@ internal static class SvgElementBinding
         double.TryParse(valueStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var numVal);
         var baseVal = CreateSvgLengthValue(numVal);
         var animVal = CreateSvgLengthValue(numVal);
-        animLength.FastAddValue((KeyString)"baseVal", baseVal, JSPropertyAttributes.EnumerableConfigurableValue);
-        animLength.FastAddValue((KeyString)"animVal", animVal, JSPropertyAttributes.EnumerableConfigurableValue);
+        animLength.FastAddValue("baseVal", baseVal, JSPropertyAttributes.EnumerableConfigurableValue);
+        animLength.FastAddValue("animVal", animVal, JSPropertyAttributes.EnumerableConfigurableValue);
         return animLength;
     }
 
@@ -163,12 +163,12 @@ internal static class SvgElementBinding
             }
         }
 
-        baseRect.FastAddValue((KeyString)"x", new JSNumber(vbX), JSPropertyAttributes.EnumerableConfigurableValue);
-        baseRect.FastAddValue((KeyString)"y", new JSNumber(vbY), JSPropertyAttributes.EnumerableConfigurableValue);
-        baseRect.FastAddValue((KeyString)"width", new JSNumber(vbW), JSPropertyAttributes.EnumerableConfigurableValue);
-        baseRect.FastAddValue((KeyString)"height", new JSNumber(vbH), JSPropertyAttributes.EnumerableConfigurableValue);
-        animRect.FastAddValue((KeyString)"baseVal", baseRect, JSPropertyAttributes.EnumerableConfigurableValue);
-        animRect.FastAddValue((KeyString)"animVal", baseRect, JSPropertyAttributes.EnumerableConfigurableValue);
+        baseRect.FastAddValue("x", new JSNumber(vbX), JSPropertyAttributes.EnumerableConfigurableValue);
+        baseRect.FastAddValue("y", new JSNumber(vbY), JSPropertyAttributes.EnumerableConfigurableValue);
+        baseRect.FastAddValue("width", new JSNumber(vbW), JSPropertyAttributes.EnumerableConfigurableValue);
+        baseRect.FastAddValue("height", new JSNumber(vbH), JSPropertyAttributes.EnumerableConfigurableValue);
+        animRect.FastAddValue("baseVal", baseRect, JSPropertyAttributes.EnumerableConfigurableValue);
+        animRect.FastAddValue("animVal", baseRect, JSPropertyAttributes.EnumerableConfigurableValue);
         return animRect;
     }
 
@@ -212,8 +212,8 @@ internal static class SvgElementBinding
         var fontSize = ReadFontSize(element);
 
         var pt = new JSObject();
-        pt.FastAddValue((KeyString)"x", new JSNumber(charnum * fontSize * 0.6), JSPropertyAttributes.EnumerableConfigurableValue);
-        pt.FastAddValue((KeyString)"y", new JSNumber(fontSize), JSPropertyAttributes.EnumerableConfigurableValue);
+        pt.FastAddValue("x", new JSNumber(charnum * fontSize * 0.6), JSPropertyAttributes.EnumerableConfigurableValue);
+        pt.FastAddValue("y", new JSNumber(fontSize), JSPropertyAttributes.EnumerableConfigurableValue);
         return pt;
     }
 
@@ -227,8 +227,8 @@ internal static class SvgElementBinding
         var fontSize = ReadFontSize(element);
 
         var pt = new JSObject();
-        pt.FastAddValue((KeyString)"x", new JSNumber((charnum + 1) * fontSize * 0.6), JSPropertyAttributes.EnumerableConfigurableValue);
-        pt.FastAddValue((KeyString)"y", new JSNumber(fontSize), JSPropertyAttributes.EnumerableConfigurableValue);
+        pt.FastAddValue("x", new JSNumber((charnum + 1) * fontSize * 0.6), JSPropertyAttributes.EnumerableConfigurableValue);
+        pt.FastAddValue("y", new JSNumber(fontSize), JSPropertyAttributes.EnumerableConfigurableValue);
         return pt;
     }
 
@@ -267,20 +267,20 @@ internal static class SvgElementBinding
     private static JSObject CreateSvgLengthValue(double numericValue)
     {
         var svgLength = new JSObject();
-        svgLength.FastAddValue((KeyString)"value", new JSNumber(numericValue), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"valueInSpecifiedUnits", new JSNumber(numericValue), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"unitType", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_UNKNOWN", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_NUMBER", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_PERCENTAGE", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_EMS", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_EXS", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_PX", new JSNumber(5), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_CM", new JSNumber(6), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_MM", new JSNumber(7), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_IN", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_PT", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
-        svgLength.FastAddValue((KeyString)"SVG_LENGTHTYPE_PC", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("value", new JSNumber(numericValue), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("valueInSpecifiedUnits", new JSNumber(numericValue), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("unitType", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_UNKNOWN", new JSNumber(0), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_NUMBER", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_PERCENTAGE", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_EMS", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_EXS", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_PX", new JSNumber(5), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_CM", new JSNumber(6), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_MM", new JSNumber(7), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_IN", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_PT", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
+        svgLength.FastAddValue("SVG_LENGTHTYPE_PC", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
         return svgLength;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/TableBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TableBinding.cs
@@ -31,37 +31,37 @@ internal sealed class TableBinding(ITableHost host)
         // HTMLTableElement interface
         if (tag == "table")
         {
-            obj.FastAddProperty((KeyString)"caption", new DomFunction((in _) => GetCaption(element), "get caption"), DomBridge.UndefinedFunction("set caption"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tHead", new DomFunction((in _) => GetTHead(element), "get tHead"), DomBridge.UndefinedFunction("set tHead"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tFoot", new DomFunction((in _) => GetTFoot(element), "get tFoot"), DomBridge.UndefinedFunction("set tFoot"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tBodies", new DomFunction((in _) => GetTBodies(element), "get tBodies"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("caption", new DomFunction((in _) => GetCaption(element), "get caption"), DomBridge.UndefinedFunction("set caption"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("tHead", new DomFunction((in _) => GetTHead(element), "get tHead"), DomBridge.UndefinedFunction("set tHead"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("tFoot", new DomFunction((in _) => GetTFoot(element), "get tFoot"), DomBridge.UndefinedFunction("set tFoot"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("tBodies", new DomFunction((in _) => GetTBodies(element), "get tBodies"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
             // rows (read-only) — all <tr> in spec order: thead rows, then tbody/direct-tr rows, then tfoot rows
-            obj.FastAddProperty((KeyString)"rows", new DomFunction((in _) => BuildTableRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"createCaption", new DomFunction((in _) => CreateCaption(element), "createCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"createTHead", new DomFunction((in _) => CreateTHead(element), "createTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"createTFoot", new DomFunction((in _) => CreateTFoot(element), "createTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteCaption", new DomFunction((in _) => DeleteCaption(element), "deleteCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteTHead", new DomFunction((in _) => DeleteTHead(element), "deleteTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteTFoot", new DomFunction((in _) => DeleteTFoot(element), "deleteTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"insertRow", new DomFunction((in a) => TableInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteRow", new DomFunction((in a) => TableDeleteRow(element, in a), "deleteRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty("rows", new DomFunction((in _) => BuildTableRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue("createCaption", new DomFunction((in _) => CreateCaption(element), "createCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("createTHead", new DomFunction((in _) => CreateTHead(element), "createTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("createTFoot", new DomFunction((in _) => CreateTFoot(element), "createTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("deleteCaption", new DomFunction((in _) => DeleteCaption(element), "deleteCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("deleteTHead", new DomFunction((in _) => DeleteTHead(element), "deleteTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("deleteTFoot", new DomFunction((in _) => DeleteTFoot(element), "deleteTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("insertRow", new DomFunction((in a) => TableInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("deleteRow", new DomFunction((in a) => TableDeleteRow(element, in a), "deleteRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // HTMLTableSectionElement (thead, tbody, tfoot) — rows and insertRow
         if (tag == "thead" || tag == "tbody" || tag == "tfoot")
         {
-            obj.FastAddProperty((KeyString)"rows", new DomFunction((in _) => SectionGetRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"insertRow", new DomFunction((in a) => SectionInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty("rows", new DomFunction((in _) => SectionGetRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue("insertRow", new DomFunction((in a) => SectionInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // HTMLTableRowElement (tr) — rowIndex, sectionRowIndex, cells, insertCell, deleteCell
         if (tag == "tr")
         {
-            obj.FastAddProperty((KeyString)"rowIndex", new DomFunction((in _) => RowGetRowIndex(element), "get rowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"sectionRowIndex", new DomFunction((in _) => RowGetSectionRowIndex(element), "get sectionRowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"cells", new DomFunction((in _) => RowGetCells(element), "get cells"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"insertCell", new DomFunction((in a) => RowInsertCell(element, in a), "insertCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteCell", new DomFunction((in a) => RowDeleteCell(element, in a), "deleteCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty("rowIndex", new DomFunction((in _) => RowGetRowIndex(element), "get rowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("sectionRowIndex", new DomFunction((in _) => RowGetSectionRowIndex(element), "get sectionRowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty("cells", new DomFunction((in _) => RowGetCells(element), "get cells"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue("insertCell", new DomFunction((in a) => RowInsertCell(element, in a), "insertCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue("deleteCell", new DomFunction((in a) => RowDeleteCell(element, in a), "deleteCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
     }
 
@@ -277,7 +277,7 @@ internal sealed class TableBinding(ITableHost host)
 
     private static JSObject WithLength(JSArray array, int length)
     {
-        array.FastAddProperty((KeyString)"length",
+        array.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(length), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         return array;

--- a/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
@@ -185,10 +185,10 @@ internal static class TimerBinding
         var enteredAt = Stopwatch.GetTimestamp();
 
         var deadline = new JSObject();
-        deadline.FastAddValue((KeyString)"didTimeout",
+        deadline.FastAddValue("didTimeout",
             didTimeout ? JSBoolean.True : JSBoolean.False,
             JSPropertyAttributes.EnumerableConfigurableValue);
-        deadline.FastAddValue((KeyString)"timeRemaining",
+        deadline.FastAddValue("timeRemaining",
             new DomFunction((in _) => new JSNumber(
                 Math.Max(0, IdleBudgetMs - Stopwatch.GetElapsedTime(enteredAt).TotalMilliseconds)),
                 "timeRemaining", 0),

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.RangeInterface.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.RangeInterface.cs
@@ -252,7 +252,7 @@ internal sealed partial class TraversalBinding
         // Range's own attribute rather than AbstractRange's, so it reads the live range — a
         // StaticRange has no common ancestor to report and is not asked for one.
         prototype.FastAddProperty(
-            (KeyString)"commonAncestorContainer",
+            "commonAncestorContainer",
             new DomFunction(
                 (in a) => RangeGetCommonAncestorContainer(StateFor(in a, "commonAncestorContainer")),
                 "get commonAncestorContainer"),
@@ -290,7 +290,7 @@ internal sealed partial class TraversalBinding
 
     private void Method(JSObject prototype, string name, int length, RangeOperation body) =>
         prototype.FastAddValue(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => body(StateFor(in a, name), in a), name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -300,7 +300,7 @@ internal sealed partial class TraversalBinding
     /// </summary>
     private void Getter(JSObject prototype, string name, Func<IRangeBoundaries, ITraversalHost, JSValue> read) =>
         prototype.FastAddProperty(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => read(BoundariesFor(in a, name), _host), $"get {name}"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Selection.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Selection.cs
@@ -179,13 +179,13 @@ internal sealed partial class TraversalBinding
 
     private void SelectionMethod(JSObject prototype, string name, int length, SelectionOperation body) =>
         prototype.FastAddValue(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => body(SelectionFor(in a, name), in a), name, length),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
     private void SelectionGetter(JSObject prototype, string name, Func<SelectionState, ITraversalHost, JSValue> read) =>
         prototype.FastAddProperty(
-            (KeyString)name,
+            name,
             new DomFunction((in a) => read(SelectionFor(in a, name), _host), $"get {name}"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
@@ -38,42 +38,42 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
     {
         // NodeFilter constants
         var nodeFilter = new JSObject();
-        nodeFilter.FastAddValue((KeyString)"FILTER_ACCEPT", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"FILTER_REJECT", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"FILTER_SKIP", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_ALL", new JSNumber(0xFFFFFFFF), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_ELEMENT", new JSNumber(0x1), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_ATTRIBUTE", new JSNumber(0x2), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_TEXT", new JSNumber(0x4), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_CDATA_SECTION", new JSNumber(0x8), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_ENTITY_REFERENCE", new JSNumber(0x10), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_ENTITY", new JSNumber(0x20), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_PROCESSING_INSTRUCTION", new JSNumber(0x40), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_COMMENT", new JSNumber(0x80), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_DOCUMENT", new JSNumber(0x100), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_DOCUMENT_TYPE", new JSNumber(0x200), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_DOCUMENT_FRAGMENT", new JSNumber(0x400), JSPropertyAttributes.EnumerableConfigurableValue);
-        nodeFilter.FastAddValue((KeyString)"SHOW_NOTATION", new JSNumber(0x800), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("FILTER_ACCEPT", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("FILTER_REJECT", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("FILTER_SKIP", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_ALL", new JSNumber(0xFFFFFFFF), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_ELEMENT", new JSNumber(0x1), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_ATTRIBUTE", new JSNumber(0x2), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_TEXT", new JSNumber(0x4), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_CDATA_SECTION", new JSNumber(0x8), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_ENTITY_REFERENCE", new JSNumber(0x10), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_ENTITY", new JSNumber(0x20), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_PROCESSING_INSTRUCTION", new JSNumber(0x40), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_COMMENT", new JSNumber(0x80), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_DOCUMENT", new JSNumber(0x100), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_DOCUMENT_TYPE", new JSNumber(0x200), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_DOCUMENT_FRAGMENT", new JSNumber(0x400), JSPropertyAttributes.EnumerableConfigurableValue);
+        nodeFilter.FastAddValue("SHOW_NOTATION", new JSNumber(0x800), JSPropertyAttributes.EnumerableConfigurableValue);
         context["NodeFilter"] = nodeFilter;
 
         // document.createTreeWalker(root, whatToShow, filter)
         document.FastAddValue(
-            (KeyString)"createTreeWalker",
+            "createTreeWalker",
             new DomFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createNodeIterator(root, whatToShow, filter)
         document.FastAddValue(
-            (KeyString)"createNodeIterator",
+            "createNodeIterator",
             new DomFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createRange()
         document.FastAddValue(
-            (KeyString)"createRange",
+            "createRange",
             new DomFunction((in _) => BuildRange(), "createRange", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createComment(data)
         document.FastAddValue(
-            (KeyString)"createComment",
+            "createComment",
             new DomFunction((in a) => CreateComment(in a), "createComment", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -83,7 +83,7 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
         // this is only reachable from page script, which runs after that.
         var getSelection = new DomFunction((in _) => GetSelection(), "getSelection", 0);
         document.FastAddValue(
-            (KeyString)"getSelection", getSelection, JSPropertyAttributes.EnumerableConfigurableValue);
+            "getSelection", getSelection, JSPropertyAttributes.EnumerableConfigurableValue);
         context["getSelection"] = getSelection;
     }
 
@@ -163,11 +163,11 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             (DomWhatToShow)(uint)whatToShow,
             node => (DomFilterResult)ApplyFilter(node, whatToShow, filterFn));
 
-        tw.FastAddValue((KeyString)"root",
+        tw.FastAddValue("root",
             _host.ToJSObject(root),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        tw.FastAddProperty((KeyString)"currentNode",
+        tw.FastAddProperty("currentNode",
             new DomFunction((in a) => _host.ToJSObject(walker.CurrentNode), "get currentNode"),
             new DomFunction((in a) =>
             {
@@ -180,31 +180,31 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             }, "set currentNode"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        tw.FastAddValue((KeyString)"whatToShow",
+        tw.FastAddValue("whatToShow",
             new JSNumber(whatToShow),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        tw.FastAddValue((KeyString)"parentNode",
+        tw.FastAddValue("parentNode",
             new DomFunction((in a) => ToTraversalJsValue(walker.ParentNode()), "parentNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        tw.FastAddValue((KeyString)"firstChild",
+        tw.FastAddValue("firstChild",
             new DomFunction((in a) => ToTraversalJsValue(walker.FirstChild()), "firstChild", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        tw.FastAddValue((KeyString)"lastChild",
+        tw.FastAddValue("lastChild",
             new DomFunction((in a) => ToTraversalJsValue(walker.LastChild()), "lastChild", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        tw.FastAddValue((KeyString)"nextSibling",
+        tw.FastAddValue("nextSibling",
             new DomFunction((in a) => ToTraversalJsValue(walker.NextSibling()), "nextSibling", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        tw.FastAddValue((KeyString)"previousSibling",
+        tw.FastAddValue("previousSibling",
             new DomFunction((in a) => ToTraversalJsValue(walker.PreviousSibling()), "previousSibling", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // nextNode() — depth-first pre-order traversal forward
-        tw.FastAddValue((KeyString)"nextNode",
+        tw.FastAddValue("nextNode",
             new DomFunction((in a) => ToTraversalJsValue(walker.NextNode()), "nextNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // previousNode() — depth-first pre-order traversal backward
-        tw.FastAddValue((KeyString)"previousNode",
+        tw.FastAddValue("previousNode",
             new DomFunction((in a) => ToTraversalJsValue(walker.PreviousNode()), "previousNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -226,29 +226,29 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             (DomWhatToShow)(uint)whatToShow,
             node => (DomFilterResult)ApplyFilter(node, whatToShow, filterFn));
 
-        iter.FastAddValue((KeyString)"root",
+        iter.FastAddValue("root",
             _host.ToJSObject(root),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        iter.FastAddValue((KeyString)"whatToShow",
+        iter.FastAddValue("whatToShow",
             new JSNumber(whatToShow),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        iter.FastAddProperty((KeyString)"referenceNode",
+        iter.FastAddProperty("referenceNode",
             new DomFunction((in a) => ToTraversalJsValue(iterator.ReferenceNode), "get referenceNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        iter.FastAddProperty((KeyString)"pointerBeforeReferenceNode",
+        iter.FastAddProperty("pointerBeforeReferenceNode",
             new DomFunction((in a) => iterator.PointerBeforeReferenceNode ? JSBoolean.True : JSBoolean.False, "get pointerBeforeReferenceNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        iter.FastAddValue((KeyString)"nextNode",
+        iter.FastAddValue("nextNode",
             new DomFunction((in a) => ToTraversalJsValue(iterator.NextNode()), "nextNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        iter.FastAddValue((KeyString)"previousNode",
+        iter.FastAddValue("previousNode",
             new DomFunction((in a) => ToTraversalJsValue(iterator.PreviousNode()), "previousNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
-        iter.FastAddValue((KeyString)"detach",
+        iter.FastAddValue("detach",
             new DomFunction((in a) =>
             {
                 iterator.Dispose();

--- a/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
@@ -54,27 +54,27 @@ internal static class WebStorageBinding
         // `Object.keys(storage)` yield keys alone. Bridge objects carry their members directly
         // (see RegisterDomInterfaceConstructors), so hiding them from enumeration is what keeps a
         // page that iterates a storage area from finding four methods among its keys.
-        storage.FastAddValue((KeyString)"getItem",
+        storage.FastAddValue("getItem",
             new DomFunction((in a) => GetItem(storage, in a), "getItem", 1),
             JSPropertyAttributes.ConfigurableValue);
 
-        storage.FastAddValue((KeyString)"setItem",
+        storage.FastAddValue("setItem",
             new DomFunction((in a) => SetItem(storage, in a), "setItem", 2),
             JSPropertyAttributes.ConfigurableValue);
 
-        storage.FastAddValue((KeyString)"removeItem",
+        storage.FastAddValue("removeItem",
             new DomFunction((in a) => RemoveItem(storage, in a), "removeItem", 1),
             JSPropertyAttributes.ConfigurableValue);
 
-        storage.FastAddValue((KeyString)"clear",
+        storage.FastAddValue("clear",
             new DomFunction((in a) => Clear(storage, in a), "clear", 0),
             JSPropertyAttributes.ConfigurableValue);
 
-        storage.FastAddValue((KeyString)"key",
+        storage.FastAddValue("key",
             new DomFunction((in a) => Key(storage, in a), "key", 1),
             JSPropertyAttributes.ConfigurableValue);
 
-        storage.FastAddProperty((KeyString)"length",
+        storage.FastAddProperty("length",
             new DomFunction((in _) => new JSNumber(storage.Count), "get length"),
             null,
             JSPropertyAttributes.ConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/Features/WindowBarPropBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WindowBarPropBinding.cs
@@ -49,7 +49,7 @@ internal static class WindowBarPropBinding
     public static void Install(JSObject window)
     {
         foreach (var name in BarNames)
-            window.FastAddValue((KeyString)name, Build(), JSPropertyAttributes.EnumerableConfigurableValue);
+            window.FastAddValue(name, Build(), JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
     /// <summary>One <c>BarProp</c>. Each member gets its own object, as in a browser.</summary>
@@ -57,7 +57,7 @@ internal static class WindowBarPropBinding
     {
         var bar = new JSObject();
 
-        bar.FastAddProperty((KeyString)"visible",
+        bar.FastAddProperty("visible",
             new DomFunction((in _) => JSBoolean.False, "get visible"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/WorkerBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WorkerBinding.cs
@@ -76,7 +76,7 @@ internal sealed class WorkerBinding : IDisposable
     public void Register(JSContext context, JSObject window)
     {
         var ctor = new JSFunction((in a) => CreateWorker(in a), "Worker", 1);
-        window.FastAddValue((KeyString)"Worker", ctor, JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue("Worker", ctor, JSPropertyAttributes.EnumerableConfigurableValue);
         context["Worker"] = ctor;
     }
 
@@ -143,7 +143,7 @@ internal sealed class WorkerBinding : IDisposable
     private void InstallWorkerHandle(JSObject handle, JSWorker? worker)
     {
         handle.FastAddValue(
-            (KeyString)"postMessage",
+            "postMessage",
             new JSFunction((in a) =>
             {
                 if (worker is null)
@@ -167,18 +167,18 @@ internal sealed class WorkerBinding : IDisposable
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         handle.FastAddValue(
-            (KeyString)"terminate",
+            "terminate",
             new JSFunction((in _) => { worker?.Terminate(); return JSUndefined.Value; }, "terminate", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        handle.FastAddValue((KeyString)"onmessage", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
-        handle.FastAddValue((KeyString)"onerror", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        handle.FastAddValue("onmessage", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
+        handle.FastAddValue("onerror", JSNull.Value, JSPropertyAttributes.EnumerableConfigurableValue);
 
         // addEventListener is accepted for the two event types this slice fires, so page code
         // written the idiomatic way works rather than silently registering nothing.
         var listeners = new List<(string Type, JSFunction Fn)>();
         handle.FastAddValue(
-            (KeyString)"addEventListener",
+            "addEventListener",
             new JSFunction((in a) =>
             {
                 if (a.Length >= 2 && a[1] is JSFunction fn)
@@ -235,8 +235,8 @@ internal sealed class WorkerBinding : IDisposable
         }
 
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"data", materialized, JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("message"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("data", materialized, JSPropertyAttributes.EnumerableConfigurableValue);
 
         Invoke(handle, "onmessage", "message", evt);
     }
@@ -244,8 +244,8 @@ internal sealed class WorkerBinding : IDisposable
     internal void FireErrorEvent(JSObject handle, string message)
     {
         var evt = new JSObject();
-        evt.FastAddValue((KeyString)"type", new JSString("error"), JSPropertyAttributes.EnumerableConfigurableValue);
-        evt.FastAddValue((KeyString)"message", new JSString(message), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("type", new JSString("error"), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue("message", new JSString(message), JSPropertyAttributes.EnumerableConfigurableValue);
         Invoke(handle, "onerror", "error", evt);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/WorkerTransfer.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WorkerTransfer.cs
@@ -93,7 +93,7 @@ internal static class WorkerTransfer
             return JSUndefined.Value;
 
         var cloneOptions = new JSObject();
-        cloneOptions.FastAddValue((KeyString)"transfer", new JSArray(buffers), JSPropertyAttributes.EnumerableConfigurableValue);
+        cloneOptions.FastAddValue("transfer", new JSArray(buffers), JSPropertyAttributes.EnumerableConfigurableValue);
         return cloneOptions;
     }
 }

--- a/src/Broiler.HtmlBridge.Scripting/ScriptEngine/JsFunctionCallbacks.cs
+++ b/src/Broiler.HtmlBridge.Scripting/ScriptEngine/JsFunctionCallbacks.cs
@@ -44,7 +44,7 @@ public sealed partial class ScriptEngine
                     return weakRef.TryGetTarget(out var t) ? t : JSUndefined.Value;
                 }
 
-                instance.FastAddValue((KeyString)"deref", new JSFunction(JsScriptEngineDeref003, "deref", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+                instance.FastAddValue("deref", new JSFunction(JsScriptEngineDeref003, "deref", 0), JSPropertyAttributes.EnumerableConfigurableValue);
                 return instance;
             }
 
@@ -60,14 +60,14 @@ public sealed partial class ScriptEngine
                 }
 
                 // register(target, heldValue [, unregisterToken])
-                instance.FastAddValue((KeyString)"register", new JSFunction(JsScriptEngineRegister005, "register", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+                instance.FastAddValue("register", new JSFunction(JsScriptEngineRegister005, "register", 3), JSPropertyAttributes.EnumerableConfigurableValue);
                 JSValue JsScriptEngineUnregister006(in Arguments unregArgs)
                 {
                     return JSBoolean.False;
                 }
 
                 // unregister(unregisterToken)
-                instance.FastAddValue((KeyString)"unregister", new JSFunction(JsScriptEngineUnregister006, "unregister", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+                instance.FastAddValue("unregister", new JSFunction(JsScriptEngineUnregister006, "unregister", 1), JSPropertyAttributes.EnumerableConfigurableValue);
                 return instance;
             }
 


### PR DESCRIPTION
## What

Removes **1286 `(KeyString)` casts across 85 files** — 954 on `FastAddValue`, 332 on `FastAddProperty` — plus the same cleanup in the `Broiler.JS` submodule (pointer bumped).

The bulk is `src/Broiler.HtmlBridge.Dom`, where nearly every WebIDL member installation was written `obj.FastAddValue((KeyString)"splitText", …)`.

## Why

`KeyString` already declares an implicit conversion from `string`:

```csharp
// Broiler.JavaScript.Storage/KeyString.cs:23
public static implicit operator KeyString(string value) => KeyStrings.GetOrCreate(value);
```

The sibling overloads take `uint`, `IJSSymbol` and `JSValue` — `string` converts to none of them — so the cast never disambiguated anything. It invoked the same implicit operator the compiler applies on its own and emitted the same call. Five call sites in the tree (`JSProxy.cs:947-948`, `ClrType.cs:276/281/282`) were already written without it and compiled fine; the casts accumulated through routine refactors rather than a deliberate decision.

An explicit `FastAddValue(string, …)` overload was considered and rejected: it would be redundant API surface delegating to the same operator.

## Reviewer notes

- **Pure syntax.** No behaviour change, no signature change, no public API change.
- **Mechanically verified**, not eyeballed: every staged line differs from its original *only* by the removed cast. Confirmed by diffing the removed lines with the cast text stripped against the added lines — exact match.
- **Line endings untouched.** This matters: several of these files are CRLF or mixed CRLF/LF, where a careless editor rewrite normalizes the whole file. 1286 casts produce 1258 changed lines (a few lines carried two), not thousands.
- Covers both the single-line form and the wrapped form where the cast sits on its own line after `FastAddValue(`.
- Six `(KeyString)` casts remain in the tree on unrelated methods (`Delete`, `SetValue`, `InvokeMethod`) — deliberately out of scope.

## Verification

- `Broiler.Cli.slnx` and `Broiler.HtmlBridge.Scripting` build clean, 0 errors.
- `Broiler.Cli.Tests`: baseline **55** failures on unmodified `main` → **48** with this change, on the same machine. Eight baseline failures disappeared and one appeared (`VectorSkinPlatformApiTests.An_Idle_Callback_Is_Handed_A_Deadline_It_Can_Read`), which passes in isolation — timing flake under the parallel run, in both directions. No regression.

## Follow-up this exposes

The cast was never the cost; the **conversion** is. Each one is a `KeyStrings.GetOrCreate` → `ConcurrentDictionary` lookup that re-hashes and re-compares the literal to rediscover a `uint`. Measured against the bridge's real 599-key corpus (avg 10.3 chars):

| lookup | ns/call |
|---|---|
| `KeyStrings.GetOrCreate` (current, warm) | 8.8 |
| `ConcurrentDictionary<string,_>` ordinal | 6.5 |
| `FrozenDictionary<string,_>` ordinal | 8.2 |
| `Dictionary`, reference-equality on interned literals | 8.1 |
| `static readonly KeyString` field | **0.44** |

Every table design sits in the same 6.5–8.8 ns band — the cost isn't *which* dictionary, it's *that* there's a dictionary. Only not consulting one escapes it. These sites are per-wrapper installs, so the multiplier is every property × every DOM node wrapper.

The engine side already has the answer (`KeyStrings.*`, generated `Names.*`); `src/Broiler.HtmlBridge.Dom` has no equivalent for its 453 distinct literal keys. Two candidates, neither in this PR:

1. A generated `DomKeys` constants class, so hot sites read `obj.FastAddValue(DomKeys.splitText, …)` — no lookup, and self-documenting.
2. A `KeyStrings.GetOrCreate(string)` overload skipping the `StringSpan` round-trip (~2.3 ns of the current 8.8), which helps the ~16 genuinely dynamic-key sites that can't use a constant.

Honest caveat on this PR: the cast, ugly as it was, *advertised* that a hash lookup happens. A bare literal doesn't. Named constants fix both; removing the cast alone only fixes the noise.

## Companion PR

The `Broiler.JS` half is Broiler-Platform/Broiler.JS#1002. The submodule push succeeded, so the pointer is bumped here rather than shipped as a patch — but that pointer references a commit on the submodule's feature branch, so **merge Broiler.JS#1002 first**.