### PR TITLE
Break the Broiler.Media ↔ Broiler.Graphics dependency cycle

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,4 +27,52 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
   </ItemGroup>
 
+  <!--
+    Broiler.Graphics carries its own Broiler.Media submodule so it builds standalone, and its
+    project references are relative, so they resolve into that NESTED checkout. In the aggregate
+    workspace that means one build compiles Broiler.Media twice: once from Broiler.Media\src\ for
+    everything else, once from Broiler.Graphics\Broiler.Media\src\ for Graphics — two assemblies
+    with the same name, one of which wins the copy into any output directory that sees both.
+    `dotnet build src\Broiler.HtmlBridge.Dom` did exactly that, since it references Broiler.Graphics
+    and Broiler.Media.Image side by side. Broiler.Media ADR 0001 forbids it: during aggregate
+    development every local project reference to Media must point at the single root checkout.
+
+    So point Graphics' Media references back at the canonical checkout. Harmless while the two
+    pins agree — which is the normal case, and is why the duplicate went unnoticed — and correct
+    when they do not.
+
+    Unlike the two Broiler.HTML blocks above, this is not a migration workaround with a deletion
+    trigger: a component that must build standalone will always carry a checkout of what it
+    depends on, so the aggregate workspace will always have a mirror to redirect. Add a line here
+    when Graphics gains a Media reference.
+  -->
+  <ItemGroup Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileDirectory)Broiler.Graphics\src\Broiler.Graphics\Broiler.Graphics.csproj'">
+    <ProjectReference Remove="..\..\Broiler.Media\src\Broiler.Media.Image\Broiler.Media.Image.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Image\Broiler.Media.Image.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileDirectory)Broiler.Graphics\src\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj'">
+    <ProjectReference Remove="..\..\Broiler.Media\src\Broiler.Media.Video\Broiler.Media.Video.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Video\Broiler.Media.Video.csproj" />
+
+    <!--
+      Broiler.Media.Video.Windows arrives with the borrowed-HWND contract patches under patches\
+      (Broiler.Media ADR 0006), which Direct2D references once applied. Redirecting it is what
+      lets the two submodules land in either order: without this, applying the Graphics patch
+      before bumping that component's own Broiler.Media gitlink leaves Direct2D pointing at a
+      project its mirror does not have, and the build fails outright. The Exists guard keeps this
+      inert until the Media patch lands; between the two patches it adds a reference Direct2D does
+      not yet declare, which is unused and harmless.
+    -->
+    <ProjectReference Remove="..\..\Broiler.Media\src\Broiler.Media.Video.Windows\Broiler.Media.Video.Windows.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Video.Windows\Broiler.Media.Video.Windows.csproj"
+                      Condition="Exists('$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Video.Windows\Broiler.Media.Video.Windows.csproj')" />
+  </ItemGroup>
+
+  <!-- The Graphics test projects are the composition roots that supply the concrete codecs. -->
+  <ItemGroup Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileDirectory)Broiler.Graphics\src\tests\Broiler.Graphics.Tests\Broiler.Graphics.Tests.csproj' Or '$(MSBuildProjectFullPath)' == '$(MSBuildThisFileDirectory)Broiler.Graphics\src\tests\Broiler.Graphics.Linux.Tests\Broiler.Graphics.Linux.Tests.csproj' Or '$(MSBuildProjectFullPath)' == '$(MSBuildThisFileDirectory)Broiler.Graphics\src\tests\Broiler.Graphics.Windows.Tests\Broiler.Graphics.Windows.Tests.csproj'">
+    <ProjectReference Remove="..\..\..\Broiler.Media\src\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Broiler.Media\src\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/patches/0001-media-break-graphics-dependency-cycle.patch
+++ b/patches/0001-media-break-graphics-dependency-cycle.patch
@@ -1,0 +1,894 @@
+From b704b8a571b201496a511827a3562164ca0a6f5e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 30 Aug 2026 08:30:19 +0000
+Subject: [PATCH] Break the Media/Graphics dependency cycle: Media depends on
+ nothing
+
+Broiler.Media.Video.MediaFoundation referenced Broiler.Graphics.Windows to
+name the concrete HwndVideoOutput presentation target it borrows, while
+Broiler.Graphics referenced Broiler.Media.Image and Broiler.Media.Video in
+the other direction. That closed a component-level cycle. The MSBuild
+project graph stayed acyclic so nothing failed to build, but the cycle was
+paid for at the repository layer: the two components carried mutually
+recursive submodules, each resolved the other through its own nested mirror
+rather than the canonical checkout (so one aggregate build compiled
+Broiler.Media.Image twice, from two source trees, emitting two assemblies
+with the same name), the two nested pins drifted apart, and neither
+component could be versioned or released without the other.
+
+Invert the contract rather than the ownership. A new Windows-only contracts
+assembly, Broiler.Media.Video.Windows, declares IHwndVideoOutput -- the
+borrower's view of a presentation target. The windowing layer implements it
+and keeps owning window creation, resize, visibility and destruction
+exactly as ADR 0005 requires; the Media Foundation backend consumes the
+interface and names no graphics type.
+
+The contract carries only observations: the handle, its geometry, whether
+it is still usable, and notification when the owner changes it. Resize,
+SetVisible and NotifyDestroyed are deliberately absent, so a borrower
+cannot reach through it to mutate a window it does not own -- ADR 0005's
+ownership split becomes a compile-time guarantee instead of a convention.
+
+Also:
+
+- Drop the Broiler.Graphics submodule; nothing here needs it now.
+- Move HwndVideoTargetChangeKind and HwndVideoTargetChangedEventArgs into
+  the new contracts assembly. Breaking for external consumers of those two
+  types; no in-tree consumer outside the implementation itself existed.
+- The Media Foundation tests supply their own IHwndVideoOutput double
+  instead of borrowing the graphics implementation, and gain a test that
+  the contract stays borrower-shaped. Coverage for the concrete target
+  moves to the component that declares it.
+- ArchitectureTests fails if any project here references Broiler.Graphics,
+  if any runtime source names it, or if a checkout of it reappears.
+
+Record the reasoning as ADR 0006.
+---
+ .gitmodules                                   |   3 -
+ Broiler.Graphics                              |   1 -
+ Broiler.Media.slnx                            |   8 +
+ ...-windows-media-foundation-borrowed-hwnd.md |   5 +-
+ docs/adr/0006-no-graphics-dependency.md       |  92 ++++++++++
+ docs/adr/README.md                            |   1 +
+ ...Broiler.Media.Video.MediaFoundation.csproj |  10 +-
+ .../IMediaFoundationMediaEngine.cs            |   4 +-
+ .../MediaFoundationMediaEngine.cs             |   6 +-
+ .../MediaFoundationVideoCodec.cs              |   6 +-
+ .../MediaFoundationVideoSession.cs            |   8 +-
+ .../Broiler.Media.Video.Windows.csproj        |  23 +++
+ .../HwndVideoTargetChangeKind.cs              |  12 ++
+ .../HwndVideoTargetChangedEventArgs.cs        |  36 ++++
+ .../IHwndVideoOutput.cs                       |  58 +++++++
+ .../Broiler.Media.Tests/ArchitectureTests.cs  |  50 +++++-
+ ...r.Media.Video.MediaFoundation.Tests.csproj |   7 +-
+ .../Program.cs                                | 159 +++++++++++++++---
+ 18 files changed, 441 insertions(+), 48 deletions(-)
+ delete mode 100644 .gitmodules
+ delete mode 160000 Broiler.Graphics
+ create mode 100644 docs/adr/0006-no-graphics-dependency.md
+ create mode 100644 src/Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj
+ create mode 100644 src/Broiler.Media.Video.Windows/HwndVideoTargetChangeKind.cs
+ create mode 100644 src/Broiler.Media.Video.Windows/HwndVideoTargetChangedEventArgs.cs
+ create mode 100644 src/Broiler.Media.Video.Windows/IHwndVideoOutput.cs
+
+diff --git a/.gitmodules b/.gitmodules
+deleted file mode 100644
+index 6f7b4cd..0000000
+--- a/.gitmodules
++++ /dev/null
+@@ -1,3 +0,0 @@
+-[submodule "Broiler.Graphics"]
+-	path = Broiler.Graphics
+-	url = https://github.com/Broiler-Platform/Broiler.Graphics.git
+diff --git a/Broiler.Graphics b/Broiler.Graphics
+deleted file mode 160000
+index cb83c76..0000000
+--- a/Broiler.Graphics
++++ /dev/null
+@@ -1 +0,0 @@
+-Subproject commit cb83c7672d6d423ddefc7179b3e766aa8ca9d4fc
+diff --git a/Broiler.Media.slnx b/Broiler.Media.slnx
+index 4e8cb93..e41109c 100644
+--- a/Broiler.Media.slnx
++++ b/Broiler.Media.slnx
+@@ -24,6 +24,7 @@
+     <File Path="docs/adr/0003-image-pixel-and-alpha-format.md" />
+     <File Path="docs/adr/0004-compatibility-window.md" />
+     <File Path="docs/adr/0005-windows-media-foundation-borrowed-hwnd.md" />
++    <File Path="docs/adr/0006-no-graphics-dependency.md" />
+   </Folder>
+   <Folder Name="/src/">
+     <Project Path="src/Broiler.Media/Broiler.Media.csproj">
+@@ -51,6 +52,13 @@
+       <BuildType Project="Release" Solution="Release-Windows|*" />
+     </Project>
+     <!-- Windows-only: builds under the *-Windows configurations exclusively. -->
++    <Project Path="src/Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj">
++      <Build Project="false" Solution="Debug|*" />
++      <Build Project="false" Solution="Release|*" />
++      <Build Project="false" Solution="Debug-Linux|*" />
++      <Build Project="false" Solution="Release-Linux|*" />
++    </Project>
++    <!-- Windows-only: builds under the *-Windows configurations exclusively. -->
+     <Project Path="src/Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj">
+       <Build Project="false" Solution="Debug|*" />
+       <Build Project="false" Solution="Release|*" />
+diff --git a/docs/adr/0005-windows-media-foundation-borrowed-hwnd.md b/docs/adr/0005-windows-media-foundation-borrowed-hwnd.md
+index 8019d5f..6530129 100644
+--- a/docs/adr/0005-windows-media-foundation-borrowed-hwnd.md
++++ b/docs/adr/0005-windows-media-foundation-borrowed-hwnd.md
+@@ -2,7 +2,10 @@
+ 
+ Date: 2026-07-03
+ 
+-Status: Accepted; validated by the Media Foundation session implementation
++Status: Accepted; validated by the Media Foundation session implementation. The ownership
++split below still holds; how the backend *names* the borrowed target was refined by
++[ADR 0006](0006-no-graphics-dependency.md), which replaced the direct reference to
++`Broiler.Graphics.Windows` with the `IHwndVideoOutput` contract.
+ 
+ ## Context
+ 
+diff --git a/docs/adr/0006-no-graphics-dependency.md b/docs/adr/0006-no-graphics-dependency.md
+new file mode 100644
+index 0000000..5a66c2f
+--- /dev/null
++++ b/docs/adr/0006-no-graphics-dependency.md
+@@ -0,0 +1,92 @@
++# ADR 0006: Broiler.Media Depends On No Graphics Component
++
++Date: 2026-08-30
++
++Status: Accepted; refines ADR 0005
++
++## Context
++
++ADR 0005 split ownership of the Windows video presentation target: `Broiler.Graphics.Windows`
++declares and owns the HWND, and `Broiler.Media.Video.MediaFoundation` borrows it for a session
++lifetime. The split itself was right. Its *implementation* was not: the backend named the
++owner's concrete type, so `Broiler.Media.Video.MediaFoundation` carried a project reference to
++`Broiler.Graphics.Windows`.
++
++`Broiler.Graphics` already depended on Media in the other direction — its core references
++`Broiler.Media.Image`, and `Broiler.Graphics.Direct2D` references `Broiler.Media.Video`. Those
++two directions closed a component-level cycle:
++
++```
++Broiler.Graphics ──────────► Broiler.Media.Image
++Broiler.Graphics.Direct2D ─► Broiler.Media.Video
++Broiler.Media.Video.MediaFoundation ─► Broiler.Graphics.Direct2D   ← closes the cycle
++```
++
++The MSBuild project graph stayed acyclic, so nothing failed to build and the cycle was easy to
++miss. It was still real, and it was paid for at the repository layer:
++
++- **Mutually recursive submodules.** `Broiler.Media` carried a `Broiler.Graphics` submodule and
++  `Broiler.Graphics` carried a `Broiler.Media` submodule. The pointer graph had a loop.
++- **Duplicate source, compiled twice.** Because those references are relative paths, each
++  component resolved the other through its *own nested mirror* rather than the canonical
++  checkout. A single `dotnet build` of `Broiler.HtmlBridge.Dom` in the aggregate workspace
++  compiled `Broiler.Media.Image` twice — once from `Broiler.Media/src/`, once from
++  `Broiler.Graphics/Broiler.Media/src/` — producing two different `Broiler.Media.Image.dll`
++  files, one of which won the copy to the output directory. ADR 0001 forbids exactly this
++  ("No component may create an independent editable copy of `Broiler.Media`").
++- **Pins that drift silently.** The two checkouts of a component are pinned independently and
++  had already diverged: the `Broiler.Graphics` nested inside `Broiler.Media` sat on a
++  pre-`src/` layout commit while the canonical one had moved on.
++- **Neither component could be released or versioned without the other.**
++
++## Decision
++
++**`Broiler.Media` depends on no other Broiler component.** It is a leaf. The dependency between
++Media and Graphics runs one way only: Graphics references Media.
++
++The borrowed-HWND arrangement of ADR 0005 is preserved by inverting the contract rather than
++the ownership. A new Windows-only contracts assembly, `Broiler.Media.Video.Windows`, declares
++`IHwndVideoOutput` — the borrower's view of a presentation target:
++
++- `Broiler.Graphics.Windows.HwndVideoOutput` *implements* `IHwndVideoOutput`. It still creates,
++  owns, resizes, shows/hides and destroys the window; nothing about ADR 0005's ownership split
++  changes.
++- `Broiler.Media.Video.MediaFoundation` consumes `IHwndVideoOutput` and names no graphics type.
++
++The contract carries only what a borrower may legitimately do — read the handle and its current
++geometry, check that the window is still usable, and be notified when the owner changes it. The
++owner-only operations (`Resize`, `SetVisible`, `NotifyDestroyed`) are deliberately absent, so a
++borrower *cannot* reach through the contract to mutate a window it does not own. ADR 0005's
++ownership split becomes a compile-time guarantee instead of a convention.
++
++`Broiler.Media.Video.Windows` is a contracts assembly: no implementation, no windowing code, no
++interop, and never a reference to `Broiler.Graphics`. It is separate from `Broiler.Media.Video`
++because that assembly is cross-platform and must stay HWND-free.
++
++The `Broiler.Graphics` submodule is removed from this repository.
++
++## Alternatives considered
++
++**A neutral `Broiler.Platform.Abstractions` component** holding OS handle contracts, depended on
++by both Media and Graphics. Rejected for now: it is a twelfth submodule to pin and version, and
++the cycle is closed by exactly one interface. If and when video presentation lands on Linux and
++Android, the same question ("who owns the native surface handle?") recurs for Wayland/X11 and
++`ANativeWindow`, and a shared platform-handles leaf earns its keep. `IHwndVideoOutput` is shaped
++so that promoting it later is a namespace move, not a redesign.
++
++**Moving `HwndVideoOutput` wholesale into Media.** Rejected: it contradicts ADR 0005 — window
++creation, destruction and thread affinity belong to the layer that owns the window.
++
++## Consequences
++
++- `Broiler.Media` builds, tests, versions and releases standalone, with no Broiler dependency.
++- The aggregate workspace compiles one copy of each Media assembly.
++- `Broiler.Graphics` keeps its `Broiler.Media` submodule; that direction is acyclic and stays.
++- `HwndVideoTargetChangeKind` and `HwndVideoTargetChangedEventArgs` move from the
++  `Broiler.Graphics.Windows` namespace to `Broiler.Media.Video.Windows`. This is a breaking
++  change for any external consumer of those two types; no in-tree consumer outside
++  `HwndVideoOutput` itself existed.
++- Tests for the concrete `HwndVideoOutput` move to `Broiler.Graphics`' own suite, where the type
++  lives. Media's Media Foundation tests supply their own `IHwndVideoOutput` double.
++- `Broiler.Media.Tests` fails if any project in the component references `Broiler.Graphics`, if
++  any runtime source names it, or if a `Broiler.Graphics` checkout reappears here.
+diff --git a/docs/adr/README.md b/docs/adr/README.md
+index ad53f1e..cb14b62 100644
+--- a/docs/adr/README.md
++++ b/docs/adr/README.md
+@@ -11,3 +11,4 @@ are retained for traceability.
+ | [0003](0003-image-pixel-and-alpha-format.md) | Image pixel and alpha format |
+ | [0004](0004-compatibility-window.md) | Graphics compatibility window (superseded by implementation) |
+ | [0005](0005-windows-media-foundation-borrowed-hwnd.md) | Borrowed HWND for Media Foundation video |
++| [0006](0006-no-graphics-dependency.md) | Broiler.Media depends on no Graphics component (refines 0005) |
+diff --git a/src/Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj b/src/Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj
+index ec1d343..c40bac3 100644
+--- a/src/Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj
++++ b/src/Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj
+@@ -14,10 +14,12 @@
+ 
+   <ItemGroup>
+     <ProjectReference Include="..\Broiler.Media.Video\Broiler.Media.Video.csproj" />
+-    <!-- The Media Foundation backend BORROWS the HWND presentation target declared and
+-         owned by Broiler.Graphics.Windows (media roadmap §6.6): it drives IMFMediaEngine
+-         against that target's HWND and never creates or destroys the window. -->
+-    <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
++    <!-- The Media Foundation backend BORROWS an HWND presentation target (media roadmap
++         §6.6): it drives IMFMediaEngine against that target's HWND and never creates or
++         destroys the window. It names the target through the IHwndVideoOutput contract, not
++         through the graphics assembly that implements it — that indirection is what keeps
++         Broiler.Media free of any dependency on another Broiler component (ADR 0006). -->
++    <ProjectReference Include="..\Broiler.Media.Video.Windows\Broiler.Media.Video.Windows.csproj" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/Broiler.Media.Video.MediaFoundation/IMediaFoundationMediaEngine.cs b/src/Broiler.Media.Video.MediaFoundation/IMediaFoundationMediaEngine.cs
+index 0d88992..4cd9ebb 100644
+--- a/src/Broiler.Media.Video.MediaFoundation/IMediaFoundationMediaEngine.cs
++++ b/src/Broiler.Media.Video.MediaFoundation/IMediaFoundationMediaEngine.cs
+@@ -1,5 +1,5 @@
+ using System;
+-using Broiler.Graphics.Windows;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Media.Video.MediaFoundation;
+ 
+@@ -21,7 +21,7 @@ internal interface IMediaFoundationMediaEngine : IDisposable
+ 
+     VideoStreamInfo GetStreamInfo();
+ 
+-    void OnTargetChanged(HwndVideoOutput target);
++    void OnTargetChanged(IHwndVideoOutput target);
+ 
+     void Shutdown();
+ }
+diff --git a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationMediaEngine.cs b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationMediaEngine.cs
+index 667cdad..0d4e1e2 100644
+--- a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationMediaEngine.cs
++++ b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationMediaEngine.cs
+@@ -1,6 +1,6 @@
+ using System;
+ using System.Runtime.InteropServices;
+-using Broiler.Graphics.Windows;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Media.Video.MediaFoundation;
+ 
+@@ -40,7 +40,7 @@ internal sealed class MediaFoundationMediaEngine : IMediaFoundationMediaEngine
+     }
+ 
+     public static MediaFoundationMediaEngine Create(
+-        HwndVideoOutput? target,
++        IHwndVideoOutput? target,
+         VideoSessionOptions options)
+     {
+         MediaFoundationFaults.ThrowIfFailed(
+@@ -163,7 +163,7 @@ internal sealed class MediaFoundationMediaEngine : IMediaFoundationMediaEngine
+         return new VideoStreamInfo((int)width, (int)height, (int)width, (int)height, duration);
+     }
+ 
+-    public void OnTargetChanged(HwndVideoOutput target)
++    public void OnTargetChanged(IHwndVideoOutput target)
+     {
+         if (target.IsDestroyed)
+             Shutdown();
+diff --git a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoCodec.cs b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoCodec.cs
+index b989a84..a8f37b6 100644
+--- a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoCodec.cs
++++ b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoCodec.cs
+@@ -3,7 +3,7 @@ using System.IO;
+ using System.Runtime.Versioning;
+ using System.Threading;
+ using System.Threading.Tasks;
+-using Broiler.Graphics.Windows;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Media.Video.MediaFoundation;
+ 
+@@ -100,10 +100,10 @@ public sealed class MediaFoundationVideoCodec : VideoCodec
+         ArgumentNullException.ThrowIfNull(output);
+         cancellationToken.ThrowIfCancellationRequested();
+ 
+-        if (output is not HwndVideoOutput target)
++        if (output is not IHwndVideoOutput target)
+         {
+             throw new ArgumentException(
+-                "Media Foundation video sessions require a Broiler.Graphics.Windows HwndVideoOutput target.",
++                "Media Foundation video sessions require an IHwndVideoOutput presentation target.",
+                 nameof(output));
+         }
+ 
+diff --git a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoSession.cs b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoSession.cs
+index 8d47179..21c34cd 100644
+--- a/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoSession.cs
++++ b/src/Broiler.Media.Video.MediaFoundation/MediaFoundationVideoSession.cs
+@@ -1,7 +1,7 @@
+ using System;
+ using System.Threading;
+ using System.Threading.Tasks;
+-using Broiler.Graphics.Windows;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Media.Video.MediaFoundation;
+ 
+@@ -9,7 +9,7 @@ public sealed class MediaFoundationVideoSession : IVideoSession
+ {
+     private readonly object _gate = new();
+     private readonly IMediaFoundationMediaEngine _engine;
+-    private readonly HwndVideoOutput _target;
++    private readonly IHwndVideoOutput _target;
+     private readonly IDisposable? _platformScope;
+     private readonly TaskCompletionSource<VideoStreamInfo> _metadataReady =
+         new(TaskCreationOptions.RunContinuationsAsynchronously);
+@@ -18,7 +18,7 @@ public sealed class MediaFoundationVideoSession : IVideoSession
+ 
+     internal MediaFoundationVideoSession(
+         IMediaFoundationMediaEngine engine,
+-        HwndVideoOutput target,
++        IHwndVideoOutput target,
+         IDisposable? platformScope = null)
+     {
+         _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+@@ -50,7 +50,7 @@ public sealed class MediaFoundationVideoSession : IVideoSession
+ 
+     internal static async ValueTask<MediaFoundationVideoSession> OpenAsync(
+         IMediaFoundationMediaEngine engine,
+-        HwndVideoOutput target,
++        IHwndVideoOutput target,
+         string sourceUri,
+         VideoSessionOptions options,
+         CancellationToken cancellationToken)
+diff --git a/src/Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj b/src/Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj
+new file mode 100644
+index 0000000..815bac9
+--- /dev/null
++++ b/src/Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj
+@@ -0,0 +1,23 @@
++<Project Sdk="Microsoft.NET.Sdk">
++
++  <PropertyGroup>
++    <TargetFramework>net10.0-windows</TargetFramework>
++    <RootNamespace>Broiler.Media.Video.Windows</RootNamespace>
++    <AssemblyName>Broiler.Media.Video.Windows</AssemblyName>
++    <Description>Windows presentation-target contracts for Broiler.Media.Video. Declares the borrowed-HWND video target a Windows video backend consumes; carries no implementation and no windowing code.</Description>
++    <PackageTags>broiler;media;video;windows</PackageTags>
++  </PropertyGroup>
++
++  <PropertyGroup>
++    <Configurations>Debug;Release;Debug-Windows;Release-Windows</Configurations>
++  </PropertyGroup>
++
++  <ItemGroup>
++    <!-- Contracts only. This project exists so that a Windows video backend can name the
++         presentation target it borrows WITHOUT referencing the graphics stack that owns the
++         window (ADR 0006) — so it must never gain a reference to that stack, nor to any
++         other Broiler component beyond Media itself. -->
++    <ProjectReference Include="..\Broiler.Media.Video\Broiler.Media.Video.csproj" />
++  </ItemGroup>
++
++</Project>
+diff --git a/src/Broiler.Media.Video.Windows/HwndVideoTargetChangeKind.cs b/src/Broiler.Media.Video.Windows/HwndVideoTargetChangeKind.cs
+new file mode 100644
+index 0000000..b9c3b51
+--- /dev/null
++++ b/src/Broiler.Media.Video.Windows/HwndVideoTargetChangeKind.cs
+@@ -0,0 +1,12 @@
++namespace Broiler.Media.Video.Windows;
++
++/// <summary>
++/// The kind of change reported by an <see cref="IHwndVideoOutput"/> when the window it
++/// presents into is resized, shown/hidden, or destroyed by its owner.
++/// </summary>
++public enum HwndVideoTargetChangeKind
++{
++    Resized,
++    VisibilityChanged,
++    Destroyed,
++}
+diff --git a/src/Broiler.Media.Video.Windows/HwndVideoTargetChangedEventArgs.cs b/src/Broiler.Media.Video.Windows/HwndVideoTargetChangedEventArgs.cs
+new file mode 100644
+index 0000000..a28ffca
+--- /dev/null
++++ b/src/Broiler.Media.Video.Windows/HwndVideoTargetChangedEventArgs.cs
+@@ -0,0 +1,36 @@
++using System;
++
++namespace Broiler.Media.Video.Windows;
++
++/// <summary>
++/// Notifies a borrower (e.g. a Media Foundation video session) that the HWND-backed
++/// presentation target behind an <see cref="IHwndVideoOutput"/> changed size, visibility,
++/// or was destroyed by its owner.
++/// </summary>
++public sealed class HwndVideoTargetChangedEventArgs : EventArgs
++{
++    public HwndVideoTargetChangedEventArgs(
++        HwndVideoTargetChangeKind kind,
++        int width,
++        int height,
++        bool isVisible)
++    {
++        if (width < 0)
++            throw new ArgumentOutOfRangeException(nameof(width));
++        if (height < 0)
++            throw new ArgumentOutOfRangeException(nameof(height));
++
++        Kind = kind;
++        Width = width;
++        Height = height;
++        IsVisible = isVisible;
++    }
++
++    public HwndVideoTargetChangeKind Kind { get; }
++
++    public int Width { get; }
++
++    public int Height { get; }
++
++    public bool IsVisible { get; }
++}
+diff --git a/src/Broiler.Media.Video.Windows/IHwndVideoOutput.cs b/src/Broiler.Media.Video.Windows/IHwndVideoOutput.cs
+new file mode 100644
+index 0000000..d87acd2
+--- /dev/null
++++ b/src/Broiler.Media.Video.Windows/IHwndVideoOutput.cs
+@@ -0,0 +1,58 @@
++using System;
++using System.Runtime.Versioning;
++
++namespace Broiler.Media.Video.Windows;
++
++/// <summary>
++/// A Windows HWND-backed video presentation target, as seen by the video backend that
++/// <em>borrows</em> it. The window itself is created, owned, resized, and destroyed by the
++/// windowing layer outside Broiler.Media that implements this interface; a backend such as
++/// <c>Broiler.Media.Video.MediaFoundation</c> only reads the handle and reacts to changes.
++/// </summary>
++/// <remarks>
++/// <para>
++/// This interface is the reason Broiler.Media depends on no other Broiler component. The
++/// borrowed-HWND arrangement of ADR 0005 originally had the backend hold the owner's
++/// concrete target class, which closed a Media → graphics → Media dependency cycle. The
++/// contract is declared here instead, on the consuming side, so the dependency runs one way
++/// only: the windowing layer implements a Media contract, and Media names no type of its
++/// own implementor (ADR 0006).
++/// </para>
++/// <para>
++/// The surface is deliberately borrower-shaped. Every member is an observation — the handle,
++/// its current geometry, whether it is still usable, and notification when the owner changes
++/// it. The owner-only operations (create, resize, show/hide, destroy) are absent by design,
++/// so a borrower cannot reach through this contract to mutate a window it does not own. That
++/// makes the ownership split of ADR 0005 a compile-time guarantee rather than a convention.
++/// </para>
++/// </remarks>
++[SupportedOSPlatform("windows")]
++public interface IHwndVideoOutput : IVideoOutput
++{
++    /// <summary>
++    /// Raised by the owner after the borrowed window is resized, shown/hidden, or destroyed.
++    /// A borrower must treat <see cref="HwndVideoTargetChangeKind.Destroyed"/> as terminal.
++    /// </summary>
++    event EventHandler<HwndVideoTargetChangedEventArgs>? TargetChanged;
++
++    /// <summary>The borrowed native window handle. Never zero for a live target.</summary>
++    nint Hwnd { get; }
++
++    /// <summary>Current width of the borrowed window, in physical pixels.</summary>
++    int Width { get; }
++
++    /// <summary>Current height of the borrowed window, in physical pixels.</summary>
++    int Height { get; }
++
++    /// <summary>Whether the owner currently considers the borrowed window visible.</summary>
++    bool IsVisible { get; }
++
++    /// <summary>Whether the owner has destroyed the borrowed window.</summary>
++    bool IsDestroyed { get; }
++
++    /// <summary>
++    /// Throws <see cref="ObjectDisposedException"/> if the borrowed window has been destroyed
++    /// by its owner. Borrowers call this before attaching to or presenting into the handle.
++    /// </summary>
++    void ThrowIfUsableTargetRequired();
++}
+diff --git a/src/tests/Broiler.Media.Tests/ArchitectureTests.cs b/src/tests/Broiler.Media.Tests/ArchitectureTests.cs
+index e0d0ac5..7f5603e 100644
+--- a/src/tests/Broiler.Media.Tests/ArchitectureTests.cs
++++ b/src/tests/Broiler.Media.Tests/ArchitectureTests.cs
+@@ -14,6 +14,7 @@ internal static class ArchitectureTests
+         tests.Add(("Media projects have no third-party package references", NoPackageReferences));
+         tests.Add(("Runtime project references match the Phase 1 allowlist", RuntimeReferenceAllowlist));
+         tests.Add(("Abstractions do not reference Graphics, HTML, or Media Foundation", AbstractionsStayNeutral));
++        tests.Add(("Nothing in the component references Broiler.Graphics", ComponentNeverReferencesGraphics));
+         tests.Add(("Runtime sources avoid hidden module-initializer registration", NoModuleInitializers));
+         tests.Add(("Shared Media has no untyped object Decode method", NoUntypedSharedDecode));
+     }
+@@ -42,12 +43,18 @@ internal static class ArchitectureTests
+                 ["../Broiler.Media.Audio/Broiler.Media.Audio.csproj"],
+             ["Broiler.Media.Video/Broiler.Media.Video.csproj"] =
+                 ["../Broiler.Media/Broiler.Media.csproj"],
+-            // §6.6: the Media Foundation backend borrows the HWND presentation target owned
+-            // by Broiler.Graphics.Windows — the one approved Graphics edge.
++            // §6.6: the Windows presentation-target contract the Media Foundation backend
++            // borrows. Contracts only — it must never reference an implementation.
++            ["Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj"] =
++                ["../Broiler.Media.Video/Broiler.Media.Video.csproj"],
++            // §6.6: the Media Foundation backend borrows an HWND presentation target through
++            // the IHwndVideoOutput contract above. It used to reference
++            // Broiler.Graphics.Windows for the concrete target type, which closed a
++            // Media → Graphics → Media cycle; ADR 0006 inverted it. No Graphics edge remains.
+             ["Broiler.Media.Video.MediaFoundation/Broiler.Media.Video.MediaFoundation.csproj"] =
+                 [
+                     "../Broiler.Media.Video/Broiler.Media.Video.csproj",
+-                    "../../Broiler.Graphics/Broiler.Graphics.Windows/Broiler.Graphics.Direct2D.csproj",
++                    "../Broiler.Media.Video.Windows/Broiler.Media.Video.Windows.csproj",
+                 ],
+             ["Broiler.Media.Image/Broiler.Media.Image.csproj"] =
+                 ["../Broiler.Media/Broiler.Media.csproj"],
+@@ -112,6 +119,42 @@ internal static class ArchitectureTests
+         return ValueTask.CompletedTask;
+     }
+ 
++    /// <summary>
++    /// Broiler.Media is a leaf: it depends on no other Broiler component. This is the guard on
++    /// ADR 0006. Until then, Broiler.Media.Video.MediaFoundation referenced
++    /// Broiler.Graphics.Windows for the concrete HWND target type while Broiler.Graphics
++    /// referenced Broiler.Media.Image — a component-level cycle that forced each repository to
++    /// carry a submodule checkout of the other, and made a single build compile two copies of
++    /// Broiler.Media.Image from two different source trees.
++    /// </summary>
++    private static ValueTask ComponentNeverReferencesGraphics()
++    {
++        string root = FindMediaRoot();
++
++        // Every project in the component, tests included — a project reference is the actual
++        // dependency, and a test project reaching for Graphics rebuilds the cycle just as
++        // surely as a runtime one. (Test *sources* may name the string in assertions like
++        // this one, so only .csproj files are scanned here.)
++        foreach (string project in Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories))
++            Assert.DoesNotContain("Broiler.Graphics", File.ReadAllText(project), project);
++
++        foreach (string file in RuntimeSourceFiles(root))
++            Assert.DoesNotContain("Broiler.Graphics", File.ReadAllText(file), file);
++
++        // A source reference is only half of it: the cycle was also physical, as a
++        // Broiler.Graphics submodule checked out inside this component. Neither may return.
++        string componentRoot = Directory.GetParent(root)!.FullName;
++        string modules = Path.Combine(componentRoot, ".gitmodules");
++        if (File.Exists(modules))
++            Assert.DoesNotContain("Broiler.Graphics", File.ReadAllText(modules), modules);
++
++        Assert.False(
++            Directory.Exists(Path.Combine(componentRoot, "Broiler.Graphics")),
++            "Broiler.Media must not carry a Broiler.Graphics checkout.");
++
++        return ValueTask.CompletedTask;
++    }
++
+     private static ValueTask NoModuleInitializers()
+     {
+         string root = FindMediaRoot();
+@@ -145,6 +188,7 @@ internal static class ArchitectureTests
+             "Broiler.Media.Audio",
+             "Broiler.Media.Audio.Managed",
+             "Broiler.Media.Video",
++            "Broiler.Media.Video.Windows",
+             "Broiler.Media.Video.MediaFoundation",
+             "Broiler.Media.Image",
+             "Broiler.Media.Image.Managed",
+diff --git a/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Broiler.Media.Video.MediaFoundation.Tests.csproj b/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Broiler.Media.Video.MediaFoundation.Tests.csproj
+index e12e40b..7b60054 100644
+--- a/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Broiler.Media.Video.MediaFoundation.Tests.csproj
++++ b/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Broiler.Media.Video.MediaFoundation.Tests.csproj
+@@ -16,10 +16,11 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
++    <!-- The test acts as the composition root: it supplies its own IHwndVideoOutput target
++         and hands it to the Media Foundation session. It deliberately references no graphics
++         component — the real implementation of that contract is covered by the suite of the
++         component that owns it, and Media stays a leaf (ADR 0006). -->
+     <ProjectReference Include="..\..\Broiler.Media.Video.MediaFoundation\Broiler.Media.Video.MediaFoundation.csproj" />
+-    <!-- The test acts as the composition root: it constructs the Graphics.Windows-owned
+-         HwndVideoOutput target and hands it to the Media Foundation session. -->
+-    <ProjectReference Include="..\..\..\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
+   </ItemGroup>
+ 
+ </Project>
+diff --git a/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Program.cs b/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Program.cs
+index c133857..d8d584b 100644
+--- a/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Program.cs
++++ b/src/tests/Broiler.Media.Video.MediaFoundation.Tests/Program.cs
+@@ -3,10 +3,11 @@ using System.Collections.Generic;
+ using System.Globalization;
+ using System.IO;
+ using System.Linq;
++using System.Reflection;
+ using System.Runtime.Versioning;
+ using System.Threading;
+ using System.Threading.Tasks;
+-using Broiler.Graphics.Windows;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Media.Video.MediaFoundation.Tests;
+ 
+@@ -18,7 +19,8 @@ internal static class Program
+         {
+             ("Media Foundation provider exposes one Windows direct-presentation codec", ProviderExposesCodec),
+             ("Media Foundation codec probes MP4 signatures and hints", CodecProbesMp4),
+-            ("Borrowed HWND target validates lifetime and records output state", BorrowedTargetLifecycle),
++            ("Borrowed HWND contract exposes observations, not owner-only operations", BorrowedTargetContractIsBorrowerShaped),
++            ("Borrowed HWND target reports lifetime and output state to its borrower", BorrowedTargetLifecycleReachesTheBorrower),
+             ("Session loads metadata and controls playback through the engine", SessionLifecycle),
+             ("Session forwards target resize and visibility changes", TargetChangesReachSession),
+             ("Target destruction fails the session and shuts down the engine", TargetDestructionFailsSession),
+@@ -26,7 +28,7 @@ internal static class Program
+             ("Codec validates source policy before native startup", SourcePolicyValidation),
+             ("Codec honors cancellation before native startup", CancellationBeforeNativeStartup),
+             ("Video abstractions stay MediaFoundation and HWND free", AbstractionsStayBackendFree),
+-            ("MediaFoundation runtime borrows only the Graphics.Windows HWND target, not the Graphics core/surfaces/HTML", RuntimeDependencyBoundary),
++            ("MediaFoundation runtime names no Broiler.Graphics type at all", RuntimeDependencyBoundary),
+         };
+ 
+         int passed = 0;
+@@ -90,11 +92,43 @@ internal static class Program
+         Assert.False(none.IsMatch);
+     }
+ 
+-    private static ValueTask BorrowedTargetLifecycle()
++    private static ValueTask BorrowedTargetContractIsBorrowerShaped()
+     {
+-        Assert.Throws<ArgumentException>(() => _ = new HwndVideoOutput(0, "zero", 1, 1, validateNativeWindow: false));
++        // ADR 0005 splits ownership: the windowing layer creates, resizes, shows/hides and
++        // destroys the HWND; the video backend only borrows it. ADR 0006 makes that split a
++        // compile-time guarantee by handing the backend an interface that simply has no
++        // owner-only operation to call. Guard that shape — re-adding one of these members
++        // would silently hand every borrower the ability to mutate a window it does not own.
++        Type[] contract = [typeof(IHwndVideoOutput), .. typeof(IHwndVideoOutput).GetInterfaces()];
++        string[] ownerOnly = ["Resize", "SetVisible", "NotifyDestroyed"];
++
++        foreach (Type type in contract)
++        {
++            foreach (MethodInfo method in type.GetMethods())
++            {
++                Assert.False(
++                    ownerOnly.Contains(method.Name, StringComparer.Ordinal),
++                    $"{type.Name} exposes owner-only operation '{method.Name}' to borrowers.");
++            }
++        }
+ 
+-        HwndVideoOutput target = CreateTarget();
++        // The observations a borrower legitimately needs must all be present.
++        foreach (string member in new[] { "Hwnd", "Width", "Height", "IsVisible", "IsDestroyed" })
++            Assert.True(typeof(IHwndVideoOutput).GetProperty(member) is not null, $"Expected {member} on the contract.");
++
++        Assert.True(
++            typeof(IHwndVideoOutput).GetMethod("ThrowIfUsableTargetRequired") is not null,
++            "Expected the usability check on the contract.");
++        Assert.True(
++            typeof(IVideoOutput).IsAssignableFrom(typeof(IHwndVideoOutput)),
++            "The borrowed HWND target must still be a platform-neutral video output.");
++
++        return ValueTask.CompletedTask;
++    }
++
++    private static ValueTask BorrowedTargetLifecycleReachesTheBorrower()
++    {
++        FakeHwndVideoTarget target = CreateTarget();
+         var changes = new List<HwndVideoTargetChangeKind>();
+         target.TargetChanged += (_, e) => changes.Add(e.Kind);
+ 
+@@ -114,7 +148,7 @@ internal static class Program
+                 HwndVideoTargetChangeKind.Destroyed,
+             },
+             changes);
+-        Assert.Throws<ObjectDisposedException>(() => target.Resize(1, 1));
++        Assert.Throws<ObjectDisposedException>(() => target.ThrowIfUsableTargetRequired());
+ 
+         var error = new MediaError(MediaErrorCode.OutputFailed, "target failed");
+         target.FailAsync(error).AsTask().GetAwaiter().GetResult();
+@@ -125,7 +159,7 @@ internal static class Program
+     private static async ValueTask SessionLifecycle()
+     {
+         FakeMediaEngine engine = new();
+-        HwndVideoOutput target = CreateTarget();
++        FakeHwndVideoTarget target = CreateTarget();
+         await using var session = new MediaFoundationVideoSession(engine, target);
+         var events = new List<VideoSessionEventKind>();
+         session.StateChanged += (_, e) => events.Add(e.Kind);
+@@ -163,7 +197,7 @@ internal static class Program
+     private static async ValueTask TargetChangesReachSession()
+     {
+         FakeMediaEngine engine = new();
+-        HwndVideoOutput target = CreateTarget();
++        FakeHwndVideoTarget target = CreateTarget();
+         await using var session = new MediaFoundationVideoSession(engine, target);
+         var events = new List<VideoSessionEventKind>();
+         session.StateChanged += (_, e) => events.Add(e.Kind);
+@@ -182,7 +216,7 @@ internal static class Program
+     private static async ValueTask TargetDestructionFailsSession()
+     {
+         FakeMediaEngine engine = new();
+-        HwndVideoOutput target = CreateTarget();
++        FakeHwndVideoTarget target = CreateTarget();
+         await using var session = new MediaFoundationVideoSession(engine, target);
+         var events = new List<VideoSessionEventKind>();
+         session.StateChanged += (_, e) => events.Add(e.Kind);
+@@ -201,7 +235,7 @@ internal static class Program
+     private static async ValueTask DisposeDisconnectsCallbacks()
+     {
+         FakeMediaEngine engine = new();
+-        HwndVideoOutput target = CreateTarget();
++        FakeHwndVideoTarget target = CreateTarget();
+         var session = new MediaFoundationVideoSession(engine, target);
+         await session.LoadAsync("file:///C:/video.mp4", CancellationToken.None).ConfigureAwait(false);
+         await session.DisposeAsync().ConfigureAwait(false);
+@@ -264,13 +298,12 @@ internal static class Program
+         {
+             string text = File.ReadAllText(file);
+ 
+-            // The one approved Graphics edge (media roadmap §6.6) is the Windows HWND video
+-            // target declared by Broiler.Graphics.Windows, which the backend borrows. Any
+-            // OTHER Broiler.Graphics reference — the rendering core, surfaces, devices, image
+-            // stores, swap chains — is forbidden. Strip the sanctioned namespace, then assert
+-            // no remaining Graphics reference survives.
+-            string withoutWindowsTarget = text.Replace("Broiler.Graphics.Windows", string.Empty);
+-            Assert.DoesNotContain("Broiler.Graphics", withoutWindowsTarget, file);
++            // There is no longer ANY approved Graphics edge. The backend borrows its HWND
++            // presentation target through Broiler.Media.Video.Windows' IHwndVideoOutput, so
++            // the graphics assembly that owns the window is invisible here (ADR 0006). This
++            // used to permit "Broiler.Graphics.Windows" — the exception that closed the
++            // Media → Graphics → Media cycle. Do not reintroduce it.
++            Assert.DoesNotContain("Broiler.Graphics", text, file);
+ 
+             Assert.DoesNotContain("Broiler.Html", text, file);
+             Assert.DoesNotContain("SwapChain", text, file);
+@@ -285,8 +318,8 @@ internal static class Program
+         return ValueTask.CompletedTask;
+     }
+ 
+-    private static HwndVideoOutput CreateTarget() =>
+-        new((nint)1234, "test hwnd", 640, 360, validateNativeWindow: false);
++    private static FakeHwndVideoTarget CreateTarget() =>
++        new((nint)1234, "test hwnd", 640, 360);
+ 
+     private static string FindMediaRoot()
+     {
+@@ -345,7 +378,7 @@ internal static class Program
+ 
+         public VideoStreamInfo GetStreamInfo() => _info;
+ 
+-        public void OnTargetChanged(HwndVideoOutput target)
++        public void OnTargetChanged(IHwndVideoOutput target)
+         {
+             TargetChangeCount++;
+             LastTargetWidth = target.Width;
+@@ -365,6 +398,90 @@ internal static class Program
+             EventReceived?.Invoke(this, new MediaFoundationMediaEngineEvent(kind, 0, 0));
+     }
+ 
++    /// <summary>
++    /// Stands in for the window owner (in production, Broiler.Graphics.Windows). The
++    /// owner-only mutators live on the class, not on <see cref="IHwndVideoOutput"/>, exactly
++    /// as they do in the real implementation — the test drives them as the owner would, while
++    /// the session under test sees only the borrower contract.
++    /// </summary>
++    private sealed class FakeHwndVideoTarget : IHwndVideoOutput
++    {
++        public FakeHwndVideoTarget(nint hwnd, string displayName, int width, int height, bool isVisible = true)
++        {
++            Hwnd = hwnd;
++            DisplayName = displayName;
++            Width = width;
++            Height = height;
++            IsVisible = isVisible;
++        }
++
++        public event EventHandler<HwndVideoTargetChangedEventArgs>? TargetChanged;
++
++        public nint Hwnd { get; }
++
++        public string DisplayName { get; }
++
++        public int Width { get; private set; }
++
++        public int Height { get; private set; }
++
++        public bool IsVisible { get; private set; }
++
++        public bool IsDestroyed { get; private set; }
++
++        public bool Completed { get; private set; }
++
++        public MediaError? Failure { get; private set; }
++
++        public void Resize(int width, int height)
++        {
++            ThrowIfUsableTargetRequired();
++            Width = width;
++            Height = height;
++            Raise(HwndVideoTargetChangeKind.Resized);
++        }
++
++        public void SetVisible(bool isVisible)
++        {
++            ThrowIfUsableTargetRequired();
++            IsVisible = isVisible;
++            Raise(HwndVideoTargetChangeKind.VisibilityChanged);
++        }
++
++        public void NotifyDestroyed()
++        {
++            if (IsDestroyed)
++                return;
++
++            IsDestroyed = true;
++            IsVisible = false;
++            Raise(HwndVideoTargetChangeKind.Destroyed);
++        }
++
++        public ValueTask CompleteAsync(CancellationToken cancellationToken = default)
++        {
++            cancellationToken.ThrowIfCancellationRequested();
++            Completed = true;
++            return ValueTask.CompletedTask;
++        }
++
++        public ValueTask FailAsync(MediaError error, CancellationToken cancellationToken = default)
++        {
++            cancellationToken.ThrowIfCancellationRequested();
++            Failure = error ?? throw new ArgumentNullException(nameof(error));
++            return ValueTask.CompletedTask;
++        }
++
++        public void ThrowIfUsableTargetRequired()
++        {
++            if (IsDestroyed)
++                throw new ObjectDisposedException(nameof(FakeHwndVideoTarget), "The borrowed HWND has been destroyed by its owner.");
++        }
++
++        private void Raise(HwndVideoTargetChangeKind kind) =>
++            TargetChanged?.Invoke(this, new HwndVideoTargetChangedEventArgs(kind, Width, Height, IsVisible));
++    }
++
+     private sealed class RecordingVideoOutput(string displayName) : IVideoOutput
+     {
+         public string DisplayName { get; } = displayName;
+-- 
+2.43.0
+

--- a/patches/0002-graphics-implement-hwnd-video-output-contract.patch
+++ b/patches/0002-graphics-implement-hwnd-video-output-contract.patch
@@ -1,0 +1,298 @@
+From 171443242a0f6a651582bd7bfbe944f14eace7ba Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 30 Aug 2026 08:30:38 +0000
+Subject: [PATCH] Implement the Media borrowed-HWND contract instead of being
+ referenced by it
+
+HwndVideoOutput is the HWND-backed video presentation target this component
+owns and a Windows video backend borrows. Until now the backend named this
+concrete class, so Broiler.Media referenced Broiler.Graphics while Graphics
+referenced Broiler.Media.Image and Broiler.Media.Video -- a component-level
+dependency cycle that forced each repository to carry a submodule checkout
+of the other and made one aggregate build compile Broiler.Media.Image twice
+from two source trees.
+
+Broiler.Media now declares the borrower's view of the target as
+IHwndVideoOutput in Broiler.Media.Video.Windows. Implement it here, so the
+dependency runs one way only: this component references a Media contract,
+and Media references nothing here. Window creation, resize, visibility and
+destruction stay owned here, unchanged -- IHwndVideoOutput deliberately
+carries no owner-only operation, so Resize, SetVisible and NotifyDestroyed
+are reachable only by the window's owner. Keep them off the interface.
+
+HwndVideoTargetChangeKind and HwndVideoTargetChangedEventArgs move to the
+contracts assembly with the interface; they are re-exposed from there, so
+external consumers of those two type names need a using change.
+
+Take over the tests for the concrete target. They lived in Broiler.Media's
+Media Foundation suite, which could reach this type only because of the
+reference that closed the cycle; the type is declared here, so its coverage
+belongs here. Media keeps testing its side of the contract against its own
+double.
+
+Requires the matching Broiler.Media change (its ADR 0006). Bump this
+component's Broiler.Media gitlink to a commit containing
+Broiler.Media.Video.Windows when applying.
+---
+ .../Broiler.Graphics.Direct2D.csproj          |  10 +-
+ .../HwndVideoOutput.cs                        |  26 +++--
+ .../HwndVideoTargetChangeKind.cs              |  12 ---
+ .../HwndVideoTargetChangedEventArgs.cs        |  36 -------
+ .../HwndVideoOutputTests.cs                   | 101 ++++++++++++++++++
+ .../Broiler.Graphics.Windows.Tests/Program.cs |   1 +
+ 6 files changed, 125 insertions(+), 61 deletions(-)
+ delete mode 100644 src/Broiler.Graphics.Windows/HwndVideoTargetChangeKind.cs
+ delete mode 100644 src/Broiler.Graphics.Windows/HwndVideoTargetChangedEventArgs.cs
+ create mode 100644 src/tests/Broiler.Graphics.Windows.Tests/HwndVideoOutputTests.cs
+
+diff --git a/src/Broiler.Graphics.Windows/Broiler.Graphics.Direct2D.csproj b/src/Broiler.Graphics.Windows/Broiler.Graphics.Direct2D.csproj
+index 45f49c6..02833b2 100644
+--- a/src/Broiler.Graphics.Windows/Broiler.Graphics.Direct2D.csproj
++++ b/src/Broiler.Graphics.Windows/Broiler.Graphics.Direct2D.csproj
+@@ -26,11 +26,13 @@
+ 
+   <ItemGroup>
+     <ProjectReference Include="..\Broiler.Graphics\Broiler.Graphics.csproj" />
+-    <!-- Graphics.Windows declares the HWND-backed video presentation target
+-         (HwndVideoOutput) implementing the Broiler.Media.Video output lifecycle, per the
+-         media roadmap §6.6/§7.5. It references only the Video ABSTRACTION, never a codec
+-         implementation. -->
++    <!-- Graphics.Windows owns the HWND-backed video presentation target (HwndVideoOutput),
++         which implements Broiler.Media.Video.Windows' IHwndVideoOutput contract per the media
++         roadmap §6.6/§7.5. It references only the Video ABSTRACTIONS, never a codec
++         implementation — and the dependency runs this way only: Media references nothing
++         here (Broiler.Media ADR 0006). -->
+     <ProjectReference Include="..\..\Broiler.Media\src\Broiler.Media.Video\Broiler.Media.Video.csproj" />
++    <ProjectReference Include="..\..\Broiler.Media\src\Broiler.Media.Video.Windows\Broiler.Media.Video.Windows.csproj" />
+   </ItemGroup>
+ 
+ </Project>
+diff --git a/src/Broiler.Graphics.Windows/HwndVideoOutput.cs b/src/Broiler.Graphics.Windows/HwndVideoOutput.cs
+index 8522d80..0c41514 100644
+--- a/src/Broiler.Graphics.Windows/HwndVideoOutput.cs
++++ b/src/Broiler.Graphics.Windows/HwndVideoOutput.cs
+@@ -4,25 +4,33 @@ using System.Runtime.Versioning;
+ using System.Threading;
+ using System.Threading.Tasks;
+ using Broiler.Media;
+-using Broiler.Media.Video;
++using Broiler.Media.Video.Windows;
+ 
+ namespace Broiler.Graphics.Windows;
+ 
+ /// <summary>
+-/// A Windows HWND-backed video presentation target, declared and owned by
+-/// <c>Broiler.Graphics.Windows</c> (which owns the window lifetime). It implements the
+-/// platform-neutral <see cref="IVideoOutput"/> lifecycle so a video backend such as
++/// A Windows HWND-backed video presentation target, created and owned by
++/// <c>Broiler.Graphics.Windows</c> (which owns the window lifetime). It implements
++/// <see cref="IHwndVideoOutput"/> so a video backend such as
+ /// <c>Broiler.Media.Video.MediaFoundation</c> can <em>borrow</em> it and drive
+ /// <c>IMFMediaEngine</c> against its HWND without ever creating or destroying the window.
+ /// </summary>
+ /// <remarks>
+-/// This type is the presentation-target contract required by the Broiler.Media roadmap
+-/// (§6.6 / §7.5): the HWND is declared and owned here in Graphics.Windows; the Media
+-/// Foundation implementation references this assembly and treats the handle's lifetime and
+-/// thread affinity as external constraints.
++/// <para>
++/// This type is the presentation target required by the Broiler.Media roadmap (§6.6 / §7.5):
++/// the HWND is created and owned here in Graphics.Windows, and a borrowing backend treats the
++/// handle's lifetime and thread affinity as external constraints.
++/// </para>
++/// <para>
++/// The dependency runs one way: this assembly references the Media contract, and Media
++/// references nothing here. The borrower sees only <see cref="IHwndVideoOutput"/>, which
++/// carries no owner-only operation — so <see cref="Resize"/>, <see cref="SetVisible"/> and
++/// <see cref="NotifyDestroyed"/> below are reachable only by the window's owner. Keep them off
++/// the interface (Broiler.Media ADR 0006).
++/// </para>
+ /// </remarks>
+ [SupportedOSPlatform("windows")]
+-public sealed class HwndVideoOutput : IVideoOutput
++public sealed class HwndVideoOutput : IHwndVideoOutput
+ {
+     private readonly object _gate = new();
+ 
+diff --git a/src/Broiler.Graphics.Windows/HwndVideoTargetChangeKind.cs b/src/Broiler.Graphics.Windows/HwndVideoTargetChangeKind.cs
+deleted file mode 100644
+index 419e88d..0000000
+--- a/src/Broiler.Graphics.Windows/HwndVideoTargetChangeKind.cs
++++ /dev/null
+@@ -1,12 +0,0 @@
+-namespace Broiler.Graphics.Windows;
+-
+-/// <summary>
+-/// The kind of change reported by an <see cref="HwndVideoOutput"/> when the window it
+-/// presents into is resized, shown/hidden, or destroyed by its owner.
+-/// </summary>
+-public enum HwndVideoTargetChangeKind
+-{
+-    Resized,
+-    VisibilityChanged,
+-    Destroyed,
+-}
+diff --git a/src/Broiler.Graphics.Windows/HwndVideoTargetChangedEventArgs.cs b/src/Broiler.Graphics.Windows/HwndVideoTargetChangedEventArgs.cs
+deleted file mode 100644
+index 4c4e84e..0000000
+--- a/src/Broiler.Graphics.Windows/HwndVideoTargetChangedEventArgs.cs
++++ /dev/null
+@@ -1,36 +0,0 @@
+-using System;
+-
+-namespace Broiler.Graphics.Windows;
+-
+-/// <summary>
+-/// Notifies a borrower (e.g. a Media Foundation video session) that the HWND-backed
+-/// presentation target owned by <see cref="HwndVideoOutput"/> changed size, visibility,
+-/// or was destroyed.
+-/// </summary>
+-public sealed class HwndVideoTargetChangedEventArgs : EventArgs
+-{
+-    public HwndVideoTargetChangedEventArgs(
+-        HwndVideoTargetChangeKind kind,
+-        int width,
+-        int height,
+-        bool isVisible)
+-    {
+-        if (width < 0)
+-            throw new ArgumentOutOfRangeException(nameof(width));
+-        if (height < 0)
+-            throw new ArgumentOutOfRangeException(nameof(height));
+-
+-        Kind = kind;
+-        Width = width;
+-        Height = height;
+-        IsVisible = isVisible;
+-    }
+-
+-    public HwndVideoTargetChangeKind Kind { get; }
+-
+-    public int Width { get; }
+-
+-    public int Height { get; }
+-
+-    public bool IsVisible { get; }
+-}
+diff --git a/src/tests/Broiler.Graphics.Windows.Tests/HwndVideoOutputTests.cs b/src/tests/Broiler.Graphics.Windows.Tests/HwndVideoOutputTests.cs
+new file mode 100644
+index 0000000..537b5ae
+--- /dev/null
++++ b/src/tests/Broiler.Graphics.Windows.Tests/HwndVideoOutputTests.cs
+@@ -0,0 +1,101 @@
++using System;
++using System.Collections.Generic;
++using Broiler.Media;
++using Broiler.Media.Video;
++using Broiler.Media.Video.Windows;
++
++namespace Broiler.Graphics.Windows.Tests;
++
++/// <summary>
++/// Coverage for the HWND-backed video presentation target this assembly owns.
++/// </summary>
++/// <remarks>
++/// These assertions used to live in Broiler.Media's Media Foundation suite, which could reach
++/// the concrete type because Media referenced this assembly. That reference closed a
++/// component-level dependency cycle and was removed (Broiler.Media ADR 0006); the type is
++/// declared here, so its tests belong here too. Broiler.Media now tests only its side of the
++/// <see cref="IHwndVideoOutput"/> contract, against its own double.
++/// </remarks>
++internal static class HwndVideoOutputTests
++{
++    public static void Register(ICollection<(string Name, Action Body)> tests)
++    {
++        tests.Add(("HwndVideoOutput rejects a zero window handle", RejectsZeroHandle));
++        tests.Add(("HwndVideoOutput reports resize, visibility and destruction to its borrower", ReportsLifecycle));
++        tests.Add(("HwndVideoOutput refuses use after its owner destroys the window", RefusesUseAfterDestroy));
++        tests.Add(("HwndVideoOutput records media output completion and failure", RecordsOutputState));
++        tests.Add(("HwndVideoOutput satisfies the borrowed-target contract", SatisfiesContract));
++    }
++
++    private static void RejectsZeroHandle() =>
++        Assert.Throws<ArgumentException>(() => _ = new HwndVideoOutput(0, "zero", 1, 1, validateNativeWindow: false));
++
++    private static void ReportsLifecycle()
++    {
++        HwndVideoOutput target = CreateTarget();
++        var changes = new List<HwndVideoTargetChangeKind>();
++        target.TargetChanged += (_, e) => changes.Add(e.Kind);
++
++        target.Resize(800, 450);
++        target.SetVisible(false);
++        target.NotifyDestroyed();
++
++        Assert.AreEqual(800, target.Width);
++        Assert.AreEqual(450, target.Height);
++        Assert.True(!target.IsVisible, "Expected the target to report itself hidden.");
++        Assert.True(target.IsDestroyed, "Expected the target to report itself destroyed.");
++
++        HwndVideoTargetChangeKind[] expected =
++        [
++            HwndVideoTargetChangeKind.Resized,
++            HwndVideoTargetChangeKind.VisibilityChanged,
++            HwndVideoTargetChangeKind.Destroyed,
++        ];
++
++        Assert.AreEqual(expected.Length, changes.Count, "Unexpected number of target-change notifications.");
++        for (int i = 0; i < expected.Length; i++)
++            Assert.AreEqual(expected[i], changes[i], $"Target-change notification {i} differs.");
++    }
++
++    private static void RefusesUseAfterDestroy()
++    {
++        HwndVideoOutput target = CreateTarget();
++        target.NotifyDestroyed();
++
++        Assert.Throws<ObjectDisposedException>(() => target.Resize(1, 1));
++        Assert.Throws<ObjectDisposedException>(target.ThrowIfUsableTargetRequired);
++    }
++
++    private static void RecordsOutputState()
++    {
++        HwndVideoOutput completed = CreateTarget();
++        completed.CompleteAsync().AsTask().GetAwaiter().GetResult();
++        Assert.True(completed.Completed, "Expected the target to record completion.");
++
++        HwndVideoOutput failed = CreateTarget();
++        var error = new MediaError(MediaErrorCode.OutputFailed, "target failed");
++        failed.FailAsync(error).AsTask().GetAwaiter().GetResult();
++        Assert.AreEqual(error, failed.Failure);
++    }
++
++    private static void SatisfiesContract()
++    {
++        // The borrowed-HWND split of ADR 0005 only holds if a borrower reaches this type
++        // through the contract; handing one the concrete class is what rebuilt the cycle
++        // before. Assert the target is usable purely as IHwndVideoOutput.
++        IHwndVideoOutput target = CreateTarget();
++
++        Assert.AreEqual((nint)1234, target.Hwnd);
++        Assert.AreEqual(640, target.Width);
++        Assert.AreEqual(360, target.Height);
++        Assert.True(target.IsVisible, "Expected a freshly created target to be visible.");
++        Assert.True(!target.IsDestroyed, "Expected a freshly created target to be live.");
++        Assert.AreEqual("test hwnd", target.DisplayName);
++        Assert.True(target is IVideoOutput, "The borrowed target must remain a platform-neutral video output.");
++
++        target.ThrowIfUsableTargetRequired();
++    }
++
++    private static HwndVideoOutput CreateTarget() =>
++        new((nint)1234, "test hwnd", 640, 360, validateNativeWindow: false);
++}
+diff --git a/src/tests/Broiler.Graphics.Windows.Tests/Program.cs b/src/tests/Broiler.Graphics.Windows.Tests/Program.cs
+index 9f3addf..604c91e 100644
+--- a/src/tests/Broiler.Graphics.Windows.Tests/Program.cs
++++ b/src/tests/Broiler.Graphics.Windows.Tests/Program.cs
+@@ -18,6 +18,7 @@ internal static class Program
+ 
+         var tests = new List<(string Name, Action Body)>();
+         WindowsImageTests.Register(tests);
++        HwndVideoOutputTests.Register(tests);
+ 
+         int passed = 0;
+         var failures = new List<string>();
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -51,13 +51,18 @@ submodule is dropped. The reasoning is recorded as Broiler.Media ADR 0006, added
 ### Applying
 
 1. `git am` 0001 in `Broiler.Media`, push, bump this repository's `Broiler.Media` gitlink.
-2. `git am` 0002 in `Broiler.Graphics`, and **in the same commit bump that component's own
-   `Broiler.Media` gitlink** to a commit containing `Broiler.Media.Video.Windows`. Its
-   relative project references resolve to its nested `Broiler.Media` mirror, so without the
-   bump `Broiler.Graphics.Direct2D` references a project that mirror does not have. Push,
-   then bump this repository's `Broiler.Graphics` gitlink.
+2. `git am` 0002 in `Broiler.Graphics`, push, bump this repository's `Broiler.Graphics` gitlink.
+   Bump that component's own `Broiler.Media` gitlink too, to a commit containing
+   `Broiler.Media.Video.Windows` — its relative project references resolve to its nested
+   `Broiler.Media` mirror, so a standalone `Broiler.Graphics` build needs it.
 
 Order matters only in that step 2's gitlink bump needs step 1's commit to exist upstream.
+**Root builds tolerate either order**, including step 2 without that inner gitlink bump: the
+`Directory.Build.targets` redirect described below points Graphics' Media references at the
+canonical top-level checkout. Verified — with both patches applied and the inner gitlink left
+un-bumped, `Broiler.Graphics.Direct2D` builds clean with the redirect and fails with
+`CS0234: The type or namespace name 'Windows' does not exist in the namespace
+'Broiler.Media.Video'` without it.
 
 ### Breaking change
 
@@ -82,13 +87,23 @@ submodule pointer changes here, so the parent builds unchanged with the patches 
 | `Broiler.Graphics.Windows.Tests` | 5/5 new; 6 pre-existing failures are `DllNotFoundException: d3d11.dll` (Windows natives absent on Linux) |
 | `Broiler.HtmlBridge.Dom`, `Broiler.Layout`, `Broiler.Playback`, `Broiler.Wpt` | build clean |
 
-### Known issue this does *not* fix
+### The nested-mirror duplicate, fixed alongside
 
-`Broiler.Graphics` still carries a `Broiler.Media` submodule (it must, to build standalone),
-and its relative project references still resolve to that nested mirror, so an aggregate-
-workspace build still compiles `Broiler.Media.Image` twice. That is benign only while the two
-pins match — which is not enforced. The durable fix is a `Directory.Build.targets` redirect in
-this repository, like the two blocks already there for `Broiler.HTML`, pointing
-`Broiler.Graphics`' Media references at the canonical top-level checkout. It is deliberately
-left out of this change: it touches the build of every `Broiler.Graphics` project and is
-independent of the cycle.
+`Broiler.Graphics` still carries a `Broiler.Media` submodule — it must, to build standalone —
+and its relative project references resolve into that nested mirror. So an aggregate build
+used to compile `Broiler.Media` twice, from two source trees, emitting same-named assemblies.
+
+`Directory.Build.targets` now redirects all five of those references to the canonical
+top-level checkout, in the same explicit style as the two `Broiler.HTML` blocks already there.
+Verified by rebuilding `src/Broiler.HtmlBridge.Dom` from clean: the nested mirror is left with
+no `obj/` at all, and every `Broiler.Media.Image.dll` in the workspace now derives from the one
+canonical compilation.
+
+This is orthogonal to the patches — it holds with them applied or not — but it is what makes
+the apply order above forgiving.
+
+Still open, and out of scope here: the same nested-mirror pattern appears **331 times**
+workspace-wide (`Broiler.Browser`, `Broiler.Writer`, `Broiler.UI` and others each carry their
+own mirrors and reference them the same way). Only the `Broiler.Graphics` → `Broiler.Media`
+edge was measured to duplicate a compile in a root build, so only it is redirected. Whether the
+rest are reached by root solutions has not been established.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,94 @@
+# Submodule patches awaiting upstream
+
+Changes that belong in a `Broiler-Platform/Broiler.*` submodule but could not be pushed
+from the session that wrote them: those remotes are outside the session's GitHub scope, so
+`git push` returns 403. Each patch is captured here for a maintainer to apply upstream; the
+submodule pointers in this repository are deliberately **not** bumped, because CI clones each
+submodule by pointer and a pointer whose commit does not exist upstream would break it.
+
+Apply with `git am` inside the target submodule, push, then bump the gitlink here.
+
+This directory is a backlog, not an archive: delete a patch once its fix is upstream, and
+renumber from `0001` against whatever is left. A `patches/NNNN` reference in an older commit
+message or document is therefore almost always dangling — name the **commit subject** instead.
+
+| Patch | Target submodule | Commit subject |
+|---|---|---|
+| `0001-media-break-graphics-dependency-cycle.patch` | `Broiler.Media` | Break the Media/Graphics dependency cycle: Media depends on nothing |
+| `0002-graphics-implement-hwnd-video-output-contract.patch` | `Broiler.Graphics` | Implement the Media borrowed-HWND contract instead of being referenced by it |
+
+## 0001 + 0002 — breaking the Broiler.Media ↔ Broiler.Graphics cycle
+
+**These two are one change and must land together.** 0001 declares the contract, 0002
+implements it. Applying either alone leaves that component unbuildable against the other.
+
+`Broiler.Media.Video.MediaFoundation` referenced `Broiler.Graphics.Windows` to name the
+concrete `HwndVideoOutput` presentation target it borrows, while `Broiler.Graphics`
+referenced `Broiler.Media.Image` and `Broiler.Graphics.Direct2D` referenced
+`Broiler.Media.Video` in the other direction. The MSBuild project graph stayed acyclic, so
+nothing failed to build and the cycle was easy to miss — but it was real, and it was paid for
+at the repository layer:
+
+- the two components were **mutually recursive git submodules** (`Broiler.Media/.gitmodules`
+  listed `Broiler.Graphics` and vice versa);
+- each resolved the other through its **own nested mirror** rather than the canonical
+  checkout, so a single `dotnet build src/Broiler.HtmlBridge.Dom` compiled
+  `Broiler.Media.Image` twice — from `Broiler.Media/src/` and from
+  `Broiler.Graphics/Broiler.Media/src/` — emitting two same-named assemblies, one of which
+  won the copy to the output directory. Broiler.Media ADR 0001 forbids exactly this;
+- the mirrors' pins **drifted**: `Broiler.Media`'s nested `Broiler.Graphics` sat on a
+  pre-`src/` layout commit while the canonical checkout had moved on;
+- neither component could be versioned or released without the other.
+
+The fix inverts the contract rather than the ownership. A new Windows-only contracts
+assembly, `Broiler.Media.Video.Windows`, declares `IHwndVideoOutput` — the borrower's view of
+a presentation target. `Broiler.Graphics.Windows.HwndVideoOutput` implements it and keeps
+owning window creation, resize, visibility and destruction exactly as Broiler.Media ADR 0005
+requires; `Broiler.Media.Video.MediaFoundation` consumes the interface and names no graphics
+type. Broiler.Media becomes a leaf with no Broiler dependency, and its `Broiler.Graphics`
+submodule is dropped. The reasoning is recorded as Broiler.Media ADR 0006, added by 0001.
+
+### Applying
+
+1. `git am` 0001 in `Broiler.Media`, push, bump this repository's `Broiler.Media` gitlink.
+2. `git am` 0002 in `Broiler.Graphics`, and **in the same commit bump that component's own
+   `Broiler.Media` gitlink** to a commit containing `Broiler.Media.Video.Windows`. Its
+   relative project references resolve to its nested `Broiler.Media` mirror, so without the
+   bump `Broiler.Graphics.Direct2D` references a project that mirror does not have. Push,
+   then bump this repository's `Broiler.Graphics` gitlink.
+
+Order matters only in that step 2's gitlink bump needs step 1's commit to exist upstream.
+
+### Breaking change
+
+`HwndVideoTargetChangeKind` and `HwndVideoTargetChangedEventArgs` move from the
+`Broiler.Graphics.Windows` namespace to `Broiler.Media.Video.Windows`. No in-tree consumer
+outside `HwndVideoOutput` itself existed; an external consumer of those two type names needs
+a `using` change.
+
+### No main-repo fallback is needed
+
+Nothing in this repository names the moved types or the removed project reference, and no
+submodule pointer changes here, so the parent builds unchanged with the patches unapplied.
+
+### Verified before capture (both patches applied in the working tree)
+
+| Suite | Result |
+|---|---|
+| `Broiler.Media.Tests` (architecture) | 13/13 |
+| `Broiler.Media.Video.MediaFoundation.Tests` | 12/12 |
+| `Broiler.Media.{Video,Image,Audio,Image.Managed,Audio.Managed}.Tests` | all pass |
+| `Broiler.Graphics.Tests` | 99/99 |
+| `Broiler.Graphics.Windows.Tests` | 5/5 new; 6 pre-existing failures are `DllNotFoundException: d3d11.dll` (Windows natives absent on Linux) |
+| `Broiler.HtmlBridge.Dom`, `Broiler.Layout`, `Broiler.Playback`, `Broiler.Wpt` | build clean |
+
+### Known issue this does *not* fix
+
+`Broiler.Graphics` still carries a `Broiler.Media` submodule (it must, to build standalone),
+and its relative project references still resolve to that nested mirror, so an aggregate-
+workspace build still compiles `Broiler.Media.Image` twice. That is benign only while the two
+pins match — which is not enforced. The durable fix is a `Directory.Build.targets` redirect in
+this repository, like the two blocks already there for `Broiler.HTML`, pointing
+`Broiler.Graphics`' Media references at the canonical top-level checkout. It is deliberately
+left out of this change: it touches the build of every `Broiler.Graphics` project and is
+independent of the cycle.


### PR DESCRIPTION
Yes, the cycle is fixable — and it turns out to be closed by exactly **one type**.

## The cycle

```
Broiler.Graphics            ──► Broiler.Media.Image
Broiler.Graphics.Direct2D   ──► Broiler.Media.Video
Broiler.Media.Video.MediaFoundation ──► Broiler.Graphics.Direct2D   ← closes it
```

That last edge exists for one reason: the Media Foundation backend held the **concrete**
`HwndVideoOutput` class to name the presentation target it borrows.

The MSBuild project graph stayed acyclic, so nothing failed to build and the cycle was easy to
miss. It was still real, and it was paid for at the repository layer:

- **Mutually recursive submodules.** `Broiler.Media/.gitmodules` listed `Broiler.Graphics`, and
  `Broiler.Graphics/.gitmodules` listed `Broiler.Media`.
- **Duplicate source, compiled twice.** Those references are relative, so each component
  resolved the other through its *own nested mirror*. A single
  `dotnet build src/Broiler.HtmlBridge.Dom` compiled `Broiler.Media.Image` twice — from
  `Broiler.Media/src/` and from `Broiler.Graphics/Broiler.Media/src/` — producing two different
  `Broiler.Media.Image.dll` files, one of which won the copy to the output directory.
  Broiler.Media ADR 0001 forbids exactly this.
- **Pins already drifting.** The `Broiler.Graphics` nested inside `Broiler.Media` sat on a
  pre-`src/` layout commit (`cb83c76`) while the canonical checkout was at `b95c859`.
- Neither component could be versioned or released without the other.

## The fix

Invert the **contract**, not the ownership. A new Windows-only contracts assembly,
`Broiler.Media.Video.Windows`, declares `IHwndVideoOutput` — the borrower's view of a
presentation target:

- `Broiler.Graphics.Windows.HwndVideoOutput` implements it, and still owns window creation,
  resize, visibility and destruction exactly as Broiler.Media ADR 0005 requires.
- `Broiler.Media.Video.MediaFoundation` consumes the interface and names no graphics type.

`Broiler.Media` becomes a **leaf** — no Broiler dependency at all — and drops its
`Broiler.Graphics` submodule.

The contract carries only observations: the handle, its geometry, whether it is still usable,
and notification when the owner changes it. `Resize`, `SetVisible` and `NotifyDestroyed` are
deliberately absent, so a borrower *cannot* reach through it to mutate a window it does not
own. ADR 0005's ownership split becomes a compile-time guarantee rather than a convention —
previously the backend held the concrete class and could have called any of them.

A new `Broiler.Media.Tests` case fails if any project there references `Broiler.Graphics`, if
any runtime source names it, or if a checkout of it reappears.

### Why not a shared `Broiler.Platform.Abstractions`?

Considered and rejected *for now*, and recorded as such in the ADR. It is a twelfth submodule
to pin and version, while the cycle is closed by one interface. When video presentation reaches
Linux and Android the same question ("who owns the native surface handle?") recurs for
Wayland/X11 and `ANativeWindow`, and a shared platform-handles leaf earns its keep —
`IHwndVideoOutput` is shaped so promoting it later is a namespace move, not a redesign.

## Two commits

### 1. The cycle fix, delivered as patches

Both `Broiler-Platform/Broiler.Media` and `Broiler-Platform/Broiler.Graphics` are outside this
session's GitHub scope, so both pushes returned 403. Per `CLAUDE.md` the work lands as patches
under `patches/` with **no submodule pointer bumped** — CI clones each submodule by pointer, and
a pointer whose commit does not exist upstream would break it.

| Patch | Target | Commit subject |
|---|---|---|
| `0001-media-break-graphics-dependency-cycle.patch` | `Broiler.Media` | Break the Media/Graphics dependency cycle: Media depends on nothing |
| `0002-graphics-implement-hwnd-video-output-contract.patch` | `Broiler.Graphics` | Implement the Media borrowed-HWND contract instead of being referenced by it |

**The two are one change and must land together.** `patches/README.md` carries the apply order
and the gitlink bumps each step needs.

### 2. The nested-mirror redirect

`Directory.Build.targets` now points all five of `Broiler.Graphics`' Media references at the
canonical top-level checkout, in the same explicit per-project style as the two `Broiler.HTML`
blocks already there. Rebuilding `src/Broiler.HtmlBridge.Dom` from clean now leaves the nested
mirror with **no `obj/` at all**, and every `Broiler.Media.Image.dll` in the workspace derives
from the one canonical compilation.

It also makes the apply order forgiving. The redirect covers
`Broiler.Media.Video.Windows` behind an `Exists` guard, so with both patches applied and
`Broiler.Graphics`' own `Broiler.Media` gitlink left un-bumped, `Broiler.Graphics.Direct2D`
builds clean — and fails with `CS0234: The type or namespace name 'Windows' does not exist in
the namespace 'Broiler.Media.Video'` without it. Verified both ways.

This commit is orthogonal to the patches: it holds whether or not they are applied, and is a
no-op today because the two pins currently agree.

### Breaking change

`HwndVideoTargetChangeKind` and `HwndVideoTargetChangedEventArgs` move from the
`Broiler.Graphics.Windows` namespace to `Broiler.Media.Video.Windows`. No in-tree consumer
outside `HwndVideoOutput` itself existed; an external consumer needs a `using` change.

## Verification

The patches were applied in the working tree, built and tested, then reverted for capture.
Submodule pointers are untouched — all 11 clean.

| Suite | Result |
|---|---|
| `Broiler.Media.Tests` (architecture) | 13/13 |
| `Broiler.Media.Video.MediaFoundation.Tests` | 12/12 |
| `Broiler.Media.{Video,Image,Audio,Image.Managed,Audio.Managed}.Tests` | all pass |
| `Broiler.Graphics.Tests` | 99/99, before and after the redirect |
| `Broiler.Graphics.Windows.Tests` | 5/5 new; 6 pre-existing failures are all `DllNotFoundException: d3d11.dll` (Windows natives absent on Linux) |
| `Direct2D`, both Graphics test projects, `Broiler.Layout`, `Broiler.Wpt`, `Broiler.Playback`, `Broiler.Cli.Tests`, `Broiler.HtmlBridge.Dom` | build clean |

Both patches re-verified with `git apply --check --3way` against the pinned submodule SHAs.

## Not addressed

The nested-mirror pattern appears **331 times** workspace-wide — `Broiler.Browser`,
`Broiler.Writer`, `Broiler.UI` and others each carry their own mirrors and reference them the
same way. Only the `Broiler.Graphics` → `Broiler.Media` edge was measured to duplicate a compile
in a root build, so only it is redirected here. Whether the rest are reached by root solutions
has not been established.