### PR TITLE
Bound the layout -> host -> layout refresh loop

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/RefreshCoalescerTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/RefreshCoalescerTests.cs
@@ -1,0 +1,192 @@
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// <see cref="RefreshCoalescer"/> — the bound on <c>ILayoutEnvironment.RequestRefresh</c>.
+/// </summary>
+/// <remarks>
+/// The path being guarded is layout → host → layout: a late image load asks the host to refresh
+/// from inside a layout pass, and a host that lays out again in its handler re-enters the request.
+/// The tests here pin the two properties that make that safe — the chain terminates, and a
+/// relayout asked for mid-pass is not silently lost — plus the two the guard must <em>not</em>
+/// break: separate containers and separate threads still refresh normally.
+/// </remarks>
+public class RefreshCoalescerTests
+{
+    [Fact]
+    public void Request_RaisesOnce_WhenTheHandlerDoesNotReenter()
+    {
+        var coalescer = new RefreshCoalescer();
+        var raises = new List<bool>();
+
+        coalescer.Request(true, layout => raises.Add(layout));
+
+        Assert.Equal([true], raises);
+    }
+
+    [Fact]
+    public void Request_StopsAtMaxPasses_WhenTheHandlerAlwaysRequestsAgain()
+    {
+        // The regression: this handler is the one that used to recurse until the stack gave out.
+        var coalescer = new RefreshCoalescer();
+        var raises = 0;
+
+        coalescer.Request(true, _ =>
+        {
+            raises++;
+            coalescer.Request(true, _ => throw new InvalidOperationException(
+                "a re-entrant request must be recorded, never raised"));
+        });
+
+        Assert.Equal(RefreshCoalescer.MaxPasses, raises);
+    }
+
+    [Fact]
+    public void Request_StopsEarly_WhenTheHandlerStopsRequesting()
+    {
+        var coalescer = new RefreshCoalescer();
+        var raises = 0;
+
+        coalescer.Request(false, _ =>
+        {
+            raises++;
+            if (raises == 1)
+                coalescer.Request(false, _ => { });
+        });
+
+        Assert.Equal(2, raises);
+    }
+
+    [Fact]
+    public void Request_CarriesTheRelayoutDemand_IntoTheFollowUpPass()
+    {
+        // A paint-only refresh whose handler uncovers a relayout: dropping the re-entrant request
+        // instead of coalescing it would lose the relayout entirely.
+        var coalescer = new RefreshCoalescer();
+        var raises = new List<bool>();
+
+        coalescer.Request(false, layout =>
+        {
+            raises.Add(layout);
+            if (raises.Count == 1)
+                coalescer.Request(true, _ => { });
+        });
+
+        Assert.Equal([false, true], raises);
+    }
+
+    [Fact]
+    public void Request_KeepsTheRelayoutDemand_WhenOnlyOneOfSeveralRequestsAsksForIt()
+    {
+        var coalescer = new RefreshCoalescer();
+        var raises = new List<bool>();
+
+        coalescer.Request(false, layout =>
+        {
+            raises.Add(layout);
+            if (raises.Count > 1)
+                return;
+
+            coalescer.Request(false, _ => { });
+            coalescer.Request(true, _ => { });
+            coalescer.Request(false, _ => { });
+        });
+
+        Assert.Equal([false, true], raises);
+    }
+
+    [Fact]
+    public void Request_OnAnotherCoalescer_RaisesNormallyFromInsideAPass()
+    {
+        // A frame's container is a separate instance; refreshing it from the page's handler is
+        // ordinary nesting, not re-entrancy.
+        var page = new RefreshCoalescer();
+        var frame = new RefreshCoalescer();
+        var frameRaises = 0;
+
+        page.Request(true, _ => frame.Request(true, _ => frameRaises++));
+
+        Assert.Equal(1, frameRaises);
+    }
+
+    [Fact]
+    public void Request_FoldsBackIntoTheOuterPass_WhenANestedCoalescerRefreshesIt()
+    {
+        // page → frame → page is the cycle that has to be caught through the nesting, not just at
+        // the innermost level.
+        var page = new RefreshCoalescer();
+        var frame = new RefreshCoalescer();
+        var pageRaises = new List<bool>();
+        var frameRaises = 0;
+
+        page.Request(false, layout =>
+        {
+            pageRaises.Add(layout);
+            if (pageRaises.Count > 1)
+                return;
+
+            frame.Request(true, _ =>
+            {
+                frameRaises++;
+                page.Request(true, _ => throw new InvalidOperationException(
+                    "the outer pass owns this container; the request must fold into it"));
+            });
+        });
+
+        Assert.Equal([false, true], pageRaises);
+        Assert.Equal(1, frameRaises);
+    }
+
+    [Fact]
+    public void Request_OnAnotherThread_IsNotSuppressedByAnInFlightPass()
+    {
+        // An asynchronous image completes on whichever thread finished it. Suppressing that
+        // refresh because the UI thread happens to be servicing one would drop real work, which is
+        // why the pass chain is per thread rather than per instance.
+        var coalescer = new RefreshCoalescer();
+        var passOpen = new ManualResetEventSlim();
+        var otherFinished = new ManualResetEventSlim();
+        var otherRaises = 0;
+
+        var other = new Thread(() =>
+        {
+            Assert.True(passOpen.Wait(TimeSpan.FromSeconds(10)));
+            coalescer.Request(true, _ => Interlocked.Increment(ref otherRaises));
+            otherFinished.Set();
+        })
+        { IsBackground = true };
+        other.Start();
+
+        coalescer.Request(false, _ =>
+        {
+            passOpen.Set();
+            Assert.True(otherFinished.Wait(TimeSpan.FromSeconds(10)));
+        });
+
+        Assert.True(other.Join(TimeSpan.FromSeconds(10)));
+        Assert.Equal(1, Volatile.Read(ref otherRaises));
+    }
+
+    [Fact]
+    public void Request_LeavesNoPassOpen_WhenTheHandlerThrows()
+    {
+        // The raise callback reports its own handler errors, but an escape must still not strand
+        // the chain — the next request has to raise rather than fold into a dead pass.
+        var coalescer = new RefreshCoalescer();
+
+        Assert.Throws<InvalidOperationException>(
+            () => coalescer.Request(true, _ => throw new InvalidOperationException("boom")));
+
+        var raises = 0;
+        coalescer.Request(true, _ => raises++);
+
+        Assert.Equal(1, raises);
+    }
+
+    [Fact]
+    public void Request_RejectsANullRaiseCallback()
+    {
+        var coalescer = new RefreshCoalescer();
+
+        Assert.Throws<ArgumentNullException>(() => coalescer.Request(true, null!));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/RefreshCoalescer.cs
+++ b/Broiler.Layout/Broiler.Layout/RefreshCoalescer.cs
@@ -1,0 +1,118 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Services a host refresh so that a refresh requested from <em>inside</em> that refresh is folded
+/// into a bounded follow-up pass instead of recursing into it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ILayoutEnvironment.RequestRefresh"/> is called from inside a layout pass — a late
+/// image load does it from <c>CssBoxImage.OnLoadImageComplete</c> and
+/// <c>CssBox.Background.OnImageLoadComplete</c> — and the host's natural response is to lay the
+/// document out again. That relayout re-enters the same code, which requests another refresh, and
+/// nothing along the path (here, <c>Broiler.HTML.Dom.LayoutEnvironment</c>, or
+/// <c>HtmlContainerInt.RequestRefresh</c>) bounded it. Every other recursion-capable path in the
+/// engine carries a depth cap, a visiting set or a re-entrancy flag; this one carried none, so a
+/// host that relayouts unconditionally in its handler recursed until the stack gave out.
+/// </para>
+/// <para>
+/// A re-entrant request is <em>coalesced</em> rather than dropped. By the time it arrives the
+/// in-flight pass has already been dispatched to the handler and cannot absorb it, so discarding it
+/// would lose real work: a <c>layout: false</c> pass that uncovers a relayout would never run one.
+/// Servicing it iteratively instead keeps the stack flat and puts a ceiling on the chain — the same
+/// shape as the table-width redistribution and event-loop drain loops.
+/// </para>
+/// <para>
+/// The pass chain is per thread and per coalescer. Per thread because an asynchronous image
+/// completes on whichever thread finished it and must still be able to refresh while another thread
+/// services one of its own; per coalescer because a nested browsing context's container is a
+/// separate instance with a chain of its own. Nesting is honoured in both directions: a refresh of
+/// container A whose handler refreshes frame B runs B's pass normally, and a further refresh of A
+/// from inside B is folded back into A's pass, which is the cycle that has to be caught.
+/// </para>
+/// <para>
+/// The type lives here, beside the interface whose contract it bounds, rather than in the renderer:
+/// the renderer references <c>Broiler.Layout</c> and not the other way round, so this is the lowest
+/// layer both the raise site and the request site can see.
+/// </para>
+/// </remarks>
+public sealed class RefreshCoalescer
+{
+    /// <summary>
+    /// How many times one <see cref="Request"/> raises the host refresh before the chain is cut.
+    /// A late image load legitimately causes a relayout, and that relayout can complete a second
+    /// deferred load which legitimately causes another, so a short chain is real work; a chain
+    /// longer than this is a handler refreshing unconditionally, and running it to convergence is
+    /// exactly the non-termination being prevented.
+    /// </summary>
+    public const int MaxPasses = 4;
+
+    /// <summary>One in-flight <see cref="Request"/>, and the pass it was raised from, if any.</summary>
+    private sealed class Pass(RefreshCoalescer owner, Pass? outer)
+    {
+        public RefreshCoalescer Owner { get; } = owner;
+
+        public Pass? Outer { get; } = outer;
+
+        /// <summary>Whether a refresh was requested while this pass was being serviced.</summary>
+        public bool Pending;
+
+        /// <summary>Whether any of those requests asked for a relayout.</summary>
+        public bool PendingLayout;
+    }
+
+    [ThreadStatic]
+    private static Pass? _current;
+
+    /// <summary>
+    /// Raises the host refresh through <paramref name="raise"/>, or — when this coalescer is
+    /// already servicing a refresh on this thread — records the request against that pass and
+    /// returns without raising.
+    /// </summary>
+    /// <param name="layout">Whether the host should lay out again, not merely repaint.</param>
+    /// <param name="raise">
+    /// Raises the host's refresh event. Called at most <see cref="MaxPasses"/> times per
+    /// <see cref="Request"/>, always on the calling thread, and expected to swallow and report
+    /// handler exceptions itself — this method does not catch, so a throw from it leaves the pass
+    /// chain intact but abandons the remaining passes.
+    /// </param>
+    public void Request(bool layout, Action<bool> raise)
+    {
+        ArgumentNullException.ThrowIfNull(raise);
+
+        for (var enclosing = _current; enclosing is not null; enclosing = enclosing.Outer)
+        {
+            if (ReferenceEquals(enclosing.Owner, this))
+            {
+                enclosing.Pending = true;
+                enclosing.PendingLayout |= layout;
+                return;
+            }
+        }
+
+        var pass = new Pass(this, _current);
+        _current = pass;
+        try
+        {
+            for (var raised = 1; ; raised++)
+            {
+                // Cleared before the raise, not after: the re-entrant requests this pass is
+                // collecting are the ones made *during* raise(), and a follow-up pass collects
+                // its own.
+                pass.Pending = false;
+                pass.PendingLayout = false;
+
+                raise(layout);
+
+                if (!pass.Pending || raised >= MaxPasses)
+                    break;
+
+                layout = pass.PendingLayout;
+            }
+        }
+        finally
+        {
+            _current = pass.Outer;
+        }
+    }
+}


### PR DESCRIPTION
## What

`ILayoutEnvironment.RequestRefresh` had no bound on re-entry. Layout calls it from *inside* a layout pass — a late image load does so from `CssBoxImage.OnLoadImageComplete` and `CssBox.Background.OnImageLoadComplete` — and the host's natural response is to lay the document out again. That relayout re-enters the same code, which requests another refresh, and nothing along the path (`Broiler.Layout` → `HtmlLayoutEnvironment` → `HtmlContainerInt.RequestRefresh` → `Refresh?.Invoke`) ever stopped it. A host that relayouts in its handler recursed until the stack gave out.

This adds `Broiler.Layout.RefreshCoalescer` and routes `HtmlContainerInt.RequestRefresh` through it. A refresh requested while one is being serviced is recorded against the in-flight pass and run as a **bounded follow-up iteration** (`MaxPasses = 4`) rather than recursed into, so the stack stays flat and the chain terminates.

## Why now

Found while mapping the dependency graph across the superproject and its eleven submodules. The `ProjectReference` graph is acyclic — 264 canonical projects, 257 assemblies, 976 references, zero assembly cycles — but the loops that matter are closed at run time by dependency-inversion seams (an interface declared low, implemented high), which a reference graph does not show. Of the recursion-capable paths in the engine, this was **the only one with no bound at all**. Every other one already carries a depth cap, a visiting set or a re-entrancy flag: `var()` cycles, `@import` chains, `@container` nesting, `currentcolor` self-reference, SVG `<use>`/viewports/patterns, grid and multicol re-layout, table width redistribution, `position-area` resolution, iframe self-embedding, the event-loop drain.

The loop is **currently open** — nothing in this repository or any submodule subscribes to `HtmlContainer.Refresh`, and the headless render paths sidestep it only because `AvoidImagesLateLoading` suppresses the call rather than bounding it. But it is a public API whose documented contract invites exactly the handler that closes it, so the decision should not rest with the embedder.

## Two design calls worth reviewing

**Coalesced, not dropped.** By the time a re-entrant request arrives, the in-flight pass has already been dispatched to the handler and cannot absorb it. Discarding it would lose real work: a `layout: false` refresh whose handler uncovers a relayout would never run one. The pending relayout demand is OR-ed across all re-entrant requests and carried into the next pass.

**The pass chain is per thread *and* per coalescer.** A plain instance flag would have been wrong — `ImagePrefetchTests` documents that an asynchronous image calls `RequestRefresh` from whichever thread completed it, so an instance flag would suppress a legitimate refresh from the pool while the UI thread serviced one of its own. The chain is also walked outward rather than only checking the innermost pass, so `page → frame → page` folds back into the page's pass instead of recursing.

## Layering

The type lives in `Broiler.Layout`, beside the `ILayoutEnvironment` contract it bounds and at the lowest layer both the raise site and the request site can see — the renderer references `Broiler.Layout`, not the other way round. This follows the repo convention of putting the *type* in the main repo and the *call* in the submodule: the `Broiler.HTML` change is 13 insertions and 1 deletion.

`HtmlContainerInt` and `HtmlLayoutEnvironment` (a pass-through) are the only production implementations of these interfaces, so this covers the whole path. The test doubles in `Broiler.Layout.Tests` implement `RequestRefresh` as no-ops and are unaffected.

## Submodule

Depends on `Broiler-Platform/Broiler.HTML` branch `claude/request-refresh-reentrancy-guard` (commit `34474d9`), pushed successfully — so the gitlink is bumped here rather than shipped as a patch. **That branch needs its own PR merged before this pointer lands on `main`.** Reverting the submodule tree does not break this repo: nothing in the main repo names anything new, so `RefreshCoalescer` would simply sit unused.

`HtmlContainerInt.cs` is a pure-CRLF file, so it was patched byte-exactly; the diff reports 13 changed lines rather than the ~1,650 a whole-file normalization would produce.

## Testing

- **10 new tests** in `Broiler.Layout.Tests` — chain terminates at `MaxPasses`, chain stops early when the handler stops requesting, relayout demand survives into the follow-up pass and across several mixed requests, a nested coalescer raises normally, `page → frame → page` folds back, a second thread is not suppressed by an in-flight pass, no pass is stranded when the handler throws, null callback rejected. **10/10 pass.**
- `Broiler.Layout.slnx` — **1327/1327 pass.**
- `Broiler.Tests.slnx` — builds with **0 errors**.
- `Broiler.Cli.Tests` — 4390 tests, **47 failures with the change vs. 48 on a baseline of the clean tree** (reverted and re-ran to check). Same total; the one-test delta is flake, not an effect of the change — nothing in-repo subscribes to `Refresh`, so the guard cannot alter a test outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
